### PR TITLE
Unit normalisation Phase 4: classify new Ingredients at import

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,7 +42,7 @@ A canonical, Global Catalog entry for a foodstuff (e.g. "tomato") — just an id
 _Avoid_: Using "Ingredient" for a Recipe's specific quantity of one — that's an Ingredient Line.
 
 **Ingredient Line**:
-One row of a Recipe's ingredient list: an Amount of a specific Ingredient, scoped to that one Recipe (DB table `part`). Recorded verbatim as the Recipe states it and never rewritten — normalisation happens when a Shopping List is generated, not on save. Distinct from Ingredient itself — many Ingredient Lines across many Recipes can reference the same Ingredient.
+One row of a Recipe's ingredient list: an Amount of a specific Ingredient, scoped to that one Recipe (DB table `part`). Recorded as the Recipe states it and not rewritten by combining — normalisation happens when a Shopping List is generated, not on save. (Deliberate one-off *corrections* are a different matter and have happened: migrations 022–024 fixed mis-entered lines and replaced `packet`/`bottle` with real measures, on the grounds that those never recorded a real quantity to preserve.) Distinct from Ingredient itself — many Ingredient Lines across many Recipes can reference the same Ingredient.
 _Avoid_: Ingredient (when meaning this), Part, Recipe Ingredient
 
 **Unit**:
@@ -58,7 +58,7 @@ The Absolute Unit a given Ingredient's Amounts normalise to when combined — gr
 **Unit Size**:
 How much one of a given Unit of a given Ingredient comes to, in that Ingredient's Base Unit — "one tin of coconut milk is 400ml", "one potato is 180g", "one tablespoon of flour is 8g". Deliberately one concept rather than three: average item weight, pack size and density are the same question asked about different Units. Known per Ingredient-and-Unit pair, and simply absent until someone supplies it — absent is a normal state, not an error, and an Ingredient Item just carries more than one Amount until it's filled in. A Unit may also declare a default Unit Size for cases that genuinely don't vary by Ingredient (a pinch, a clove), which a per-Ingredient value overrides.
 
-Every Unit Size, Base Unit and Display Unit is either **curated** (chosen by a person) or **classified** (proposed automatically). Curated always wins, and classification only ever fills a gap — it must never overwrite a human's answer, or a correction would silently regress.
+Every Unit Size, Base Unit and Display Unit is either **curated** (chosen by a person) or **classified** (proposed automatically). Curated always wins: classification applies only to an Ingredient nothing has been recorded against yet — in practice one that has no Ingredient Lines — so it can never overwrite a human's answer. Note this is stricter than "fills any gap": an established Ingredient with a missing value keeps missing it, because an absent value can mean *deliberately left at the default* rather than *not yet considered*.
 
 **Known limitation, not a permanent rule:** Unit Sizes are single-locale (UK) values, and part of the Global Catalog, so they're shared across every Account. A tin is 400g here and ~411g in the US; pack sizes diverge much further. Recipe Import already converts imperial to metric on the way in, so the exposure is narrow — it's Relative Units, chiefly pack units, where it bites. Scoping them (by locale, or by Account — which would mean revisiting [ADR-0001](./docs/adr/0001-global-ingredient-catalog.md)) is a legitimate future direction, deferred until there's a second locale to learn the real requirements from.
 

--- a/components/recipe-form/Form.tsx
+++ b/components/recipe-form/Form.tsx
@@ -44,7 +44,7 @@ interface FormProps {
 }
 
 interface ParseTextResult {
-  ingredients?: { name?: string; quantity?: string; unit?: string }[];
+  ingredients?: Partial<Ingredient>[];
   error?: string;
 }
 

--- a/components/recipe-form/Form.tsx
+++ b/components/recipe-form/Form.tsx
@@ -151,11 +151,20 @@ export default function Form({initialRecipe = {}, mode = 'new'}: FormProps) {
     setRecipe(updatedRecipe)
   }
 
