### PR TITLE
Authenticate /api/recipe-image, and require aud/iss on Auth0 tokens

### DIFF
--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -4,10 +4,13 @@
 //    bearer-token authenticated.
 //  - nextApiGet/nextApiPost/nextApiPostFormData: this app's own Next.js API
 //    routes (pages/api/*, see technical-architecture.md's "Next.js API
-//    Routes" section), error-shaped as `{ error: string }` on failure. These
-//    routes don't validate a token themselves, but the import ones forward
-//    one to the Go API to read canonical Ingredient/Unit names server-side
-//    (lib/recipe-import/known-names.ts), so they take an optional token.
+//    Routes" section), error-shaped as `{ error: string }` on failure. None of
+//    them verifies a token itself; each forwards it to the Go API, which is
+//    the only thing that can. The parse routes do that to read canonical
+//    Ingredient/Unit names server-side (lib/recipe-import/known-names.ts);
+//    /api/recipe-image does it to authenticate the caller at all
+//    (lib/authenticate.ts), and rejects a request without one. Hence the
+//    optional token on all three.
 
 async function parseBody(res: Response): Promise<unknown> {
   const text = await res.text();
@@ -52,8 +55,10 @@ async function handleNextApiResponse<T>(res: Response, label: string): Promise<T
   return data as T;
 }
 
-export async function nextApiGet<T>(url: string): Promise<T> {
-  const res = await fetch(url);
+export async function nextApiGet<T>(url: string, token?: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined
+  });
   return handleNextApiResponse<T>(res, `GET ${url}`);
 }
 

--- a/lib/authenticate.test.ts
+++ b/lib/authenticate.test.ts
@@ -1,0 +1,85 @@
+import type { NextApiRequest } from 'next';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { authenticateAccount } from './authenticate';
+
+const req = (headers: Record<string, string> = {}) => ({ headers }) as unknown as NextApiRequest;
+
+beforeEach(() => {
+  vi.stubEnv('NEXT_PUBLIC_API_HOST', 'http://api.test');
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('authenticateAccount', () => {
+  it('resolves the caller to their Account', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ id: 7, users: [] }) }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(authenticateAccount(req({ authorization: 'Bearer good' }))).resolves.toEqual({
+      ok: true,
+      account: { id: 7 }
+    });
+    expect(fetchMock).toHaveBeenCalledWith('http://api.test/account', {
+      headers: { Authorization: 'Bearer good' }
+    });
+  });
+
+  it('rejects a request with no Authorization header without calling the API', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(authenticateAccount(req())).resolves.toEqual({
+      ok: false,
+      status: 401,
+      error: 'Authentication required'
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a token the API refuses', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 401, json: async () => ({}) })));
+
+    await expect(authenticateAccount(req({ authorization: 'Bearer forged' }))).resolves.toEqual({
+      ok: false,
+      status: 401,
+      error: 'Authentication required'
+    });
+  });
+
+  // A gate that fails open is not a gate - unlike fetchKnownNames, which
+  // deliberately degrades to an empty list on exactly these failures.
+  it('fails closed when the API is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+
+    await expect(authenticateAccount(req({ authorization: 'Bearer good' }))).resolves.toMatchObject({
+      ok: false,
+      status: 500
+    });
+  });
+
+  it('fails closed when NEXT_PUBLIC_API_HOST is unset', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_HOST', '');
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(authenticateAccount(req({ authorization: 'Bearer good' }))).resolves.toMatchObject({
+      ok: false,
+      status: 500
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the API answers without an account id', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ users: [] }) })));
+
+    await expect(authenticateAccount(req({ authorization: 'Bearer good' }))).resolves.toMatchObject({
+      ok: false,
+      status: 500
+    });
+  });
+});

--- a/lib/authenticate.ts
+++ b/lib/authenticate.ts
@@ -1,0 +1,60 @@
+import type { NextApiRequest } from 'next';
+
+// Who the caller of a Next.js API route is.
+//
+// These routes hold no JWKS, no audience and no issuer, and nothing in the
+// frontend's dependencies can verify an Auth0 token - the Go API is the only
+// thing in this system that decides whether one is good (the same reason
+// lib/recipe-import/known-names.ts forwards the caller's header rather than
+// reading it). So authenticating here means asking it: one GET /account with
+// the caller's own Authorization header. A 2xx means the token passed Auth0
+// validation, and the body says which Account it resolved to.
+//
+// The Account, not the user, is the unit of ownership everywhere else in Big
+// Shop - every Go handler scopes its queries to account_id, and two people
+// sharing an Account are meant to see each other's data - so it is the right
+// key for anything a route here needs to own.
+//
+// Under DISABLE_AUTH the Go API resolves every request to the fixed dev user,
+// so this passes for any header value. That is the same latitude local dev
+// already gives every other endpoint.
+export type AuthenticatedAccount = { id: number };
+
+export type AuthenticationResult =
+  | { ok: true; account: AuthenticatedAccount }
+  | { ok: false; status: 401 | 500; error: string };
+
+export async function authenticateAccount(req: NextApiRequest): Promise<AuthenticationResult> {
+  const host = process.env.NEXT_PUBLIC_API_HOST;
+  if (!host) {
+    console.error('NEXT_PUBLIC_API_HOST is not set - cannot authenticate the caller');
+    return { ok: false, status: 500, error: 'Authentication is not configured' };
+  }
+
+  const authorization = req.headers.authorization;
+  if (!authorization) {
+    return { ok: false, status: 401, error: 'Authentication required' };
+  }
+
+  try {
+    const res = await fetch(`${host}/account`, { headers: { Authorization: authorization } });
+
+    if (!res.ok) {
+      return { ok: false, status: 401, error: 'Authentication required' };
+    }
+
+    const account = (await res.json()) as { id?: unknown };
+    if (typeof account?.id !== 'number') {
+      console.error('Token accepted but the API returned no account id');
+      return { ok: false, status: 500, error: 'Could not verify authentication' };
+    }
+
+    return { ok: true, account: { id: account.id } };
+  } catch (e) {
+    // Unlike fetchKnownNames, this deliberately does not degrade to a usable
+    // result when the API is unreachable. Losing canonical names costs a bonus;
+    // a gate that fails open is not a gate.
+    console.error('Could not reach the API to authenticate the caller', e);
+    return { ok: false, status: 500, error: 'Could not verify authentication' };
+  }
+}

--- a/lib/recipe-import/known-names.ts
+++ b/lib/recipe-import/known-names.ts
@@ -28,8 +28,12 @@ export async function fetchKnownNames(req: NextApiRequest): Promise<KnownNames> 
     return EMPTY;
   }
 
-  // Forwarded straight through from the browser. These routes do not validate
-  // it themselves; the Go API is the thing that decides whether it is good.
+  // Forwarded straight through from the browser. No route here validates a
+  // token itself; the Go API is the thing that decides whether it is good -
+  // which is also how lib/authenticate.ts authenticates a caller, by asking it.
+  // This call is not that check: a missing or bad token costs canonical names
+  // (see below), and any route that needs the caller authenticated says so
+  // separately.
   const authorization = req.headers.authorization;
   const headers = authorization ? { Authorization: authorization } : undefined;
 

