### PR TITLE
Fix Chat with Dave layout overflowing viewport on mobile

### DIFF
--- a/pages/dave.module.css
+++ b/pages/dave.module.css
@@ -1,7 +1,14 @@
 .daveContainer {
   display: flex;
-  height: calc(100vh - 100px);
+  flex-direction: column;
   gap: var(--space-4);
+}
+
+@media (min-width: 800px) {
+  .daveContainer {
+    flex-direction: row;
+    height: calc(100vh - 100px);
+  }
 }
 
 .recipesSidebar {

--- a/pages/styles.css
+++ b/pages/styles.css
@@ -124,6 +124,7 @@ html {
      matched its content. */
   min-height: 100%;
   background: var(--color-primary-soft);
+  overflow-x: hidden;
 }
 
 body {
@@ -132,6 +133,7 @@ body {
   min-height: 100vh;
   font-family: var(--font-body);
   -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
 }
 
 button {


### PR DESCRIPTION
## Summary
- The "Chat with Dave" page (`pages/dave.tsx`) built its own two-column layout in `pages/dave.module.css` (`display: flex`, no responsive breakpoint) instead of reusing the shared `Grid` component that every other two-column page (e.g. Your Recipes) uses, which correctly stacks to a single column below 800px.
- On mobile this kept the recipes sidebar side-by-side with the chat panel, pushing it ~110px past the viewport edge and widening the whole document (confirmed via a headless check: `document.documentElement.scrollWidth` was 502px against a 390px viewport). That's what was cropping the header/nav and page content in the reported screenshot.
- Fixed by making `.daveContainer` stack vertically by default and only switch to the side-by-side row (with its `calc(100vh - 100px)` height) at the existing `800px` breakpoint used elsewhere in the layout.
- Added a defensive `overflow-x: hidden` on `html`/`body` in `pages/styles.css` so this class of bug can never produce a horizontal scrollbar, even if something else overflows in future.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] Verified with a headless browser at a 390×844 mobile viewport and a 1024×800 desktop viewport (with mocked recipe data) that `/dave` no longer overflows the viewport on mobile and the desktop side-by-side layout is unchanged.
- [ ] `npm run test:e2e` (Dave page is explicitly out of scope for the e2e suite per `CLAUDE.md`)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01K4rTpiL4ZdMwSqi3dZSFw6

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4rTpiL4ZdMwSqi3dZSFw6)_