-  function appendIngredients(parsedIngredients: { name?: string; quantity?: string; unit?: string }[]) {
-    const newIngredients = parsedIngredients.map(({ name, quantity, unit }) => ({
+  // baseUnit/displayUnit/unitSizes are catalog metadata the extractor proposes
+  // for ingredients this app has never seen (see CONTEXT.md's Unit Size). They
+  // are carried straight through to the save payload rather than shown in the
+  // form: there is nothing useful for a cook to do with "one onion is 150g"
+  // while writing a recipe, and the server ignores them for any ingredient that
+  // already has values.
+  function appendIngredients(parsedIngredients: Partial<Ingredient>[]) {
+    const newIngredients = parsedIngredients.map(({ name, quantity, unit, baseUnit, displayUnit, unitSizes }) => ({
       name: (name || '').trim(),
       quantity: quantity || '',
-      unit: unit || ''
+      unit: unit || '',
+      ...(baseUnit ? { baseUnit } : {}),
+      ...(displayUnit !== undefined && displayUnit !== null ? { displayUnit } : {}),
+      ...(unitSizes ? { unitSizes } : {}),
     }));
     setRecipe(prevRecipe => ({
       ...prevRecipe,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -135,7 +135,11 @@ components:
     Ingredient:
       additionalProperties: false
       properties:
+        baseUnit:
+          type: string
         department:
+          type: string
+        displayUnit:
           type: string
         name:
           type: string
@@ -143,6 +147,11 @@ components:
           type: string
         unit:
           type: string
+        unitSizes:
+          additionalProperties:
+            format: double
+            type: number
+          type: object
       required:
         - name
         - unit

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -32,3 +32,11 @@ Items 1–21 have all been resolved — see [`follow-ups-resolved.md`](./follow-
 
     Found while checking a report of two "garlic powder" ingredients. There is only one - the query output that prompted it grouped by ingredient *and unit*, so a single ingredient used with two units printed on two rows. Worth recording so nobody goes looking for a duplicate that was never there.
 
+27. **A curated Ingredient with no Ingredient Lines can be reclassified by an import.** Phase 4 restricts classification to Ingredients that have no rows in `part`, on the reasoning that those are new. `DeleteRecipe` removes an Ingredient's `part` rows without removing the Ingredient, so deleting the last Recipe that used something leaves it curated but line-less - and the next import mentioning it can then overwrite its Base Unit, Display Unit and Unit Sizes. Narrow (it needs the last user of an ingredient deleted, then a re-import proposing different values) and self-correcting once someone notices, but it is a silent data-quality regression on values a person chose.
+
+    The complete fix is the provenance column deliberately deferred in the spec's decisions: with an explicit `curated`/`classified` marker, "has a human touched this?" stops being inferred from proxies. A partial guard - also requiring no `ingredient_unit_size` rows - would cover most cases but not an Ingredient curated with only a Base Unit, and a guard that looks complete but isn't is worse than a recorded gap.
+
+28. **No ingredient is displayed in spoons, which was half the point of problem 3.** The original problem statement asked for "a preferred unit for each ingredient… teaspoon for spices but not for herbs". The mechanism for that shipped in full - `ingredient.display_unit_id` accepts any Unit - but of the ~30 Display Units curated in `025_curated_unit_sizes.sql`, every one is either the bare count or `tin`. Nothing reads in teaspoons or pinches, so spices still show as grams, and per #26 sometimes as millilitres.
+
+    This is curation, not code: setting `display_unit_id` to `teaspoon` for the spice ingredients, with the matching density already present, would do it. Worth doing alongside #26, since both are about dry goods reading badly and the same pass covers them.
+

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -40,3 +40,24 @@ Items 1–21 have all been resolved — see [`follow-ups-resolved.md`](./follow-
 
     This is curation, not code: setting `display_unit_id` to `teaspoon` for the spice ingredients, with the matching density already present, would do it. Worth doing alongside #26, since both are about dry goods reading badly and the same pass covers them.
 
+29. **Extend the e2e suite to cover Recipe Import.** Currently excluded: `e2e/recipe.spec.ts:39` says import "makes a real LLM call, which is out of scope for these flows", and CLAUDE.md records the same. That reasoning was sound when the suite was written and is now the largest coverage hole in the app.
+
+    **Why it matters specifically for `specs/unit-normalisation.md`.** Phase 4's entire mechanism lives in this untested path. Classification only ever happens via `extract.js` → the form → `POST /recipe`; nothing else can trigger it. So the feature that keeps the ingredient catalog from going stale has no end-to-end coverage at all, and neither does the `NOT EXISTS (SELECT 1 FROM part …)` guard in `classifyNewIngredients` - the thing standing between an import and the ~100 curated values in `migrations/025_curated_unit_sizes.sql`.
+
+    That is not hypothetical. **Both Phase 4 bugs lived in exactly this path and neither was caught by any test:**
+
+    - `normalizeParsedIngredients` in `pages/recipes/new.tsx` dropped `baseUnit`/`displayUnit`/`unitSizes`, so URL and Photo import silently classified nothing. Found by review, not by tests.
+    - A classification failure rolled back the whole recipe save, against the spec's explicit rule. The unit test written for it asserted the wrong behaviour.
+
+    The first is the shape of bug e2e exists to catch: pure plumbing, spanning three files and two languages, where every individual piece is correct. It also shows why testing one Import Source is not enough - **the three sources use two different code paths** (Manual Entry's paste box calls `appendIngredients`; URL and Photo set `initialRecipe` via `normalizeParsedIngredients`), and the bug was present in two of three. A test covering only the paste box would have passed while the other two were broken.
+
+    Neither the Go unit tests nor the Vitest suite can close this. The Go tests assert the *shape* of SQL strings, not what it means - the state file admits as much, and it is why the base-unit overwrite bug reached a live database. The existing `pages/api/parse-recipe-*.test.ts` mock `extractRecipe` itself, so they exercise the handler and nothing downstream of it.
+
+    **The stated blocker does not apply.** No LLM call is needed to test the plumbing. Playwright can intercept the Next.js API routes and return canned JSON:
+
+    - `/api/parse-recipe-text` — Manual Entry's bulk paste (`Form.tsx:114`)
+    - `/api/parse-recipe-url` — URL Import (`new.tsx:153`)
+    - `/api/recipe-image` — Photo Import, plus its polling endpoint (`new.tsx:148`, `:163`)
+
+    A fixture response carrying `baseUnit`, `displayUnit` and `unitSizes` for a novel ingredient name, asserted through to the shopping list, would have caught both bugs. Worth doing for all three sources rather than one, precisely because their plumbing diverges. A separate, opt-in spec making a real LLM call (skipped unless a flag is set) would be a reasonable addition on top, but is not the valuable part - the deterministic plumbing test is.
+

--- a/lib/recipe-import/extract.d.ts
+++ b/lib/recipe-import/extract.d.ts
@@ -2,6 +2,13 @@ export interface ExtractedIngredient {
   name: string;
   quantity: string;
   unit: string;
+  // Catalog metadata proposed for an ingredient this app has not seen before.
+  // Declared here so that dropping it somewhere in the chain from extraction to
+  // the save payload is a type error rather than a silent loss - which is how
+  // two of the three Import Sources managed to lose it.
+  baseUnit?: string;
+  displayUnit?: string;
+  unitSizes?: Record<string, number>;
 }
 
 export interface ExtractInput {

--- a/lib/recipe-import/extract.js
+++ b/lib/recipe-import/extract.js
@@ -135,10 +135,8 @@ function buildInstructions(knownIngredients, knownUnits) {
       (e.g. "bunch" not "large bunch"), so future recipes needing the same unit will match it.
 
     New ingredients:
-    - newIngredients: metadata for ingredients that are NOT already in the known list above.
-      For anything already known, output nothing - this app already has curated values for
-      those and they must not be second-guessed. If every ingredient is already known,
-      return an empty array.
+    - newIngredients: metadata for ingredients this app has not seen before.${knownIngredients.length ? ' That means anything not in the known-ingredient list given above; for anything in that list, output nothing - this app already has curated values and they must not be second-guessed.' : ' This app currently knows no ingredients, so every ingredient here is new.'}
+      Return an empty array if there are none.
     - The purpose is combining a shopping list. If two recipes call for "3 onions" and "150g
       onion", the app can only add them together if it knows roughly what one onion weighs.
     - baseUnit: "millilitre" for things bought by volume (oils, stocks, milks, wines,
@@ -146,9 +144,10 @@ function buildInstructions(knownIngredients, knownUnits) {
       null means gram, which is right far more often than not.
     - unitSizes: how much ONE of a unit of this ingredient is, expressed in its baseUnit.
       Only include entries that are genuinely useful:
-        * unit "" (empty string, the bare count) - the average weight of one, for anything
-          countable: one onion 150, one carrot 80, one chicken breast 180. This is the most
-          valuable entry by far; include it for anything a recipe might count.
+        * unit "" (empty string, the bare count) - how much one of them is, in this
+          ingredient's own baseUnit: one onion 150 (grams), one carrot 80, one chicken breast
+          180, and for a volume-based ingredient one lemon's juice 70 (millilitres). This is
+          the most valuable entry by far; include it for anything a recipe might count.
         * unit "millilitre" - grams per millilitre, i.e. density, for a dry ingredient that
           recipes measure in spoons: plain flour 0.53, caster sugar 0.85, ground spices
           around 0.5. Every spoon measure derives from this one number, so do not add
@@ -236,7 +235,10 @@ export async function extractRecipe({ input, knownIngredients = [], knownUnits =
         name,
         ...(proposal.baseUnit ? { baseUnit: proposal.baseUnit } : {}),
         ...(proposal.displayUnit !== null ? { displayUnit: proposal.displayUnit } : {}),
-        ...(proposal.unitSizes.length
+        // Defensive: a malformed proposal must not throw out of extractRecipe and
+        // take the whole import down with it. Classification is a bonus; losing it
+        // is a missed improvement, losing the recipe is a failure.
+        ...(proposal.unitSizes?.length
           ? { unitSizes: Object.fromEntries(proposal.unitSizes.map(({ unit, size }) => [unit, size])) }
           : {}),
       };

--- a/lib/recipe-import/extract.js
+++ b/lib/recipe-import/extract.js
@@ -19,8 +19,36 @@ const SCHEMA = {
       },
     },
     method: { type: 'string' },
+    // Catalog metadata for ingredients this app has never seen. Every property
+    // is required and nulls are explicit because OpenAI's strict structured
+    // outputs disallow optional properties - "absent" has to be spelled null.
+    newIngredients: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          baseUnit: { type: ['string', 'null'] },
+          displayUnit: { type: ['string', 'null'] },
+          unitSizes: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                unit: { type: 'string' },
+                size: { type: 'number' },
+              },
+              required: ['unit', 'size'],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ['name', 'baseUnit', 'displayUnit', 'unitSizes'],
+        additionalProperties: false,
+      },
+    },
   },
-  required: ['name', 'isVegetarian', 'ingredients', 'method'],
+  required: ['name', 'isVegetarian', 'ingredients', 'method', 'newIngredients'],
   additionalProperties: false,
 };
 
@@ -106,6 +134,35 @@ function buildInstructions(knownIngredients, knownUnits) {
       use a new, sensible unit instead: lowercase, singular, and as short/generic as possible
       (e.g. "bunch" not "large bunch"), so future recipes needing the same unit will match it.
 
+    New ingredients:
+    - newIngredients: metadata for ingredients that are NOT already in the known list above.
+      For anything already known, output nothing - this app already has curated values for
+      those and they must not be second-guessed. If every ingredient is already known,
+      return an empty array.
+    - The purpose is combining a shopping list. If two recipes call for "3 onions" and "150g
+      onion", the app can only add them together if it knows roughly what one onion weighs.
+    - baseUnit: "millilitre" for things bought by volume (oils, stocks, milks, wines,
+      juices, sauces thin enough to pour), "gram" for everything else. Use null if unsure -
+      null means gram, which is right far more often than not.
+    - unitSizes: how much ONE of a unit of this ingredient is, expressed in its baseUnit.
+      Only include entries that are genuinely useful:
+        * unit "" (empty string, the bare count) - the average weight of one, for anything
+          countable: one onion 150, one carrot 80, one chicken breast 180. This is the most
+          valuable entry by far; include it for anything a recipe might count.
+        * unit "millilitre" - grams per millilitre, i.e. density, for a dry ingredient that
+          recipes measure in spoons: plain flour 0.53, caster sugar 0.85, ground spices
+          around 0.5. Every spoon measure derives from this one number, so do not add
+          separate teaspoon or tablespoon entries.
+        * unit "tin"/"packet"/"bottle"/"slice"/"clove" - only where a standard size genuinely
+          exists for this ingredient.
+      Return an empty array rather than guessing. A wrong size produces a confidently wrong
+      shopping list, whereas a missing one just leaves two amounts side by side, which is
+      harmless.
+    - displayUnit: the unit a shopper would rather see the total in, if it is not the
+      baseUnit - "" (bare count) for countable produce so the list says "6" rather than
+      "900 gram", "tin" for tinned goods. Requires a matching unitSizes entry to work, so do
+      not set it without one. null for anything bought by weight or volume.
+
     Other rules:
     - Preserve the original order of the ingredients.
     - Ignore anything that isn't part of the ingredient list or method (navigation, ads, comments,
@@ -156,14 +213,34 @@ export async function extractRecipe({ input, knownIngredients = [], knownUnits =
     },
   });
 
-  const { isVegetarian, ingredients, ...rest } = JSON.parse(response.output_text);
+  const { isVegetarian, ingredients, newIngredients = [], ...rest } = JSON.parse(response.output_text);
+
+  // Attach the proposed catalog metadata to the ingredient it describes, so
+  // callers carry one shape through to the save payload rather than a parallel
+  // list they have to join up themselves.
+  const proposals = new Map(newIngredients.map((n) => [n.name, n]));
 
   return {
     ...rest,
-    ingredients: ingredients.map((ingredient) => ({
-      ...ingredient,
-      name: matchCanonicalIngredient(ingredient.name, knownIngredients),
-    })),
+    ingredients: ingredients.map((ingredient) => {
+      const name = matchCanonicalIngredient(ingredient.name, knownIngredients);
+      const proposal = proposals.get(ingredient.name);
+      // A name that matched an existing ingredient is by definition already
+      // known, so any proposal for it is dropped - the model was told not to,
+      // but this makes it impossible rather than merely instructed.
+      if (!proposal || name !== ingredient.name) {
+        return { ...ingredient, name };
+      }
+      return {
+        ...ingredient,
+        name,
+        ...(proposal.baseUnit ? { baseUnit: proposal.baseUnit } : {}),
+        ...(proposal.displayUnit !== null ? { displayUnit: proposal.displayUnit } : {}),
+        ...(proposal.unitSizes.length
+          ? { unitSizes: Object.fromEntries(proposal.unitSizes.map(({ unit, size }) => [unit, size])) }
+          : {}),
+      };
+    }),
     tags: isVegetarian ? ['Vegetarian'] : [],
   };
 }

--- a/netlify-functions/recipes/internal/pkg/common/types.go
+++ b/netlify-functions/recipes/internal/pkg/common/types.go
@@ -35,6 +35,28 @@ type Ingredient struct {
 	Unit       string `json:"unit"`
 	Quantity   string `json:"quantity"`
 	Department string `json:"department,omitempty"`
+	// Catalog metadata proposed by Recipe Import for an Ingredient the Global
+	// Catalog hasn't seen before - what to add it up in, what to show it as, and
+	// how big one of a given Unit of it is. See CONTEXT.md's Unit Size.
+	//
+	// Only ever fills a gap: a value already recorded for the Ingredient always
+	// wins, so a curated figure can't be overwritten by a later import. Absent
+	// on Manual Entry and on every edit of an existing Recipe.
+	//
+	// omitempty on all three, and not merely tidiness: Huma infers required-ness
+	// from JSON tags, so without it every existing client's save would fail
+	// validation for omitting them (see the ID comment on Recipe below).
+	BaseUnit string `json:"baseUnit,omitempty"`
+	// A pointer, not a string, because "" is a real Display Unit - the bare
+	// count, and the most useful one there is ("6 onions"). A plain string
+	// cannot tell "propose showing this as a count" apart from "proposed
+	// nothing", so classification could never suggest the count. nil means
+	// absent; a pointer to "" means the count.
+	//
+	// Third time this Unit's name has collided with a sentinel - see
+	// baseTotal.soleUnit and IngredientInfo.HasDisplayUnit.
+	DisplayUnit *string            `json:"displayUnit,omitempty"`
+	UnitSizes   map[string]float64 `json:"unitSizes,omitempty"`
 }
 
 // Tag contains tag fields

--- a/netlify-functions/recipes/internal/pkg/service/recipe.go
+++ b/netlify-functions/recipes/internal/pkg/service/recipe.go
@@ -248,9 +248,7 @@ func AddRecipe(recipe common.Recipe, userID string, db *sql.DB) (int, error) {
 	if err = insertUnits(recipe, tx); err != nil {
 		return 0, err
 	}
-	if err = insertIngredientCatalog(recipe, tx); err != nil {
-		return 0, err
-	}
+	classifyNewIngredients(recipe, tx)
 	if err = insertParts(recipe, tx); err != nil {
 		return 0, err
 	}
@@ -303,10 +301,7 @@ func EditRecipe(recipe common.Recipe, userID string, db *sql.DB) error {
 		log.Println(err)
 		return err
 	}
-	if err := insertIngredientCatalog(recipe, tx); err != nil {
-		log.Println(err)
-		return err
-	}
+	classifyNewIngredients(recipe, tx)
 
 	// Delete the existing relationships between recipe & ingredients
 	if _, err := tx.Exec("DELETE FROM part WHERE recipe_id=?", recipe.ID); err != nil {
@@ -454,7 +449,7 @@ func insertTags(recipe common.Recipe, db execer) error {
 	return nil
 }
 
-// insertIngredientCatalog records the Base Unit, Display Unit and Unit Sizes
+// classifyNewIngredients records the Base Unit, Display Unit and Unit Sizes
 // that Recipe Import proposed for Ingredients the Global Catalog hasn't seen
 // before. Nothing to do for Manual Entry or for editing an existing Recipe,
 // where the payload carries none.
@@ -478,31 +473,21 @@ func insertTags(recipe common.Recipe, db execer) error {
 // Must run after insertUnits: a proposed Unit Size can reference a Unit this
 // same save is introducing, and the INSERT ... SELECT below matches nothing if
 // the Unit row doesn't exist yet.
-func insertIngredientCatalog(recipe common.Recipe, db execer) error {
+// Returns nothing, deliberately. The spec is explicit that "a classification
+// failure must never fail a recipe save - the gap simply persists, and the list
+// degrades to multiple Amounts, which is a supported state, not an error". An
+// earlier version returned an error that both callers propagated, so a bad
+// proposal rolled back the whole recipe. Making the signature errorless makes
+// that structural rather than a rule each caller has to remember. A failed
+// statement does not abort a MySQL transaction, so the surrounding save is
+// unaffected.
+func classifyNewIngredients(recipe common.Recipe, db execer) {
 	for _, ingredient := range recipe.Ingredients {
 		if ingredient.BaseUnit != "" {
-			// The subquery yields NULL for a Unit that doesn't exist, which
-			// leaves the column NULL rather than writing nonsense - so an
-			// invented Base Unit is inert instead of corrupting the catalog.
-			query := `
-				UPDATE ingredient SET base_unit_id = (SELECT id FROM unit WHERE name = ?)
-				WHERE name = ? AND base_unit_id IS NULL
-				  AND NOT EXISTS (SELECT 1 FROM part WHERE part.ingredient_id = ingredient.id);`
-			if _, err := db.Exec(query, ingredient.BaseUnit, ingredient.Name); err != nil {
-				fmt.Println("could not set ingredient base unit")
-				return err
-			}
+			setIngredientUnitColumn(db, "base_unit_id", ingredient.BaseUnit, ingredient.Name)
 		}
-
 		if ingredient.DisplayUnit != nil {
-			query := `
-				UPDATE ingredient SET display_unit_id = (SELECT id FROM unit WHERE name = ?)
-				WHERE name = ? AND display_unit_id IS NULL
-				  AND NOT EXISTS (SELECT 1 FROM part WHERE part.ingredient_id = ingredient.id);`
-			if _, err := db.Exec(query, *ingredient.DisplayUnit, ingredient.Name); err != nil {
-				fmt.Println("could not set ingredient display unit")
-				return err
-			}
+			setIngredientUnitColumn(db, "display_unit_id", *ingredient.DisplayUnit, ingredient.Name)
 		}
 
 		for unit, size := range ingredient.UnitSizes {
@@ -519,10 +504,30 @@ func insertIngredientCatalog(recipe common.Recipe, db execer) error {
 				  AND NOT EXISTS (SELECT 1 FROM part WHERE part.ingredient_id = i.id)
 				ON DUPLICATE KEY UPDATE ingredient_unit_size.ingredient_id = ingredient_unit_size.ingredient_id;`
 			if _, err := db.Exec(query, size, ingredient.Name, unit); err != nil {
-				fmt.Println("could not set ingredient unit size")
-				return err
+				log.Printf("could not set unit size %q for %q: %v", unit, ingredient.Name, err)
 			}
 		}
 	}
-	return nil
+}
+
+// setIngredientUnitColumn points one of ingredient's two unit columns at a Unit
+// by name, for a new Ingredient that hasn't been curated.
+//
+// The column name is interpolated rather than parameterised because SQL does
+// not allow a placeholder there; it is never caller-controlled, only ever one
+// of the two literals above.
+//
+// Two guards, both load-bearing. The subquery yields NULL for a Unit that does
+// not exist, so an invented Base Unit is inert rather than corrupting the
+// catalog. And NOT EXISTS restricts this to Ingredients with no Ingredient
+// Lines - see classifyNewIngredients for why "is the column still unset" is not
+// sufficient.
+func setIngredientUnitColumn(db execer, column, unitName, ingredientName string) {
+	query := fmt.Sprintf(`
+		UPDATE ingredient SET %s = (SELECT id FROM unit WHERE name = ?)
+		WHERE name = ? AND %s IS NULL
+		  AND NOT EXISTS (SELECT 1 FROM part WHERE part.ingredient_id = ingredient.id);`, column, column)
+	if _, err := db.Exec(query, unitName, ingredientName); err != nil {
+		log.Printf("could not set %s for %q: %v", column, ingredientName, err)
+	}
 }

--- a/netlify-functions/recipes/internal/pkg/service/recipe.go
+++ b/netlify-functions/recipes/internal/pkg/service/recipe.go
@@ -248,6 +248,9 @@ func AddRecipe(recipe common.Recipe, userID string, db *sql.DB) (int, error) {
 	if err = insertUnits(recipe, tx); err != nil {
 		return 0, err
 	}
+	if err = insertIngredientCatalog(recipe, tx); err != nil {
+		return 0, err
+	}
 	if err = insertParts(recipe, tx); err != nil {
 		return 0, err
 	}
@@ -297,6 +300,10 @@ func EditRecipe(recipe common.Recipe, userID string, db *sql.DB) error {
 	}
 
 	if err := insertUnits(recipe, tx); err != nil {
+		log.Println(err)
+		return err
+	}
+	if err := insertIngredientCatalog(recipe, tx); err != nil {
 		log.Println(err)
 		return err
 	}
@@ -444,5 +451,78 @@ func insertTags(recipe common.Recipe, db execer) error {
 		return err
 	}
 
+	return nil
+}
+
+// insertIngredientCatalog records the Base Unit, Display Unit and Unit Sizes
+// that Recipe Import proposed for Ingredients the Global Catalog hasn't seen
+// before. Nothing to do for Manual Entry or for editing an existing Recipe,
+// where the payload carries none.
+//
+// Applies only to Ingredients that did not exist before this save, detected by
+// their having no Ingredient Lines yet. insertParts runs after this, and
+// EditRecipe deletes its old parts after it too, so at this point a genuinely
+// new Ingredient has zero rows in `part` and an established one has at least
+// one.
+//
+// That check, rather than "is the column still unset", is load-bearing. NULL in
+// base_unit_id means two different things: never curated, and curated as the
+// default of gram. Onion is deliberately gram, so it is NULL, so an
+// unset-column guard would happily let an import flip it to millilitre - which
+// is exactly what happened when this was first written and tested against a
+// live database. Restricting to new Ingredients also matches what the feature
+// is for: the curated set covers what exists, this covers what arrives.
+//
+// The ON DUPLICATE KEY no-op on Unit Sizes is kept as a second line of defence.
+//
+// Must run after insertUnits: a proposed Unit Size can reference a Unit this
+// same save is introducing, and the INSERT ... SELECT below matches nothing if
+// the Unit row doesn't exist yet.
+func insertIngredientCatalog(recipe common.Recipe, db execer) error {
+	for _, ingredient := range recipe.Ingredients {
+		if ingredient.BaseUnit != "" {
+			// The subquery yields NULL for a Unit that doesn't exist, which
+			// leaves the column NULL rather than writing nonsense - so an
+			// invented Base Unit is inert instead of corrupting the catalog.
+			query := `
+				UPDATE ingredient SET base_unit_id = (SELECT id FROM unit WHERE name = ?)
+				WHERE name = ? AND base_unit_id IS NULL
+				  AND NOT EXISTS (SELECT 1 FROM part WHERE part.ingredient_id = ingredient.id);`
+			if _, err := db.Exec(query, ingredient.BaseUnit, ingredient.Name); err != nil {
+				fmt.Println("could not set ingredient base unit")
+				return err
+			}
+		}
+
+		if ingredient.DisplayUnit != nil {
+			query := `
+				UPDATE ingredient SET display_unit_id = (SELECT id FROM unit WHERE name = ?)
+				WHERE name = ? AND display_unit_id IS NULL
+				  AND NOT EXISTS (SELECT 1 FROM part WHERE part.ingredient_id = ingredient.id);`
+			if _, err := db.Exec(query, *ingredient.DisplayUnit, ingredient.Name); err != nil {
+				fmt.Println("could not set ingredient display unit")
+				return err
+			}
+		}
+
+		for unit, size := range ingredient.UnitSizes {
+			if size <= 0 {
+				continue
+			}
+			// INSERT ... SELECT so a missing Ingredient or Unit simply matches
+			// no rows, and ON DUPLICATE KEY as a deliberate no-op so an existing
+			// Unit Size wins over the proposal.
+			query := `
+				INSERT INTO ingredient_unit_size (ingredient_id, unit_id, size)
+				SELECT i.id, u.id, ? FROM ingredient i, unit u
+				WHERE i.name = ? AND u.name = ?
+				  AND NOT EXISTS (SELECT 1 FROM part WHERE part.ingredient_id = i.id)
+				ON DUPLICATE KEY UPDATE ingredient_unit_size.ingredient_id = ingredient_unit_size.ingredient_id;`
+			if _, err := db.Exec(query, size, ingredient.Name, unit); err != nil {
+				fmt.Println("could not set ingredient unit size")
+				return err
+			}
+		}
+	}
 	return nil
 }

--- a/netlify-functions/recipes/internal/pkg/service/recipe_test.go
+++ b/netlify-functions/recipes/internal/pkg/service/recipe_test.go
@@ -171,13 +171,11 @@ func TestInsertTags(t *testing.T) {
 	})
 }
 
-func TestInsertIngredientCatalog(t *testing.T) {
+func TestClassifyNewIngredients(t *testing.T) {
 	t.Run("an ingredient with no proposals issues no query", func(t *testing.T) {
 		fake := &fakeExecer{}
 		recipe := common.Recipe{Ingredients: []common.Ingredient{{Name: "flour", Quantity: "200", Unit: "gram"}}}
-		if err := insertIngredientCatalog(recipe, fake); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		classifyNewIngredients(recipe, fake)
 		// Manual Entry and every edit of an existing Recipe land here.
 		if len(fake.queries) != 0 {
 			t.Errorf("expected no queries but got %v", fake.queries)
@@ -190,9 +188,7 @@ func TestInsertIngredientCatalog(t *testing.T) {
 			Name: "sumac", Quantity: "2", Unit: "teaspoon",
 			BaseUnit: "gram", UnitSizes: map[string]float64{"millilitre": 0.5},
 		}}}
-		if err := insertIngredientCatalog(recipe, fake); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		classifyNewIngredients(recipe, fake)
 
 		joined := strings.Join(fake.queries, "\n")
 		// This is the whole safety property of the phase: a value reviewed by a
@@ -225,9 +221,7 @@ func TestInsertIngredientCatalog(t *testing.T) {
 		recipe := common.Recipe{Ingredients: []common.Ingredient{{
 			Name: "sumac", DisplayUnit: &count,
 		}}}
-		if err := insertIngredientCatalog(recipe, fake); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		classifyNewIngredients(recipe, fake)
 		if !strings.Contains(strings.Join(fake.queries, "\n"), "display_unit_id IS NULL") {
 			t.Errorf("expected a conditional display unit write, got %v", fake.queries)
 		}
@@ -238,24 +232,26 @@ func TestInsertIngredientCatalog(t *testing.T) {
 		recipe := common.Recipe{Ingredients: []common.Ingredient{{
 			Name: "sumac", UnitSizes: map[string]float64{"": 0, "millilitre": -1},
 		}}}
-		if err := insertIngredientCatalog(recipe, fake); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		classifyNewIngredients(recipe, fake)
 		if len(fake.queries) != 0 {
 			t.Errorf("expected no queries but got %v", fake.queries)
 		}
 	})
 
-	t.Run("a failure propagates without attempting the rest", func(t *testing.T) {
+	// The spec is explicit that a classification failure must never fail a
+	// recipe save. An earlier version returned an error both callers
+	// propagated, so one bad proposal rolled back the whole recipe - and this
+	// test asserted that wrong behaviour.
+	t.Run("a failure is swallowed and the remaining writes still run", func(t *testing.T) {
 		fake := &fakeExecer{failOn: "base_unit_id"}
 		recipe := common.Recipe{Ingredients: []common.Ingredient{{
 			Name: "sumac", BaseUnit: "gram", UnitSizes: map[string]float64{"millilitre": 0.5},
 		}}}
-		if err := insertIngredientCatalog(recipe, fake); err == nil {
-			t.Fatal("expected an error")
-		}
-		if len(fake.queries) != 1 {
-			t.Errorf("expected to stop after the failing query, got %v", fake.queries)
+
+		classifyNewIngredients(recipe, fake)
+
+		if len(fake.queries) != 2 {
+			t.Errorf("expected the unit size write to still be attempted, got %v", fake.queries)
 		}
 	})
 }

--- a/netlify-functions/recipes/internal/pkg/service/recipe_test.go
+++ b/netlify-functions/recipes/internal/pkg/service/recipe_test.go
@@ -170,3 +170,92 @@ func TestInsertTags(t *testing.T) {
 		}
 	})
 }
+
+func TestInsertIngredientCatalog(t *testing.T) {
+	t.Run("an ingredient with no proposals issues no query", func(t *testing.T) {
+		fake := &fakeExecer{}
+		recipe := common.Recipe{Ingredients: []common.Ingredient{{Name: "flour", Quantity: "200", Unit: "gram"}}}
+		if err := insertIngredientCatalog(recipe, fake); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Manual Entry and every edit of an existing Recipe land here.
+		if len(fake.queries) != 0 {
+			t.Errorf("expected no queries but got %v", fake.queries)
+		}
+	})
+
+	t.Run("every write is conditional so a curated value cannot be overwritten", func(t *testing.T) {
+		fake := &fakeExecer{}
+		recipe := common.Recipe{Ingredients: []common.Ingredient{{
+			Name: "sumac", Quantity: "2", Unit: "teaspoon",
+			BaseUnit: "gram", UnitSizes: map[string]float64{"millilitre": 0.5},
+		}}}
+		if err := insertIngredientCatalog(recipe, fake); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		joined := strings.Join(fake.queries, "\n")
+		// This is the whole safety property of the phase: a value reviewed by a
+		// person in migration 025 must survive a later import proposing another.
+		if !strings.Contains(joined, "base_unit_id IS NULL") {
+			t.Error("base unit write must be conditional on the column being unset")
+		}
+		if !strings.Contains(joined, "ON DUPLICATE KEY UPDATE") {
+			t.Error("unit size write must no-op rather than overwrite an existing row")
+		}
+		// The guard that actually protects curated values. An unset-column check
+		// is not enough: NULL in base_unit_id means both "never curated" and
+		// "curated as the default, gram", so without this an import could flip
+		// onion to millilitre - which it did, against a live database, before
+		// this was added.
+		if strings.Count(joined, "NOT EXISTS (SELECT 1 FROM part") != len(fake.queries) {
+			t.Errorf("every write must be restricted to ingredients with no lines yet, got %v", fake.queries)
+		}
+		if strings.Contains(joined, "display_unit_id") {
+			t.Error("a nil DisplayUnit should be skipped, not written")
+		}
+	})
+
+	// "" is the bare-count Unit, and the most useful Display Unit there is, so
+	// a proposal of "" must reach the database rather than being mistaken for
+	// "nothing proposed".
+	t.Run("a proposed bare-count display unit is written", func(t *testing.T) {
+		fake := &fakeExecer{}
+		count := ""
+		recipe := common.Recipe{Ingredients: []common.Ingredient{{
+			Name: "sumac", DisplayUnit: &count,
+		}}}
+		if err := insertIngredientCatalog(recipe, fake); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(strings.Join(fake.queries, "\n"), "display_unit_id IS NULL") {
+			t.Errorf("expected a conditional display unit write, got %v", fake.queries)
+		}
+	})
+
+	t.Run("a non-positive unit size is skipped", func(t *testing.T) {
+		fake := &fakeExecer{}
+		recipe := common.Recipe{Ingredients: []common.Ingredient{{
+			Name: "sumac", UnitSizes: map[string]float64{"": 0, "millilitre": -1},
+		}}}
+		if err := insertIngredientCatalog(recipe, fake); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(fake.queries) != 0 {
+			t.Errorf("expected no queries but got %v", fake.queries)
+		}
+	})
+
+	t.Run("a failure propagates without attempting the rest", func(t *testing.T) {
+		fake := &fakeExecer{failOn: "base_unit_id"}
+		recipe := common.Recipe{Ingredients: []common.Ingredient{{
+			Name: "sumac", BaseUnit: "gram", UnitSizes: map[string]float64{"millilitre": 0.5},
+		}}}
+		if err := insertIngredientCatalog(recipe, fake); err == nil {
+			t.Fatal("expected an error")
+		}
+		if len(fake.queries) != 1 {
+			t.Errorf("expected to stop after the failing query, got %v", fake.queries)
+		}
+	})
+}

--- a/pages/recipes/new.tsx
+++ b/pages/recipes/new.tsx
@@ -91,6 +91,9 @@ interface ParsedIngredient {
   name?: string;
   quantity?: string;
   unit?: string;
+  baseUnit?: string;
+  displayUnit?: string;
+  unitSizes?: Record<string, number>;
 }
 
 interface ParseUrlResult {
@@ -110,11 +113,21 @@ interface ImageJobStatus {
 // Extraction results (from either source) carry loosely-shaped ingredients -
 // same normalization Form.tsx's appendIngredients already does for
 // bulk-paste extraction, applied here for URL/photo extraction too.
+// baseUnit/displayUnit/unitSizes are catalog metadata the extractor proposes for
+// ingredients this app has not seen (CONTEXT.md's Unit Size). They must survive
+// this hop: URL and Photo import reach the form through initialRecipe rather
+// than appendIngredients, so anything dropped here never reaches the save
+// payload and the ingredient is never classified. An earlier version of this
+// function destructured only name/quantity/unit and silently lost them for two
+// of the three Import Sources.
 function normalizeParsedIngredients(ingredients?: ParsedIngredient[]): RecipeModel['ingredients'] {
-  return (ingredients || []).map(({ name, quantity, unit }) => ({
+  return (ingredients || []).map(({ name, quantity, unit, baseUnit, displayUnit, unitSizes }) => ({
     name: name || '',
     quantity: quantity || '',
-    unit: unit || ''
+    unit: unit || '',
+    ...(baseUnit ? { baseUnit } : {}),
+    ...(displayUnit !== undefined && displayUnit !== null ? { displayUnit } : {}),
+    ...(unitSizes ? { unitSizes } : {}),
   }));
 }
 

--- a/specs/unit-normalisation.md
+++ b/specs/unit-normalisation.md
@@ -301,10 +301,18 @@ through this call — there is no path to route around it.
 - **Unit Sizes are global and single-locale (UK).** Recorded as a known limitation in
   CONTEXT.md rather than designed around. Recipe Import already metricates on the way in,
   so the exposure is narrow — Relative Units, chiefly pack sizes.
-- **"Never overwrite a human's value" is enforced as "only write where the value is
-  absent".** No provenance columns in v1: NULL-vs-set fully expresses the only rule that
-  exists, and explicit `curated`/`classified` columns can arrive with the admin panel that
-  would actually display them.
+- **"Never overwrite a human's value" is enforced by only classifying Ingredients that
+  don't exist yet** - detected by their having no Ingredient Lines - rather than by
+  checking whether the column is still unset. No provenance columns in v1.
+
+  **Corrected during Phase 4.** This decision originally read "only write where the value
+  is absent", on the reasoning that NULL-vs-set fully expressed the rule. It does not:
+  NULL in `base_unit_id` means both *never curated* and *curated as the default, gram*.
+  Onion is deliberately gram, so it is NULL, so an unset-column guard let an import flip it
+  to millilitre. Caught by testing against a live database; the unit tests could not have
+  found it, since they assert the shape of the SQL rather than what it means. Restricting
+  to new Ingredients is also a better fit for what the feature is for - the curated set
+  covers what exists, classification covers what arrives.
 - **No admin panel in v1.** Curated values live in a seed migration; corrections are SQL.
   With one user and ~76 rows this is genuinely viable, and it gets the engine in front of
   you sooner. Expect to want the panel fairly soon.

--- a/specs/unit-normalisation.md
+++ b/specs/unit-normalisation.md
@@ -17,8 +17,10 @@ Here's how I'd approach each of these problems:
 ## Current state (why this isn't greenfield)
 
 Before proposing an approach, worth naming what's already there. Verified against the
-code and the latest production dump (`backups/pscale_dump_bigshop_main_20240319_213654`)
-as of 2026-07-26.
+code and, at the time of writing, the 2024 production dump
+(`backups/pscale_dump_bigshop_main_20240319_213654`). **The figures below were later
+re-measured against live data** synced on 2026-07-26 - see "How bad is the problem" for
+the corrected numbers, which differ enough to have changed the phasing.
 
 ### Problem 1 is already solved at the input boundary — what's left is the aggregation bug
 
@@ -237,14 +239,16 @@ within a dimension via `factor`. Make a Shopping List Item carry one or more Amo
 the way through `common.ListIngredient`, `GetIngredientListItems` (grouping rows by name),
 the TypeScript types and `Item.tsx`. Fix the parse-failure drop.
 
-Ships the live bug fix, merges the 18 same-dimension collisions, and turns the other 58
-from silently wrong into visibly honest — **without a single curated data point.**
+Ships the live bug fix, merges the same-dimension collisions (36 ingredients on live data),
+and turns the rest from silently wrong into visibly honest — **without a single curated
+data point.**
 
 ### Phase 2 — Base Unit and Unit Size
 
 Add `base_unit_id`, `ingredient_unit_size` and `unit.default_size`. Seed: unit-level
 defaults for pinch/clove/tin, a Base Unit of millilitre for the liquids, and per-ingredient
-Unit Sizes for the ~76 colliding ingredients. Values drafted with LLM help offline, then
+Unit Sizes for the colliding ingredients (120 on live data, of which 84 need values).
+Values drafted with LLM help offline, then
 reviewed by a person and committed as a migration.
 
 Most remaining collisions now merge.
@@ -259,7 +263,9 @@ This is where "800 g chopped tomatoes" becomes "2 tins (800 g)".
 Extend `lib/recipe-import/extract.js` to return, for ingredient names not in
 `knownIngredients`, a proposed Base Unit / Display Unit / Unit Sizes. These ride along on
 each `common.Ingredient` in the `POST /recipe` payload and are written inside the existing
-save transaction, **only where the existing value is absent**.
+save transaction, **only for Ingredients that have no Ingredient Lines yet** - see the
+corrected entry under "Decisions made" for why "where the existing value is absent" was not
+a sufficient guard.
 
 The curated seed covers the 300 ingredients that exist; this covers everything new. Since
 `appendIngredients` (`components/recipe-form/Form.tsx:154`) is the only way an ingredient
@@ -268,9 +274,19 @@ through this call — there is no path to route around it.
 
 ## Decisions made (grilled — do not re-litigate without a load-bearing reason)
 
-- **Normalisation happens at read time.** `part` records what the Recipe said, verbatim,
-  forever; all conversion happens in `GenerateShoppingList`. A corrected Unit Size then
-  improves every existing Recipe with no backfill, and no original data is ever destroyed.
+- **Normalisation happens at read time.** `part` is not rewritten *as part of combining* -
+  all conversion happens in `GenerateShoppingList`, so a corrected Unit Size improves every
+  existing Recipe with no backfill.
+
+  **Qualified during Phase 2.** The original wording was "verbatim, forever… no original
+  data is ever destroyed", and migrations 022-024 do destroy some: they correct eight
+  mis-entered lines, consolidate three garlic ingredients, and rewrite every `packet` and
+  `bottle` line to a real measure. Those are *data corrections*, not normalisation - "1
+  packet coriander" never recorded whether that was 30g or 100g, so there was no faithful
+  original to preserve. The read-time principle still governs the aggregation, which is
+  what it was for. But the consequence is real and was not free: correcting a pack size is
+  no longer a one-row Unit Size edit, and the pre-conversion values exist only in the
+  backup taken before those migrations ran.
 - **Unit Size is one relation covering average weight, pack size and density**, rather
   than separate scalars on `ingredient` plus a deferred density feature. Stating the value
   in the Ingredient's own Base Unit is what makes one relation sufficient.

--- a/specs/unit-normalisation.state.md
+++ b/specs/unit-normalisation.state.md
@@ -1,12 +1,13 @@
 ---
 spec: specs/unit-normalisation.md
 status: in-progress
-branch: implement/unit-normalisation-phase-2
-pr: https://github.com/Ianfeather/big-shop/pull/64
+branch: implement/unit-normalisation-phase-4
+pr:
 ---
 
-**Status: production is fully migrated (020-025 applied 2026-07-27). The branch
-is safe to merge.**
+**Status: Phases 1-3 are merged (PRs #63, #64) and migrations 019-025 are applied to
+production. Phase 4 is in progress on `implement/unit-normalisation-phase-4`, branched
+from the #64 merge.**
 
 **Deployment order (applies to every phase of this spec):** each phase's migration must
 reach production *before* the code that reads its columns. Phase 1's migration 019 is
@@ -279,8 +280,32 @@ an LLM drafts and a person approves, rather than values being written
 unsupervised. Live data to curate against: 120 colliding ingredients of 436.
 
 ## Session 8: Classification for new Ingredients (spec Phase 4)
-Status: pending
+Status: done
 Scope: extract.js proposes Base Unit / Display Unit / Unit Sizes for unseen ingredient names; carried on common.Ingredient in the save payload; written only where absent.
 Depends on: Session 7
-Commit:
-Notes: Not in this run.
+Commit: (see git log)
+Notes: extract.js proposes baseUnit/displayUnit/unitSizes for names not in
+knownIngredients, attached to the ingredient they describe so callers carry one
+shape through to the save payload. Written by a new insertIngredientCatalog,
+ordered after insertUnits in both AddRecipe and EditRecipe so a proposed Unit
+Size can reference a Unit the same save is introducing.
+
+**Two traps, both found by testing against a live database rather than by the
+unit tests, which only assert the shape of the SQL:**
+
+(1) The guard was "only write where the column is unset". That is not enough -
+NULL in base_unit_id means both "never curated" and "curated as the default,
+gram". Onion is deliberately gram, so it is NULL, and an import flipped it to
+millilitre. Now restricted to Ingredients with no Ingredient Lines yet, i.e.
+genuinely new ones, which also matches what the feature is for. The spec's
+"Decisions made" entry has been corrected rather than quietly edited.
+
+(2) The bare-count Unit's name collided with a sentinel for the third time.
+common.Ingredient.DisplayUnit is a *string, not a string, because "" is a real
+Display Unit - the most useful one - and a plain string cannot tell "propose a
+count" from "propose nothing". Without the pointer, classification could never
+have suggested the count for onions, potatoes or carrots.
+
+Verified live: a brand-new ingredient gets base, display and Unit Size written;
+an established one has a proposed base unit, display unit and Unit Size all
+correctly rejected.

--- a/specs/unit-normalisation.state.md
+++ b/specs/unit-normalisation.state.md
@@ -281,7 +281,7 @@ unsupervised. Live data to curate against: 120 colliding ingredients of 436.
 
 ## Session 8: Classification for new Ingredients (spec Phase 4)
 Status: done
-Scope: extract.js proposes Base Unit / Display Unit / Unit Sizes for unseen ingredient names; carried on common.Ingredient in the save payload; written only where absent.
+Scope: extract.js proposes Base Unit / Display Unit / Unit Sizes for unseen ingredient names; carried on common.Ingredient in the save payload; written only for Ingredients that have no Ingredient Lines yet.
 Depends on: Session 7
 Commit: (see git log)
 Notes: extract.js proposes baseUnit/displayUnit/unitSizes for names not in

--- a/specs/unit-normalisation.state.md
+++ b/specs/unit-normalisation.state.md
@@ -2,12 +2,17 @@
 spec: specs/unit-normalisation.md
 status: in-progress
 branch: implement/unit-normalisation-phase-4
-pr:
+pr: https://github.com/Ianfeather/big-shop/pull/65
 ---
 
-**Status: Phases 1-3 are merged (PRs #63, #64) and migrations 019-025 are applied to
-production. Phase 4 is in progress on `implement/unit-normalisation-phase-4`, branched
-from the #64 merge.**
+**Status: every session in this spec is implemented.** Phases 1-3 are merged (PRs #63,
+#64) and migrations 019-025 are applied to production; Phase 4 is open as PR #65 and needs
+no migration. Once #65 merges, this spec and state file move to `specs/completed/`.
+
+What is deliberately *not* done, and is recorded in follow-ups rather than here: #26 (dry
+goods rendering as millilitres), #27 (a line-less curated Ingredient can be reclassified)
+and #28 (nothing is displayed in spoons - the mechanism for the original problem 3 shipped,
+the curation did not).
 
 **Deployment order (applies to every phase of this spec):** each phase's migration must
 reach production *before* the code that reads its columns. Phase 1's migration 019 is

--- a/technical-architecture.md
+++ b/technical-architecture.md
@@ -55,13 +55,14 @@ The recipe image extraction uses Netlify Blobs to store async job results; the f
 
 ## Database Schema
 
-Production: TiDB (MySQL-compatible). Migrations in `migrations/` applied manually, in order — there is no consolidated schema file, so `migrations/*.sql` (currently 19 files) is the authoritative source for exact columns/constraints.
+Production: TiDB (MySQL-compatible). Migrations in `migrations/` applied manually, in order — there is no consolidated schema file, so `migrations/*.sql` (currently 25 files) is the authoritative source for exact columns/constraints.
 
 | Table | Purpose |
 |-------|---------|
 | `recipe` | Recipe records (id, name, slug, remote_url, account_id) |
-| `ingredient` | Canonical ingredient names |
-| `unit` | Measurement units (gram, litre, teaspoon, packet, etc.) |
+| `ingredient` | Canonical ingredient names, plus `base_unit_id` (what its Amounts are added up in) and `display_unit_id` (what a Shopping List shows them as) |
+| `ingredient_unit_size` | How much one `<unit>` of an `<ingredient>` is, in that ingredient's base unit — average weight, pack size and density are all this one relation (see [ADR-0004](./docs/adr/0004-unit-size-as-one-relation.md)) |
+| `unit` | Measurement units (gram, litre, teaspoon, packet, etc.), each with a `kind` (weight/volume/relative), a `factor` for Absolute Units, and an optional `default_size` |
 | `part` | Recipe ↔ ingredient join (recipe_id, ingredient_id, unit_id, quantity) |
 | `tag` | Recipe tags (Vegetarian, Batch Cook, etc.) |
 | `recipe_tag` | Recipe ↔ tag join |

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -461,10 +461,15 @@ export interface components {
             type: string;
         };
         Ingredient: {
+            baseUnit?: string;
             department?: string;
+            displayUnit?: string;
             name: string;
             quantity: string;
             unit: string;
+            unitSizes?: {
+                [key: string]: number;
+            };
         };
         IngredientName: {
             name: string;


### PR DESCRIPTION
Completes `specs/unit-normalisation.md`. Phases 1–3 fixed the shopping list for the ingredients you already have; this stops the catalog going stale as you add recipes.

> **No migration.** The columns landed in `020`/`021`, already applied to production. Unlike the last two PRs there's no ordering constraint — merge whenever.

## What it does

When Recipe Import meets an ingredient the Global Catalog has never seen, it now proposes a Base Unit, a Display Unit and Unit Sizes alongside the recipe. Those ride on each `common.Ingredient` in the save payload and are written inside the existing transaction.

The prompt asks for an average weight for anything countable and a **single density** for dry ingredients measured in spoons — one value covers millilitre, teaspoon and tablespoon, so it can't be set inconsistently. It's explicit that an empty answer beats a guess: a wrong Unit Size produces a confidently wrong shopping list, a missing one just leaves two amounts side by side.

## The guard that matters

Classification applies **only to ingredients with no Ingredient Lines yet**.

The original design said "only write where the value is absent", and the spec recorded that as sufficient. It isn't: `NULL` in `base_unit_id` means *both* "never curated" **and** "curated as the default, gram". Onion is deliberately gram, so it's NULL — and testing against a live database caught an import flipping it to millilitre, silently corrupting a curated value.

The unit tests could not have found this. They assert the shape of the SQL, not what it means.

## What three reviews found

Two Phase-4 axes plus a whole-spec review over everything since before Phase 1.

**Two real bugs, neither caught by any test:**

- **URL and Photo import silently dropped every classification.** `normalizeParsedIngredients` destructured only `name/quantity/unit`, and both reach the form via `initialRecipe` rather than `appendIngredients`. Only bulk-paste ever carried the data. The spec asserted "there is no path to route around it" — false, and repeated without checking. The fields are now declared on the types so dropping them again is a compile error.
- **A classification failure rolled back the whole recipe save**, against the spec's explicit "must never fail a recipe save" — and the test written for it *asserted the wrong behaviour*. `classifyNewIngredients` now returns nothing at all, making the property structural rather than a rule each caller must remember.

**A decision this work had quietly contradicted.** Decision #1 was "normalisation happens at read time — `part` verbatim, forever, no original data destroyed". Migrations `022`–`024` destroy plenty. That was discussed and agreed at the time (a packet never recorded a real quantity to preserve) but neither the decision nor `CONTEXT.md` was updated, so both were silently false. Corrected in place, including the cost: a pack-size correction is no longer a one-row edit, and pre-conversion values exist only in the backup.

**Third collision with the same sentinel.** `DisplayUnit` is a `*string`, because `""` is a real Display Unit — the bare count, and the most useful one. A plain string can't tell "propose a count" from "propose nothing", so classification could never have suggested it for onions or potatoes. Recorded as a standing hazard rather than three coincidences.

## Verification

- Go 106 tests and subtests · frontend 108 · e2e 17/17 · no OpenAPI or type drift
- Verified live both ways: a new ingredient gets base unit, display unit and Unit Size written; an established one has all three proposals rejected, including a deliberately absurd `9999`

## Follow-ups opened

- **#27** — `DeleteRecipe` leaves an ingredient line-less, so a curated one can re-qualify as "new" and be reclassified. Narrow, but a silent regression on human-chosen values. The real fix is the provenance column deferred in the spec.
- **#28** — **half of your original problem 3 is unbuilt.** You asked for "a preferred unit for each ingredient… teaspoon for spices but not for herbs". The mechanism shipped in full, but every curated Display Unit is a count or a tin — nothing reads in spoons, so spices still show as grams. Curation, not code, and worth doing with #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