--- a/netlify-functions/recipes/internal/pkg/app/app.go
+++ b/netlify-functions/recipes/internal/pkg/app/app.go
@@ -76,6 +76,39 @@ func devUserMiddleware(w http.ResponseWriter, r *http.Request, next http.Handler
 	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
+// normalizeAudience rewrites the `aud` claim into a shape MapClaims.
+// VerifyAudience understands.
+//
+// It accepts only []string or string and returns false for anything else,
+// while encoding/json decodes a JSON array into []interface{} - which is what
+// Auth0 sends whenever a token was requested with an audience. Hence the
+// conversion (https://github.com/form3tech-oss/jwt-go/issues/7).
+//
+// Returns an error rather than asserting. The `claims["aud"].([]interface{})`
+// this replaced panicked outright on a token whose `aud` was absent or a bare
+// string, and there is no Recovery middleware in the negroni stack to turn
+// that into a response - so an unauthenticated request could kill the handler
+// instead of being refused by it.
+func normalizeAudience(claims jwt.MapClaims) error {
+	switch aud := claims["aud"].(type) {
+	case []interface{}:
+		values := make([]string, len(aud))
+		for i, v := range aud {
+			value, ok := v.(string)
+			if !ok {
+				return errors.New("invalid audience")
+			}
+			values[i] = value
+		}
+		claims["aud"] = values
+	case []string, string:
+		// Already a shape VerifyAudience reads.
+	default:
+		return errors.New("missing audience")
+	}
+	return nil
+}
+
 func getPemCert(token *jwt.Token) (string, error) {
 	cert := ""
 	resp, err := http.Get("https://" + os.Getenv("AUTH0_DOMAIN") + "/.well-known/jwks.json")
@@ -113,24 +146,30 @@ func (a *App) GetRouter(base string) (*negroni.Negroni, huma.API, error) {
 
 	jwtMiddleware := jwtmiddleware.New(jwtmiddleware.Options{
 		ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {
-			// Have to fiddle with the types here due to a casting issue in
-			// the package https://github.com/form3tech-oss/jwt-go/issues/7
-			aud := token.Claims.(jwt.MapClaims)["aud"].([]interface{})
-			s := make([]string, len(aud))
-			for i, v := range aud {
-				s[i] = fmt.Sprint(v)
+			claims, ok := token.Claims.(jwt.MapClaims)
+			if !ok {
+				return nil, errors.New("invalid claims")
 			}
-			token.Claims.(jwt.MapClaims)["aud"] = s
 
-			checkAud := token.Claims.(jwt.MapClaims).VerifyAudience(os.Getenv("AUTH0_AUDIENCE"), false)
-			if !checkAud {
-				return token, errors.New("Invalid audience")
+			if err := normalizeAudience(claims); err != nil {
+				return nil, err
+			}
+
+			// Both claims are *required*, not merely checked-if-present. With
+			// the `false` this passed before, verifyAud returns true for an
+			// empty `aud` and VerifyIssuer returns true for a token carrying
+			// no `iss` at all - so any token the tenant's key signed was
+			// accepted, whatever it was minted for. The signature check below
+			// meant that was never an open door, but a token issued by this
+			// Auth0 tenant for some other audience is exactly what this API
+			// must refuse.
+			if !claims.VerifyAudience(os.Getenv("AUTH0_AUDIENCE"), true) {
+				return nil, errors.New("invalid audience")
 			}
 
 			iss := "https://" + os.Getenv("AUTH0_DOMAIN") + "/"
-			checkIss := token.Claims.(jwt.MapClaims).VerifyIssuer(iss, false)
-			if !checkIss {
-				return token, errors.New("invalid issuer")
+			if !claims.VerifyIssuer(iss, true) {
+				return nil, errors.New("invalid issuer")
 			}
 
 			cert, err := getPemCert(token)

--- a/netlify-functions/recipes/internal/pkg/app/app_test.go
+++ b/netlify-functions/recipes/internal/pkg/app/app_test.go
@@ -1,0 +1,112 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/form3tech-oss/jwt-go"
+)
+
+const (
+	testAudience = "https://api.bigshop.test"
+	testIssuer   = "https://tenant.eu.auth0.com/"
+)
+
+func TestNormalizeAudience(t *testing.T) {
+	t.Run("converts the []interface{} a JSON array decodes to", func(t *testing.T) {
+		claims := jwt.MapClaims{"aud": []interface{}{testAudience, testIssuer + "userinfo"}}
+
+		if err := normalizeAudience(claims); err != nil {
+			t.Fatalf("normalizeAudience() error = %v", err)
+		}
+
+		got, ok := claims["aud"].([]string)
+		if !ok {
+			t.Fatalf("aud is %T, want []string", claims["aud"])
+		}
+		if len(got) != 2 || got[0] != testAudience {
+			t.Errorf("aud = %v", got)
+		}
+	})
+
+	t.Run("leaves a bare string audience alone", func(t *testing.T) {
+		claims := jwt.MapClaims{"aud": testAudience}
+
+		if err := normalizeAudience(claims); err != nil {
+			t.Fatalf("normalizeAudience() error = %v", err)
+		}
+		if claims["aud"] != testAudience {
+			t.Errorf("aud = %v, want it untouched", claims["aud"])
+		}
+	})
+
+	// Both of these panicked before, taking the request down with no response
+	// rather than refusing it - there is no Recovery middleware in the stack.
+	t.Run("rejects a token carrying no audience", func(t *testing.T) {
+		if err := normalizeAudience(jwt.MapClaims{"iss": testIssuer}); err == nil {
+			t.Error("normalizeAudience() = nil, want an error")
+		}
+	})
+
+	t.Run("rejects a non-string value in the audience array", func(t *testing.T) {
+		claims := jwt.MapClaims{"aud": []interface{}{testAudience, 42}}
+
+		if err := normalizeAudience(claims); err == nil {
+			t.Error("normalizeAudience() = nil, want an error")
+		}
+	})
+}
+
+// Guards the `true` (required) argument in GetRouter's VerifyAudience and
+// VerifyIssuer calls. Every case here verified successfully under the `false`
+// this replaced, which meant any token the Auth0 tenant's key had signed was
+// accepted regardless of what it was minted for.
+func TestRequiredClaims(t *testing.T) {
+	t.Run("an empty audience array does not satisfy the audience", func(t *testing.T) {
+		claims := jwt.MapClaims{"aud": []interface{}{}, "iss": testIssuer}
+		if err := normalizeAudience(claims); err != nil {
+			t.Fatalf("normalizeAudience() error = %v", err)
+		}
+
+		if claims.VerifyAudience(testAudience, true) {
+			t.Error("VerifyAudience() = true for an empty aud")
+		}
+	})
+
+	t.Run("a token minted for another audience does not verify", func(t *testing.T) {
+		claims := jwt.MapClaims{"aud": []interface{}{"https://other-api.test"}, "iss": testIssuer}
+		if err := normalizeAudience(claims); err != nil {
+			t.Fatalf("normalizeAudience() error = %v", err)
+		}
+
+		if claims.VerifyAudience(testAudience, true) {
+			t.Error("VerifyAudience() = true for another audience")
+		}
+	})
+
+	t.Run("a token carrying no issuer does not verify", func(t *testing.T) {
+		claims := jwt.MapClaims{"aud": []string{testAudience}}
+
+		if claims.VerifyIssuer(testIssuer, true) {
+			t.Error("VerifyIssuer() = true for a missing iss")
+		}
+	})
+
+	// The shape Auth0 actually issues: an array holding this API's audience
+	// alongside the tenant's /userinfo endpoint.
+	t.Run("a genuine access token still verifies", func(t *testing.T) {
+		claims := jwt.MapClaims{
+			"aud": []interface{}{testAudience, testIssuer + "userinfo"},
+			"iss": testIssuer,
+		}
+		if err := normalizeAudience(claims); err != nil {
+			t.Fatalf("normalizeAudience() error = %v", err)
+		}
+
+		if !claims.VerifyAudience(testAudience, true) {
+			t.Error("VerifyAudience() = false for a genuine token")
+		}
+		if !claims.VerifyIssuer(testIssuer, true) {
+			t.Error("VerifyIssuer() = false for a genuine token")
+		}
+	})
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "openai": "^6.46.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "swagger-ui-react": "^5.32.8",
+        "swagger-ui-react": "^5.32.9",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -2652,13 +2652,13 @@
       "license": "MIT"
     },
     "node_modules/@swagger-api/apidom-ast": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.11.3.tgz",
-      "integrity": "sha512-Nfi/0vy+cIHClX7raXamtHnCMBbwI1PEg+yroIzyy8LcCH7zcS0Xi4ARG3CkDQswOnWO2gLDAUAFjDvkQWdZ+A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.12.0.tgz",
+      "integrity": "sha512-C4Px0M/hNIBf2jFphrHlKe8rN5OuUaxNb3FNandzM8++Uyp9TKjdt0+FI6+sX4s8u3axvQ4c4jrjb0LW7r2jPA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-error": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2666,14 +2666,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.11.3.tgz",
-      "integrity": "sha512-21/PXEqCzsWkiwKWHt0TPJE7GUtog3BhMlvYLUEPbteXOrk+PNazbjYDPl4zfZGRLaoGhTqpFBY5pXafdzaHWQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.12.0.tgz",
+      "integrity": "sha512-HXiJ6c7R/Sfpj1nz8Tgzy6jvaKE333b3FA4XTuKrwne/fgGq+ITksp6SaDMp7F/FbvP8iik2OFT9wJ3BRw1wjw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ast": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "minim": "~0.23.8",
         "ramda": "~0.30.0",
@@ -2683,37 +2683,52 @@
       }
     },
     "node_modules/@swagger-api/apidom-error": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.11.3.tgz",
-      "integrity": "sha512-Z4mIDyZUF2kDFHBzKsxkYSaHpGSvGDc7gAkdzLKxcQk4849iCUXxs0PpQLxZxfYcmUSwkw7AZmIP/OKGpsR8JA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.12.0.tgz",
+      "integrity": "sha512-mdQbyeolFyhyJiVchAJlfOUYntD4p10ORtpVRTLw0vFfqQZtDfr+uMVgiB/kmmyTZ27PoJPR51RDqaXB88aq2Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7"
       }
     },
     "node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.11.3.tgz",
-      "integrity": "sha512-z6eEvJ5HIb0aFqVldHyU5Guut+bv/opu28i+rrfDb1LEG3IWk5T3DbW9d/nWpAfNze/bjwiZvPphmkuycijb2w==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.12.0.tgz",
+      "integrity": "sha512-L6JaaeNjG6J5Ros4MLd+Yb2ZS0RhfJ5fj8w5UtCyf1I0cnwJo7hrRExE5RWXVBtF5nl8mO3eIGUe959hC1DtVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
         "@swaggerexpert/json-pointer": "^2.10.1"
       }
     },
-    "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.11.3.tgz",
-      "integrity": "sha512-HTISScqScdnUc2BKqMaWM+ISU79AlHlr+XHUR9g0R8QiO4KzCkWUi6TncP0gvGoEY+BvfR0OkztfxYrelkksmg==",
+    "node_modules/@swagger-api/apidom-ns-a2a-1": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-a2a-1/-/apidom-ns-a2a-1-1.12.0.tgz",
+      "integrity": "sha512-kYfltECH/D3+bT+7IxYtF7VGNrSeDqqDttiIjx7R3pBgPPbxNWAi/EA4Rx+c7qY56sDz0CdbtZNTH28bNi00og==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.3"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-api-design-systems": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.12.0.tgz",
+      "integrity": "sha512-opXxaAZGxy/IDdUxqfTugtoGeKarb+pDchdVMOWNUD4NZH5weE519dcqCdLMqWtcHX2RL2m9UdcJjGLnAt+GQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2721,15 +2736,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-arazzo-1": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.11.3.tgz",
-      "integrity": "sha512-AHRSbuYy5oA8c/7j7nahxMASjt0cuOWyUk4yu+cKG+KS85ho2f2NiFThqQjtIJLisvrp+qNniJ1EwTfcCTivTQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.12.0.tgz",
+      "integrity": "sha512-xqtr7pZ5IQBsHZA6yWbSprVSTzpIbM5FtX40rY7lx4wsm4TyhIfJBxOf99+jFmELt7QHoKCUZ8zZQOdf+uOqLw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2737,15 +2752,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.11.3.tgz",
-      "integrity": "sha512-bn/Pf52SCsSGcw7qO3gAje+KjhhpWJxWjjWQe5Jv9oPoXCnvGoSspSXMY3zIrhz9XfrP94AdWBUpOlWBoaaDBQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.12.0.tgz",
+      "integrity": "sha512-xe3Y3PeRqohaOinEtKTqnUxPoMAopTYAPEnXew5qRcnH7wVWO99J3+XrbY+x9JEXhcAKHpKSWmuNx5o7oU0WdA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2753,15 +2768,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-3": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.11.3.tgz",
-      "integrity": "sha512-QhZtf8YeMRVtgVioJj0qKdNG0LEzi9RPSrC9KWfCdwEBlkhNDhHFh6FIJWayYAwR6DPlOXjTYQf97V9QwIuRmQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.12.0.tgz",
+      "integrity": "sha512-WZ/j/Hk8nsX0lkHiTUFfESkQgGGEba9dwiKMP9OvX9qLsoxJ04Dg1Z7E58WCrmwistEpynMHO+KY3qo2trWOUQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2769,15 +2784,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2019-09": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.11.3.tgz",
-      "integrity": "sha512-zHA4/oin6Fg6VN0bWmMRu1nt4Xnd05mF5T+Od6vEmid1bxDXpfSSMaPpdu+WCBJ5dDX19EeBVTJoAI0U4psxBg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.12.0.tgz",
+      "integrity": "sha512-fWRjOvOiOFqKp0vJgFJn1fm9i+H5eSOQ1J0xWldTnHJPHsYPQkYPLAQdpXcBbBiB5o0JYVeJe7PyWv3DvNxqSA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2785,15 +2800,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-2020-12": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.11.3.tgz",
-      "integrity": "sha512-zUWRb5DlvlZXtf2JmiNqUwwgGc4eUAsUQPU59kP140vkPT98HDhNJx9UXoHLgP5F/Zk8f2rzeG237u+JnCT9/g==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.12.0.tgz",
+      "integrity": "sha512-U0sv+7aD6njyxcvQOS9Lkpr4feJRowMn0/shiIlXrXY1ox3BDJBgipsgx/0IqfQNseP3Zj43Ec5kGk4PFmsjCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2801,14 +2816,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.11.3.tgz",
-      "integrity": "sha512-udOM8ZQT7BzsyT9012R7/VjeazjOlyLwKpmpbgHZDG6uGHqsnWn9lN+F8/5Eox9qqBnQNqDNtDhBEMYjE6RYNQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.12.0.tgz",
+      "integrity": "sha512-c+NYp+DZvoZ0+3hFgKhQn507kba0HUv8C60cJEqQPCpIKqKpWvpZ6YF8GsKVhJoML4PAr6Zl6SWjFVvOnDUbBg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.3",
-        "@swagger-api/apidom-core": "^1.11.3",
+        "@swagger-api/apidom-ast": "^1.12.0",
+        "@swagger-api/apidom-core": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2816,15 +2831,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.11.3.tgz",
-      "integrity": "sha512-ZOgo5OtpQ6e5XQ5R1H8CYTYXEtnD0l+FyN065A6c2O1NxJXFKS2a5SZTvx+udA4mugtkTSmr7hAQe2ae+KAXQw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.12.0.tgz",
+      "integrity": "sha512-O8aM7l/+K2ej3AH6f7NbEVADAuZhulLWmAGFFwRBHvE022mUeOQiDrcA1cd5q/s8fY+UFE+GIrfVAq0aBPLvxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2832,15 +2847,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.11.3.tgz",
-      "integrity": "sha512-L5Sc0qMUrUbgVex3fN+tnNHjed/JCAwpwyzdHY8KgUfXHkfM5aLUyyAGirm+ObwZvGDEejsTT2Otp6B5S29eqw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.12.0.tgz",
+      "integrity": "sha512-gWTTBmz6CyBytc4v7tMcm0KJ/0xp8n0zyWE1VSBXvLjFylOfvlkzmPL/MD8sqiEqUCGXXSQAyUmyL7heU8uGzQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2848,16 +2863,16 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.11.3.tgz",
-      "integrity": "sha512-T241UD+1My1hVJHayTCz9f7rznmeM8rxQW4NtUnD8k677SShpnNkrfeoc1elrpJXdTsnEPIOLCK0EEIyEplHgA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.12.0.tgz",
+      "integrity": "sha512-eISSf1rj7/HZAzOBGdZneUNp4M3FPwvqmKFL9ODBN+kpKFQ438TnYPdMVm60EoiinpvKa7hrKVKj/RubDfvcIQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2865,15 +2880,15 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.11.3.tgz",
-      "integrity": "sha512-FZvBqWpZFciemMgWBGY89RIH5uLl6ZYtmMAhWzDcmEi1JSjmWKkoqZno//KlqSgbI09gbkzipdMjGK825givPA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.12.0.tgz",
+      "integrity": "sha512-8DqRCkRTxQPtFjRjWiFo5F/IZcBqFFcqjmtoVWbxkUNGyJpgfZjx5Mne/QCB9ZV5vqNeBPF2IYfjQZEvgOBKvA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2881,17 +2896,17 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.11.3.tgz",
-      "integrity": "sha512-ObCP+l3/ZhuPaSqXqmSnCpEOIMalQns0c4IZgX6h3o7Jc6K6BcqDMeq4s17dwcQja9fFUtkoIIFuquJBKvK86Q==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.12.0.tgz",
+      "integrity": "sha512-6h4NJyCb/I9GkPYCma7SiEp3MlMNH9DFDntamb49AJDBNlibOG1VyR+y3R4+vzUlYOZayMDwe7Z1zC+qN0ulYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.3",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-json-pointer": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
+        "@swagger-api/apidom-ast": "^1.12.0",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-json-pointer": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -2899,163 +2914,195 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.11.3.tgz",
-      "integrity": "sha512-Ri7KLrfrpJeteghUdzbozxKve2NG5Z1aPWX91DI14j75+v/xBAu91AIZt7K+LV8JWUNk+VbhUlhgSH1JAIVa0g==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.12.0.tgz",
+      "integrity": "sha512-kkrXfvRPpiJTcK6qr0dB5Jf80kD3jgTo1DU9W6Q5/n06WcyGQhtKTofY7YRHQ52r2Nfpuh9JbxtoD0PIHE0STQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.3",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-json-pointer": "^1.11.3",
-        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
+        "@swagger-api/apidom-ast": "^1.12.0",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-json-pointer": "^1.12.0",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
         "ts-mixer": "^6.0.3"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.11.3.tgz",
-      "integrity": "sha512-6LcwiY2Ce1qmsq8CSxCoRMJ3q2quFnEsNgI48LpM9/PYK/idjsB/WrnU9xSl9fXm/aTo/bOO0ckc8KadxVykfA==",
+    "node_modules/@swagger-api/apidom-parser-adapter-a2a-json-1": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-a2a-json-1/-/apidom-parser-adapter-a2a-json-1-1.12.0.tgz",
+      "integrity": "sha512-RwUkRb92938NiTriueninR0MaeXYJRZKcZtYyEB5h2JRQ7nQGsCO6a6F1rNwehzLoPeRWLGMYr0wRWP1tTy7fw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-a2a-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-a2a-yaml-1": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-a2a-yaml-1/-/apidom-parser-adapter-a2a-yaml-1-1.12.0.tgz",
+      "integrity": "sha512-G2L1mRcuAJQICU18cjYH6FIZshYVJOCAmz5JSNknriIL0LYXr8xlbQ7kStTC5cmM9YfxDfD3eLb92vQ+yvpbCA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-a2a-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.12.0.tgz",
+      "integrity": "sha512-Co9BcoTlEAcrDIVTE/o0B6+HAlIuwB5hvKMs+w9+P+r6cSDRqx4NOi16iqBH6leCEtO6xU8H152ua0e8hKkQSQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.11.3.tgz",
-      "integrity": "sha512-zk2NuWAOvjEHYQ3lZ43VhAqJk+9KK452HeFfZFne4a4iALhCQ/wceK7tCG81jBMMoWnR0f1JS/vxz7/Y2CNwLA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.12.0.tgz",
+      "integrity": "sha512-vBnmuMflgcxPkqQX8rXFIWU6GdC0OPMO73LU4iOOjG2kxycET6NTs0zu6mTKRwfCk7PmVR+MzaqLyORCkL3Rjw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-api-design-systems": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.11.3.tgz",
-      "integrity": "sha512-vXP6lYp6Q5/5nLkMJyBRTWYIZYxL6GnOsJsdnN0KdTHuoPXNZWsv5p2oPYlVE/W7gRAZDylUmYZQ1L9rr7BGRw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.12.0.tgz",
+      "integrity": "sha512-5SHEWHdLXpbugsDN2NVYxqh87Sson4pDS+Yk9Zp00cJSl2dNtLZ+LHq3dtIgjFcKy9yOCnaiKjzqoZtpdQB1zQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.11.3.tgz",
-      "integrity": "sha512-zI57Q5DIf7TGv1A2gIk3umbPWMEFWYO3tEmfP0xJGDBn6gZRHgJvvVjn0wQrljigEEw1V3hRDUXk6Zzg3oVNvA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.12.0.tgz",
+      "integrity": "sha512-l0ocWS0IcWYx0ZFosEQguOS72dJXYnEC42KrQgYJMvZCfpMZPtP4HahAYryFxRZWiHZnhunkSChv8MRnBplcQA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.11.3.tgz",
-      "integrity": "sha512-VGl15mpHaL+SlsXaRvcVaWXir+pCLrj99QN//Kuir3cpPW6P9IdBztj11bjoIG3aX1bOIrU16/uOhV4G5J4Kag==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.12.0.tgz",
+      "integrity": "sha512-oZt3H7qH4ttU+RILLQ8G8tgOLe+hRMQDh7q/W/Dfxc2xGGsLb6jYG4gl45ry/QHDpudCc2SKC3GxdXfQ3Dl4pg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.11.3.tgz",
-      "integrity": "sha512-37dNwdLAcAd7TZW8YqSbpuBoujfoM2AvXBoT1BUxzbYetwNkxP19Q1VtCEAzMxUEQ/9niBANSzuo0zClUEc2kw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.12.0.tgz",
+      "integrity": "sha512-O4osrUo/q0ErGPqmCHfYEdRpeH894Dix0AQwLwuovgIS5OxWMa2r6Z8mzz3emRoyVi9ucF+0//OFm7WeU7NcGg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.11.3.tgz",
-      "integrity": "sha512-MEZHn+qROKehrXLhDhl7kSQADXjwU2NGSeNuBTr1/nINShpu4Tkxrk7xT0LY8GauKrZR9MyAnueATDQgK8NWhQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.12.0.tgz",
+      "integrity": "sha512-AfcdwWREQhBAEbVTwIVjFLvW/j5wTXmY8/VkKp1OmF7zXyyZDMA+xRAoGZlOlc+KNJ46O6yeN9CLfUaJ0IoRog==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.11.3.tgz",
-      "integrity": "sha512-qHOK0NXnG7t5Gx0xCIbyfrM5FXLgK6krlZRPlrlT6K853MWWWWmjAieuayPtu72Ak1hd/8U2/oWgbONnPqj76w==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.12.0.tgz",
+      "integrity": "sha512-+gAKV6dwr1neG3ngONPYWYRATrYD/ooRO+dY6kOgc2yy99YagtSZjtNNSosvoMdPL8vhI6OkZRyew41kyW+Vwg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-asyncapi-3": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.11.3.tgz",
-      "integrity": "sha512-Wj/DTb6mblsaxKfye9kXLwS+KmWWLAM2M2oSs4muOclhAOtcffr2H+STtiT3Hwrzb+cW8RpX6Htvey4rvbj/Jg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.12.0.tgz",
+      "integrity": "sha512-Tftr63g71VwTsWtafYgI7xrmkp6lcs8p6hwo06UzZICTyEsfMrye6Hjvs2TM0KBO/e6Hw8cTdCIBVtEV10Knqw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.3",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ast": "^1.12.0",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0",
@@ -3065,144 +3112,144 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.11.3.tgz",
-      "integrity": "sha512-aDR5vKSApqQgDkvJNJZqvp8slEWHGByz5bzDbw6ZHRPSIZcA2IEHdJPgWJVS5gNtJ+YAnA7veM39oqeoF2yy8w==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.12.0.tgz",
+      "integrity": "sha512-2cMgq3NBAS7magAFqgtBZOoi3vRR7/txQOOA1nzEODiS4WV4ERbe2B59+uaQ7+yzJlkm0OPqzFhXy3IkOB6Z0g==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.11.3.tgz",
-      "integrity": "sha512-hpSBiaVG7qbyJy25/Pl48NCT9uvvsOPAAj+xCAb9TwmIPBcFkVYvj6ZWJbYZsOmzUzcNLOZEOBjRNPN3G31zmQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.12.0.tgz",
+      "integrity": "sha512-ws5vsTv8KtrwzPPGwyeNUrEGYLlsRSByTWHFXH8hU8eGbSAcmmKsENhNeEjslimzD2Cev5vJzmdat5oWpKY4fA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.11.3.tgz",
-      "integrity": "sha512-EP7U25s5We8Q/2olymVrJL2nKT+skTea6SnR8F3OETsBoef3i1XgQx7AHqUc9S83hp+bOxZ+oPyI6dNwO+J+MA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.12.0.tgz",
+      "integrity": "sha512-C2/oMuyGarGAPQj5Taob9MOI9Hme6D5Qm/ZyJkRgXBg50ZA3WeaFCr51St6dNU1lDhe8i++cZeWMsp4wegPllw==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.11.3.tgz",
-      "integrity": "sha512-WLuMb0pwH+5hjosRHGvUFLm9iWP0/XNnEdrwdUio4y0eodjDwrPGb2LSdH3zaR8p7mKrqe007jqpjaLLsStzrQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.12.0.tgz",
+      "integrity": "sha512-kuSIq/Tht5LQ2lezsz6O1x+PM1U5DWeZBQKqHkTgQokhsbxM9dmO6xmSW/aQUk+0jUWf8n6ROrGmscrw6AawWg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.11.3.tgz",
-      "integrity": "sha512-PyD0E4fwOhOCcP/Aqa9HlvZYuw825E6N0IRC69dxxt6Fy6w6Fv2KYRnRw8OINoog8I6/8uSZOLdeDla3FCqhFA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.12.0.tgz",
+      "integrity": "sha512-QR0XdBWzjN/8ZmgBrbswP+Bpj+BllUqFiJu43VZNm1M8u/AtbJnsdlTw3coXLVpVpV7ruAKjp0GtsqQyOKNA1w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.11.3.tgz",
-      "integrity": "sha512-7ULkLaEAAVKRNWT525PdKOaUjrZ7G2ulH9VBsMJ9niaZN/n6hnSW8IR4Iaf0cLZ1MjsZsdWovq5slPz2hpqR4A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.12.0.tgz",
+      "integrity": "sha512-2Mzft9tXXodoRBqEEXQ1p5MRLrzIDt7SCqZyXF9cBF5ukIdHfgq7vDoX7XUECELzhCf3mMRxLaxH+JcPC26izg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.11.3.tgz",
-      "integrity": "sha512-2VqxGS0PaNrYeLgGyOl9m4m6EbJjrtxOswzWK2Rk3/M3gEDfnFdyOVffKWlcdEv6XFJ+wgLy5MPlODrzyOOKCA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.12.0.tgz",
+      "integrity": "sha512-dYrUHnD7r6uhsh2H+gMwxFTSaqSADFHmpG1tFi7b7m/aFbNFCppB63iJ7LYg9Ew6IBej9WrYkr2jXDLKBgsMaA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.11.3.tgz",
-      "integrity": "sha512-fRJYMozAyIJP46kKbUPQX2wIzfX9FSC7ZxUn+VWOa587f3zZC3XmydGO46GA/TGuc8cWs7AFD/EfSKWDbsB3Tg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.12.0.tgz",
+      "integrity": "sha512-KrNSQmsmp6iO2o+AxJ9jpwKd4lVmPIaDcWrbp4se5b1MnHUmtf7d7h9kvI5pXhGFGuyA59HMp6qQzNfuS5SMEA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.11.3.tgz",
-      "integrity": "sha512-mSPMfVzDkLC+HPDI/6ho8TxI1PEcDJl/Y53gZdmfCU1xYzUdOF4s0iHalHHt0ipxYpt0EQXD+oGBnpp/TTx4IQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.12.0.tgz",
+      "integrity": "sha512-vydWYSj1I0t4fsBeu7nAieivBKsW2A7KW9keS+osXLuyYWs1GLHdby5AXRHPv6ktR507vAq8RxQUXkODRxyRCg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-ast": "^1.11.3",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-ast": "^1.12.0",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
         "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
         "@types/ramda": "~0.30.0",
         "ramda": "~0.30.0",
@@ -3231,16 +3278,6 @@
         }
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/node-addon-api": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
-      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
       "version": "0.22.4",
       "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
@@ -3254,46 +3291,49 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.11.3.tgz",
-      "integrity": "sha512-Y0J+pAru/Est0wQJlFeQq2AsWyboOJP456Zv2wV4m0Ib1QY6N2wWiL6clkHpHA0pughemN6gcjBeNlMeRGqXuw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.12.0.tgz",
+      "integrity": "sha512-GApJUvwLROSyM2KfbdvuV/zC6ccb54khvhy2eJ7jPhAk5FU0zZE5Ijt0NmY5nSf97sET87MjrWgCCMszdqPXfw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.26.10",
-        "@swagger-api/apidom-core": "^1.11.3",
-        "@swagger-api/apidom-error": "^1.11.3",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
         "@types/ramda": "~0.30.0",
-        "axios": "^1.16.0",
-        "minimatch": "^10.2.1",
+        "axios": "^1.18.0",
+        "minimatch": "^10.2.6",
         "ramda": "~0.30.0",
         "ramda-adjunct": "^5.0.0"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-json-pointer": "^1.11.3",
-        "@swagger-api/apidom-ns-arazzo-1": "^1.11.3",
-        "@swagger-api/apidom-ns-asyncapi-2": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-2": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-0": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.3",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-json": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.11.3",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.3"
+        "@swagger-api/apidom-json-pointer": "^1.12.0",
+        "@swagger-api/apidom-ns-a2a-1": "^1.12.0",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-a2a-json-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-a2a-yaml-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0"
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/balanced-match": {
@@ -3306,24 +3346,24 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4539,13 +4579,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -7381,13 +7421,10 @@
       "license": "ISC"
     },
     "node_modules/immutable": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
-      "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -8675,6 +8712,16 @@
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -9720,6 +9767,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-copy-to-clipboard": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.1.tgz",
+      "integrity": "sha512-s+HrzLyJBxrpGTYXF15dTgMjAJpEPZT/Yp6NytAtZMRngejxt6Pt5WrfFxLAcsqUDU6sY1Jz6tyHwIicE1U2Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-to-clipboard": "^3.3.3",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=15.3.0"
       }
     },
     "node_modules/react-dom": {
@@ -10773,19 +10833,19 @@
       }
     },
     "node_modules/swagger-client": {
-      "version": "3.37.5",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.5.tgz",
-      "integrity": "sha512-MuABJgD8vIsT5GVBTGj3HjmiEhArf58ng+YP4fo23NOJb/mKXOpKW3Rln90fnoi7ROt6IJsJy9d5kg8Yidn0/Q==",
+      "version": "3.37.8",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.8.tgz",
+      "integrity": "sha512-uoKwfq+8DvWVDhoALDrEtex9f26Yi2VkvEFjsrMHd8Gl+TcApJkVXtNiE35p5JQjMsvwkvr1eLVlOFNF4GL1bQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.22.15",
         "@scarf/scarf": "=1.4.0",
-        "@swagger-api/apidom-core": "^1.11.0",
-        "@swagger-api/apidom-error": "^1.11.0",
-        "@swagger-api/apidom-json-pointer": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
-        "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
-        "@swagger-api/apidom-reference": "^1.11.0",
+        "@swagger-api/apidom-core": "^1.12.0",
+        "@swagger-api/apidom-error": "^1.12.0",
+        "@swagger-api/apidom-json-pointer": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.12.0",
+        "@swagger-api/apidom-reference": "^1.12.0",
         "@swaggerexpert/cookie": "^2.0.2",
         "deepmerge": "~4.3.0",
         "fast-json-patch": "^3.0.0-1",
@@ -10799,12 +10859,35 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "optionalDependencies": {
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.12.0",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.12.0",
+        "@swagger-api/apidom-ns-openapi-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-json": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.12.0",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.12.0"
       }
     },
     "node_modules/swagger-ui-react": {
-      "version": "5.32.8",
-      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.8.tgz",
-      "integrity": "sha512-Cstx4Tq8fT5l2TBxHxts8pG+ks0qKSkuO1pwUwgrQQiZ241Mqs+KUODLVIonsYXL/gqX143rkcipUa4d0Rid7w==",
+      "version": "5.32.12",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.12.tgz",
+      "integrity": "sha512-WCdkNOQyMTZDu+z356FpwVWHf1dwZgQPUjdQPh1L4r7jULaJTKKlIItXq6WsZdYeXvsHndMdxxccEQXOAroUHQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.27.1",
@@ -10814,16 +10897,16 @@
         "classnames": "^2.5.1",
         "css.escape": "1.5.1",
         "deep-extend": "0.6.0",
-        "dompurify": "^3.4.11",
+        "dompurify": "^3.4.12",
         "ieee754": "^1.2.1",
-        "immutable": "^3.x.x",
+        "immutable": "^4.3.9",
         "js-file-download": "^0.4.12",
-        "js-yaml": "=4.2.0",
+        "js-yaml": "=4.3.0",
         "lodash": "^4.18.1",
         "prop-types": "^15.8.1",
         "randexp": "^0.5.3",
         "randombytes": "^2.1.0",
-        "react-copy-to-clipboard": "5.1.0",
+        "react-copy-to-clipboard": "5.1.1",
         "react-debounce-input": "=3.3.0",
         "react-immutable-proptypes": "2.2.0",
         "react-immutable-pure-component": "^2.2.0",
@@ -10836,7 +10919,7 @@
         "reselect": "^5.1.1",
         "serialize-error": "^8.1.0",
         "sha.js": "^2.4.12",
-        "swagger-client": "^3.37.4",
+        "swagger-client": "^3.37.8",
         "url-parse": "^1.5.10",
         "xml": "=1.0.1",
         "xml-but-prettier": "^1.0.1",
@@ -10871,17 +10954,26 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/swagger-ui-react/node_modules/react-copy-to-clipboard": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
-      "integrity": "sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==",
+    "node_modules/swagger-ui-react/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "copy-to-clipboard": "^3.3.1",
-        "prop-types": "^15.8.1"
+        "argparse": "^2.0.1"
       },
-      "peerDependencies": {
-        "react": "^15.3.0 || 16 || 17 || 18"
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/swagger-ui-react/node_modules/react-debounce-input": {
@@ -11103,26 +11195,6 @@
         "tree-sitter": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tree-sitter-json/node_modules/node-addon-api": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
-      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
-    "node_modules/tree-sitter/node_modules/node-addon-api": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
-      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/ts-api-utils": {

--- a/pages/api/recipe-image.test.mts
+++ b/pages/api/recipe-image.test.mts
@@ -1,0 +1,144 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+
+vi.mock('@netlify/blobs', () => ({
+  getStore: vi.fn()
+}));
+
+// Imported transitively by the route, and constructs an OpenAI client at module
+// load - which needs a key that no test should have. Nothing here gets as far
+// as an extraction anyway.
+vi.mock('../../lib/recipe-import/extract', () => ({
+  extractRecipe: vi.fn()
+}));
+
+import { getStore } from '@netlify/blobs';
+import handler from './recipe-image';
+
+const mockedGetStore = getStore as unknown as Mock;
+
+// One job, owned by account 7.
+const job = { id: 'job-1', accountId: 7, status: 'completed', result: { name: 'Omelette' }, error: null };
+
+function mockReq(overrides: Partial<NextApiRequest>): NextApiRequest {
+  return { headers: {}, query: {}, ...overrides } as NextApiRequest;
+}
+
+function mockRes(): NextApiResponse {
+  const res: Partial<NextApiResponse> = {};
+  res.status = vi.fn(() => res) as unknown as NextApiResponse['status'];
+  res.json = vi.fn(() => res) as unknown as NextApiResponse['json'];
+  return res as NextApiResponse;
+}
+
+// Stands in for the Go API's GET /account, which is what lib/authenticate.ts
+// asks whether a token is good.
+const stubAccountApi = (account: { id: number } | null) =>
+  vi.stubGlobal('fetch', vi.fn(async () =>
+    account ? { ok: true, json: async () => account } : { ok: false, status: 401, json: async () => ({}) }
+  ));
+
+const storeGet = vi.fn();
+
+beforeEach(() => {
+  vi.stubEnv('NEXT_PUBLIC_API_HOST', 'http://api.test');
+  vi.stubEnv('NETLIFY_BLOB_STORE_TOKEN', 'token');
+  vi.stubEnv('NETLIFY_SITE_ID', 'site');
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  storeGet.mockReset();
+  storeGet.mockResolvedValue(JSON.stringify(job));
+  mockedGetStore.mockReturnValue({ get: storeGet, set: vi.fn() });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('recipe-image job status (GET)', () => {
+  it('rejects an unauthenticated caller without touching the job store', async () => {
+    stubAccountApi({ id: 7 });
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'GET', query: { jobId: 'job-1' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(storeGet).not.toHaveBeenCalled();
+  });
+
+  it('rejects a caller whose token the API refuses', async () => {
+    stubAccountApi(null);
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'GET', headers: { authorization: 'Bearer forged' }, query: { jobId: 'job-1' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(storeGet).not.toHaveBeenCalled();
+  });
+
+  // The job holds the entire contents of somebody's photographed recipe, and
+  // the blob store is shared by every Account.
+  it('does not hand a job to another Account, even with the right job id', async () => {
+    stubAccountApi({ id: 9 });
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'GET', headers: { authorization: 'Bearer good' }, query: { jobId: 'job-1' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Job not found' });
+  });
+
+  // Written before jobs carried an owner, so there is nothing to match on.
+  it('does not hand over a job with no accountId', async () => {
+    storeGet.mockResolvedValue(JSON.stringify({ id: 'job-1', status: 'completed', result: {} }));
+    stubAccountApi({ id: 7 });
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'GET', headers: { authorization: 'Bearer good' }, query: { jobId: 'job-1' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns the job to the Account that created it', async () => {
+    stubAccountApi({ id: 7 });
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'GET', headers: { authorization: 'Bearer good' }, query: { jobId: 'job-1' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(job);
+  });
+
+  it('still requires a job id', async () => {
+    stubAccountApi({ id: 7 });
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'GET', headers: { authorization: 'Bearer good' }, query: {} }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+describe('recipe-image upload (POST)', () => {
+  // An anonymous request should not reach the 5MB upload, let alone the
+  // OpenAI call behind it.
+  it('rejects an unauthenticated caller before parsing the form', async () => {
+    stubAccountApi({ id: 7 });
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'POST' }), res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Authentication required' });
+  });
+
+  it('rejects a caller whose token the API refuses', async () => {
+    stubAccountApi(null);
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'POST', headers: { authorization: 'Bearer forged' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+});

--- a/pages/api/recipe-image.ts
+++ b/pages/api/recipe-image.ts
@@ -8,6 +8,7 @@ import { extractRecipe } from '../../lib/recipe-import/extract';
 import { imageToInput } from '../../lib/recipe-import/photo';
 import { requireEnv } from '../../lib/env';
 import { fetchKnownNames } from '../../lib/recipe-import/known-names';
+import { authenticateAccount } from '../../lib/authenticate';
 
 // Configure API route to handle form data
 export const config: PageConfig = {
@@ -82,11 +83,16 @@ const getBlobStoreConfig = () => ({
 // change - switched to the real getStore() API. The `{ ttl: 3600 }` option
 // passed to .set() doesn't exist on this version's SetOptions either (no
 // replacement attempted here - was already inert given the above).
-const updateJobStatus = async (jobId: string, status: string, result: unknown = null, error: string | null = null) => {
+//
+// `accountId` is written on every update, not just the first: each call
+// replaces the whole blob, so omitting it on the completed/failed write would
+// drop the owner exactly when there is finally a result worth protecting.
+const updateJobStatus = async (jobId: string, accountId: number, status: string, result: unknown = null, error: string | null = null) => {
   const store = getStore(getBlobStoreConfig());
 
   const job = {
     id: jobId,
+    accountId,
     status,
     result,
     error,
@@ -100,6 +106,11 @@ const updateJobStatus = async (jobId: string, status: string, result: unknown = 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'GET') {
     // Handle job status check
+    const auth = await authenticateAccount(req);
+    if (!auth.ok) {
+      return res.status(auth.status).json({ error: auth.error });
+    }
+
     const jobId = req.query.jobId as string | undefined;
     if (!jobId) {
       return res.status(400).json({ error: 'Job ID is required' });
@@ -115,6 +126,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
 
       const job = JSON.parse(jobData);
+
+      // A completed job holds the entire contents of somebody's photographed
+      // recipe, in one shared blob store keyed by nothing but the job id, so
+      // it is readable only by the Account that created it. 404 rather than
+      // 403, matching how the Go API answers a Recipe belonging to another
+      // Account - there is no reason to confirm that an id exists.
+      //
+      // A job written before jobs carried an accountId has no owner to match
+      // and so fails this check. That can only affect an import already in
+      // flight at deploy time, which the user retries.
+      if (job.accountId !== auth.account.id) {
+        return res.status(404).json({ error: 'Job not found' });
+      }
+
       return res.status(200).json(job);
     } catch (error) {
       console.error('Error fetching job:', error);
@@ -124,6 +149,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  // Before the form is parsed, so an unauthenticated caller never gets as far
+  // as uploading 5MB, let alone as far as an OpenAI call on this account's
+  // quota.
+  const auth = await authenticateAccount(req);
+  if (!auth.ok) {
+    return res.status(auth.status).json({ error: auth.error });
   }
 
   try {
@@ -149,16 +182,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     // Create a new job
     const jobId = uuidv4();
-    const initialJob = await updateJobStatus(jobId, 'processing');
+    const initialJob = await updateJobStatus(jobId, auth.account.id, 'processing');
 
     // Start processing in the background
     processImage(base64Image, knownIngredients, knownUnits)
       .then(async (result) => {
-        await updateJobStatus(jobId, 'completed', result);
+        await updateJobStatus(jobId, auth.account.id, 'completed', result);
       })
       .catch(async (error) => {
         console.error('Error processing recipe:', error);
-        await updateJobStatus(jobId, 'failed', null, error instanceof Error ? error.message : String(error));
+        await updateJobStatus(jobId, auth.account.id, 'failed', null, error instanceof Error ? error.message : String(error));
       });
 
     // Return the job ID immediately

--- a/pages/recipes/new.tsx
+++ b/pages/recipes/new.tsx
@@ -145,9 +145,11 @@ const NewRecipe = () => {
   const { getAccessTokenSilently } = useAuth();
 
   // Both import routes read the canonical Ingredient/Unit names from the
-  // database themselves; the token is forwarded purely so they can make that
-  // call on the user's behalf. Both are extraction only - they write no Big
-  // Shop state, so neither invalidates anything. The Ingredients and Units an
+  // database themselves, and /api/recipe-image additionally requires the token
+  // to authenticate the caller (lib/authenticate.ts) - it runs an OpenAI
+  // extraction and stores the result, neither of which is on offer to an
+  // anonymous request. Both are extraction only - they write no Big Shop
+  // state, so neither invalidates anything. The Ingredients and Units an
   // import introduces are created when the Recipe is saved, and it is
   // Form.tsx's save that invalidates for them.
   const uploadImageMutation = useMutation({
@@ -171,7 +173,12 @@ const NewRecipe = () => {
   const jobStatusQuery = useQuery<ImageJobStatus>({
     queryKey: queryKeys.recipeImageJob(processingJob?.jobId),
     enabled: !!processingJob,
-    queryFn: () => nextApiGet<ImageJobStatus>(`${process.env.NEXT_PUBLIC_HOST}/api/recipe-image?jobId=${processingJob!.jobId}`),
+    // Every poll carries the token: the route resolves it to an Account and
+    // hands back only that Account's job.
+    queryFn: async () => {
+      const token = await getAccessTokenSilently();
+      return nextApiGet<ImageJobStatus>(`${process.env.NEXT_PUBLIC_HOST}/api/recipe-image?jobId=${processingJob!.jobId}`, token);
+    },
     refetchInterval: (query) => {
       const status = query.state.data?.status;
       return status === 'completed' || status === 'failed' ? false : 2000;


### PR DESCRIPTION
Found while auditing whether users can reach other users' data by iterating IDs. **They can't** — every Go handler resolves the account from the JWT `sub` and puts `account_id = ?` in the WHERE clause, which I verified by running two accounts against one database and attacking one from the other (recipe read/edit/delete by id and slug, shopping-list generation from another account's recipe ids, list mutations, account membership — all refused, with a control proving the refusals were authorization and not a broken test).

These are the two gaps that audit did turn up. Neither is reachable by iteration, but both are holes on their own terms.

## `/api/recipe-image` had no authentication at all

Anyone could POST an image and run an extraction on this account's OpenAI quota, and anyone holding a job id could GET the entire contents of somebody's photographed recipe — the blob store is shared and keyed by nothing but that id.

The route now resolves its caller through the Go API (`lib/authenticate.ts`), which is the only thing in this system that can judge an Auth0 token — the same reason `known-names.ts` forwards the header rather than reading it. No second JWT verifier in JS.

- **POST** authenticates before `parseForm`, so an anonymous caller never reaches the 5MB upload, let alone the OpenAI call.
- **GET** requires the caller to own the job. Jobs now carry the Account that created them, and another Account gets a **404** — the same answer the Go API gives for a Recipe it doesn't own, rather than confirming the id exists.
- Ownership is keyed on the **Account**, not the user, matching every Go handler: two people sharing an Account are meant to see each other's data.
- Fails **closed**. An unreachable API or unset `NEXT_PUBLIC_API_HOST` is a 500, deliberately unlike `fetchKnownNames`, which fails open because losing canonical names costs a bonus rather than the import.

The status poll sent no token, so `nextApiGet` takes one now and `pages/recipes/new.tsx` fetches one per poll. That costs one extra Go API round-trip per 2-second poll during an import — the trade for a job being readable only by its owner.

## `aud` and `iss` were verified with `required=false`

Reading the pinned `form3tech-oss/jwt-go@v3.2.2` source rather than assuming: `verifyAud` returns `true` for an **empty** `aud`, and `VerifyIssuer` reads a missing `iss` as `""` and returns `true`. So `"aud": []`, or no `iss` at all, sailed through, and any token this Auth0 tenant's key had signed was accepted whatever it was minted for. The signature check meant this was never an open door — but a token issued by this tenant for another audience is exactly what this API must refuse. Both are required now.

That needed an adjacent crash fixed first: `claims["aud"].([]interface{})` **panicked** on a token whose `aud` was absent or a bare string, and there's no Recovery middleware in the negroni stack — so those tokens killed the request instead of being refused by it. `normalizeAudience` returns an error instead.

## Verification

- **New tests aren't vacuous**: reverting the route to its old behaviour fails 6 of the 8 new route tests.
- `app_test.go` covers the conversion, both former panic inputs, and — as the regression guard — that a genuine Auth0 token (`aud: [audience, tenant/userinfo]`) still verifies. `go vet`, `gofmt`, `go test ./...` clean.
- Full Vitest suite 134/134. `e2e/recipe-import.spec.ts` passes all three import sources, including the photo path whose polling changed.
- Live route against a real Go API: `401 {"error":"Authentication required"}` unauthenticated on both verbs; a valid token passes the gate.

## Notes for the reviewer

- Branched from `master`, not from `data-access`, so this PR doesn't drag along that branch's unrelated `two specs` commit.
- **One known bug is deliberately not fixed here**: `POST /invite/reject` deletes any invite by token with no ownership check (`app/invites.go:72`). I confirmed one account can cancel another's invite. Tokens are 32 bytes of `crypto/rand` so it isn't iterable, and it felt like a separate change — happy to fold it in if you'd rather.
- **Second commit resyncs `package-lock.json`, and is unrelated to the security work.** `npm ci` has failed on every PR since `ca63f0d` bumped `swagger-ui-react` to `^5.32.9` in `package.json` without regenerating the lock, which still pins `5.32.8`. Both CI jobs died at "Install dependencies" before running a single test — here and equally on #70, which predates this branch. It's `npm install` and nothing else; `package.json` is untouched. Happy to split it into its own PR if you'd rather land it separately.
- With dependencies actually in sync, `npm run lint`, `npm run typecheck` and `npm run build` are all clean. (An earlier revision of this description claimed 3 pre-existing typecheck errors — those were an artifact of my worktree's stale `node_modules`, not of the repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
