### PR TITLE
Design: observability stack, and move the Go API off Netlify Functions

### DIFF
--- a/docs/adr/0006-go-api-leaves-netlify-functions.md
+++ b/docs/adr/0006-go-api-leaves-netlify-functions.md
@@ -83,7 +83,11 @@ instrumenting it would mostly serve to document that cost in detail.
   address the Fly host directly instead. Note this path does not get faster overall — it
   trades N transatlantic DB hops per tool call for one transatlantic API hop per tool
   call, which is an improvement but a smaller one than elsewhere.
-- Netlify can JWS-sign proxied requests with a shared secret, so the Fly origin can reject
-  anything that did not arrive via Netlify. Worth doing; not required for correctness.
+- The origin can tell proxied traffic apart from direct traffic for free: Netlify attaches
+  `x-nf-netlify-proxy`, a signed JWT (`iss: netlify`, `sub: proxy`), to every proxied
+  request — no shared secret and no JWS configuration needed. This does not change the
+  decision to leave the origin publicly reachable, because Dave's server-side calls
+  address Fly directly and carry no such header, so unsigned traffic must be accepted
+  regardless. Recorded because it is the obvious thing to reach for if that changes.
 - Connection pooling to TiDB starts working properly. Every cold Lambda container
   previously built a fresh pool and `Ping`ed across the Atlantic during `init()`.

--- a/docs/adr/0006-go-api-leaves-netlify-functions.md
+++ b/docs/adr/0006-go-api-leaves-netlify-functions.md
@@ -1,0 +1,89 @@
+# The Go API leaves Netlify Functions for a long-lived container in Frankfurt
+
+Status: accepted
+
+The Go API stops being an AWS Lambda deployed through Netlify Functions and becomes a
+long-lived container running on Fly.io in `fra` (Frankfurt), the same metro as the TiDB
+cluster. Netlify keeps everything else — the Next.js site, SSR, the four LLM API routes,
+branch deploys — and proxies `/api/*` to the Fly host with a `status = 200` rewrite, so
+the API stays on `www.bigshop.life` and remains same-origin to the browser.
+
+**Same metro is not the same datacenter, and deliberately so.** Fly.io runs its own
+hardware rather than reselling AWS; TiDB Cloud Serverless is on AWS `eu-central-1`. So the
+API-to-database hop crosses a provider boundary over Frankfurt peering rather than staying
+on a provider's internal network — call it ~1–5ms with more jitter than an intra-AWS link,
+against ~0.5–1ms had the API been placed in AWS `eu-central-1` itself. Across a
+query-heavy request that difference is perhaps 10–25ms of the ~500ms this move recovers,
+and buying it back would mean an AWS-native host: either materially more expensive
+(App Runner, or Fargate behind an ALB) or handing back the OS, TLS and patching burden
+that ruled out a VPS below. Accepted knowingly.
+
+## Why
+
+**Latency, mostly.** Netlify's functions region defaults to `cmh` (US East, Ohio) and
+region selection is a Pro/Enterprise feature. TiDB is in `eu-central-1`. So every query
+Big Shop makes is transatlantic, at roughly 90ms round trip, and the data-heavy paths —
+shopping list generation especially — issue several sequentially. Moving the API into the
+same metro as the database plausibly removes 300–500ms from those requests. Nothing else
+on the table comes close to that.
+
+**Netlify has deprecated Lambda compatibility mode**, and deploys containing functions in
+that mode stop being accepted on 1 July 2027. `main.go` is squarely in that mode
+(`lambda.Start` with `events.APIGatewayProxyRequest`), the documented migration path is an
+npm package, and Netlify's public docs do not say what the path is for Go. Rather than
+bet on that being resolved, this removes the dependency.
+
+**No Netlify tier exposes Lambda layers or extensions** — this is a product boundary, not
+a paywall, confirmed against the functions configuration docs. That rules out the standard
+serverless observability pattern (a collector extension on `localhost:4318` flushing after
+the response) at any price, and would have forced a synchronous flush on the critical path
+of every request. A long-lived process makes the problem disappear rather than mitigating
+it: the OTel SDK's batch processor exports in the background, off the request path. See
+[ADR-0007](./0007-observability-otel-grafana-cloud.md).
+
+## Why it is cheap to do
+
+The API already runs as an ordinary HTTP server. `main.go`'s `dev` branch starts a plain
+`http.Server` on `:8080` using the *same* negroni router the Lambda handler wraps, and
+`netlify-functions/recipes/Dockerfile.dev` plus the `api` service in `docker-compose.yml`
+already containerize it for local development and e2e. This is a production Dockerfile and
+the deletion of a branch of `main()`, not a rewrite.
+
+## Considered options
+
+**Netlify Pro (~$19/mo) with `region = "fra"`** would fix the latency with no migration at
+all, keeping branch deploys perfectly intact. Rejected because it costs roughly four times
+a Fly machine while fixing strictly less: no tier gives a sidecar, the synchronous flush
+would remain, and the 2027 Lambda-compat deadline would still be there.
+
+**A Hetzner or Lightsail VPS (~£4/mo)** is cheaper still and gives complete control.
+Rejected on ops burden — OS patching, TLS termination, restart policy and deploy tooling
+all become ours, which is a poor trade against Fly's `fly deploy`-from-a-Dockerfile for a
+few pounds a month.
+
+**Staying on Netlify Functions** remains workable; the observability design that assumed
+it was sound. Rejected because it means paying ~90ms per query indefinitely, and
+instrumenting it would mostly serve to document that cost in detail.
+
+## Consequences
+
+- **Branch deploys degrade.** A branch deploy of the frontend proxies to the same single
+  API instance as production, rather than being a complete isolated stack. This is the one
+  thing on the "what I like about Netlify" list that genuinely gets worse. Per-branch API
+  deploys are possible on Fly but are not in scope.
+- **Two deploy pipelines instead of one.** The Go tests currently run inside Netlify's
+  build via `./build.sh`; they move to CI and the Fly deploy. `build.sh`, `netlify.toml`
+  and the OpenAPI drift check all need revisiting.
+- **Uptime for the API becomes ours**, including TLS at the Fly edge and restart
+  behaviour. Previously Netlify's problem.
+- `NEXT_PUBLIC_API_HOST` changes from `/.netlify/functions/recipes` to the proxied path.
+- **Dave's server-side calls need thought.** `lib/dave/tools.ts` runs in a Netlify function
+  in us-east-2 and makes several sequential calls to the Go API per turn. Routing those
+  through the Netlify proxy would go us-east-2 → Netlify edge → Frankfurt; they should
+  address the Fly host directly instead. Note this path does not get faster overall — it
+  trades N transatlantic DB hops per tool call for one transatlantic API hop per tool
+  call, which is an improvement but a smaller one than elsewhere.
+- Netlify can JWS-sign proxied requests with a shared secret, so the Fly origin can reject
+  anything that did not arrive via Netlify. Worth doing; not required for correctness.
+- Connection pooling to TiDB starts working properly. Every cold Lambda container
+  previously built a fresh pool and `Ping`ed across the Atlantic during `init()`.

--- a/docs/adr/0007-observability-otel-grafana-cloud.md
+++ b/docs/adr/0007-observability-otel-grafana-cloud.md
@@ -1,0 +1,95 @@
+# Observability: OpenTelemetry to a Grafana Cloud stack in eu-central-1
+
+Status: accepted
+
+Big Shop emits traces, metrics and logs via OpenTelemetry, correlated by `trace_id`, to a
+Grafana Cloud Free stack in **AWS eu-central-1 (Frankfurt)**. Sampling is 100%. Grafana
+Faro covers the browser for errors and web vitals. OpenTelemetry rather than a vendor SDK
+is deliberate: the instrumentation is the durable asset and the backend should stay
+swappable, since Grafana Cloud Free is a starting point rather than a commitment.
+
+Long-horizon product questions ("is Dave used more than three months ago") are explicitly
+**out of scope** and belong to Google Analytics. That is what makes Grafana Cloud Free's
+14-day retention a non-issue rather than a constraint.
+
+## Two export paths, because there are two runtimes
+
+**The Go API (Fly.io, Frankfurt)** exports through an OpenTelemetry Collector running as a
+sidecar in the same Fly app, over `localhost:4318`. Because the process is long-lived, the
+SDK's batch processor exports in the background, entirely off the request path — there is
+no flush, no cold start cost and no per-request latency. Redaction, sampling policy and
+the Grafana credentials live in collector config rather than in application code.
+
+**The Next.js functions (Netlify, us-east-2)** are still Lambdas, so they still export
+directly over OTLP/HTTP with a bounded synchronous `ForceFlush` before returning. A
+Lambda's execution environment freezes the instant the handler returns, so anything still
+buffered is lost; there is no "after the response" available. This applies to four
+LLM-backed routes whose latency is dominated by OpenAI calls measured in seconds, so a
+flush is proportionally noise.
+
+That asymmetry is the point: the awkward pattern is confined to the four routes where it
+does not matter, rather than applied to the whole API. See
+[ADR-0006](./0006-go-api-leaves-netlify-functions.md).
+
+**Local development and e2e** use `grafana/otel-lgtm` in `docker-compose.yml` — Collector,
+Tempo, Loki, Prometheus and Grafana in one image — exporting to `localhost:4318`. Grafana
+Cloud credentials therefore exist only in Fly and Netlify production config, development
+noise never touches the free-tier quota, and the feedback loop while writing
+instrumentation is sub-second.
+
+## The Netlify flush has dangerous defaults
+
+Recorded because a future reader will see the configuration and assume it is a mistake.
+The Go OTLP HTTP exporter defaults to `retry.DefaultConfig` (**retries enabled**,
+exponential backoff, one-minute elapsed cap) and a **10 second per-attempt timeout**. Left
+alone, an unreachable Grafana endpoint means every Netlify function request blocks until
+the platform timeout — *Grafana Cloud going down would take Big Shop down*. So:
+
+- `WithRetry(RetryConfig{Enabled: false})` — the process is about to freeze; there is no
+  second attempt to be alive for.
+- `WithTimeout(~250ms)`, overriding the 10s default. Not shorter: below the cost of one
+  reconnect, a stale keep-alive would drop telemetry every time.
+- A bounded `context.WithTimeout` on every `ForceFlush`, never `context.Background()`.
+- A package-level circuit breaker: after N consecutive failures, stop flushing for the
+  rest of that container's life. Containers persist across invocations, so one that has
+  learned the endpoint is down stops paying the timeout; new containers re-probe, so it
+  self-heals with no cooldown logic.
+
+The same principle applies to the Go sidecar: a dead collector must be a silent drop, not
+a retry storm.
+
+**Telemetry must never affect the application.** Exporter errors are swallowed, the SDK's
+default `ErrorHandler` is replaced so it does not spam function logs, and no telemetry
+initialisation may `log.Fatal` the way `main.go`'s DB ping currently does.
+
+## Why eu-central-1
+
+The stack sits in the same metro as the Go API and the same AWS region as TiDB. Because
+the Go export is a background batch, its distance to Grafana is close to irrelevant —
+which means the region was chosen for residency and coherence rather than latency. An
+earlier draft of this decision chose us-east-2 to co-locate with what were then
+Lambda-hosted Go handlers paying a synchronous flush; ADR-0006 removed that constraint
+entirely.
+
+Worth stating precisely, since "everything is in Frankfurt" is a convenient shorthand that
+hides a boundary: Grafana Cloud and TiDB are both on AWS `eu-central-1`, while the Go API
+runs on Fly's own hardware in the same metro. The Go-to-Grafana export therefore crosses a
+provider boundary — which is why it being a background batch, rather than anything on a
+request path, is load-bearing rather than incidental.
+
+**This is permanent.** Grafana Cloud does not support changing an existing stack's region,
+and the free tier allows one stack — so this governs every future project sharing it.
+Revisit only by creating a second account.
+
+## Consequences
+
+- Multi-project tenancy on one stack comes from resource attributes, not separate stacks:
+  `service.namespace` per project, `service.name` per runtime (`bigshop-api`,
+  `bigshop-web`, `bigshop-browser`), plus `deployment.environment.name` and
+  `service.version`.
+- Metrics only leave a Lambda on `ForceFlush` — the `PeriodicReader` never fires in a
+  frozen process — so the metrics flush is not optional on the Netlify side.
+- The browser path is genuinely fire-and-forget; Faro cannot affect page behaviour.
+- No shared instrumentation library is extracted. The reusable asset is this convention
+  plus Big Shop as a worked reference, on the grounds that an abstraction derived from one
+  example is usually wrong at the joints.

--- a/docs/adr/0008-what-telemetry-does-not-carry.md
+++ b/docs/adr/0008-what-telemetry-does-not-carry.md
@@ -1,0 +1,57 @@
+# What telemetry deliberately does not carry
+
+Status: accepted
+
+Three restrictions on emitted telemetry, written down because each one looks like an
+oversight and will otherwise be "fixed" by someone acting reasonably.
+
+## 1. Pseudonymous identifiers, never content
+
+Spans and log lines carry `account.id`, the Auth0 subject, and structural counts
+(`recipe.count`, `ingredient.count`, token counts, rows affected). They do **not** carry
+recipe names, ingredient text, Dave chat messages, email addresses, SQL bind values, or
+OpenAI prompts and completions.
+
+The identifiers are what make after-the-fact debugging work at all — "show me everything
+that happened for account 1 around 14:20" is the question the whole design exists to
+answer. Content adds bulk and third-party exposure for cases that are usually reproducible
+locally. Email is excluded by rule rather than by care, because it is real personal data
+and appears in the Invite flow.
+
+The cost is accepted knowingly: when an LLM extraction fails because GPT returned
+unparseable JSON, the response body *is* the evidence, and it will not be in the trace.
+Attaching payloads on error only was considered and rejected as too easy to apply
+inconsistently across call sites.
+
+## 2. No unbounded labels on metrics — including `account.id`
+
+`account.id` on a *span* is free; on a *metric* it multiplies every series by the account
+count, permanently, against a 10,000 active-series ceiling. The metric label sets are
+bounded by design and total roughly 970 series: a duration histogram by route and status
+class, an import-outcome counter by source and result, and a token counter by model and
+direction.
+
+This asymmetry is the single most likely thing to be "corrected" by a future reader who
+notices the attribute on spans and adds it to metrics for consistency. It is not an
+inconsistency. Spans and metrics have different cardinality economics.
+
+Relatedly, metrics from the Netlify functions use **delta** temporality rather than the
+Prometheus-default cumulative. A Lambda process dies constantly, so cumulative counters
+reset endlessly and each container churns new series. Delta is the serverless-correct
+choice and must be configured explicitly.
+
+## 3. The service layer does not log
+
+`internal/pkg/service/*` returns wrapped errors (`fmt.Errorf("adding invite: %w", err)`)
+and logs nothing. A single error-recording middleware at the handler boundary calls
+`span.RecordError` and sets the span status, capturing every handler error with no
+per-call-site work.
+
+This replaced roughly 70 `log.*` calls, of which 26 were a bare `log.Println(err)`
+immediately before returning a 500 — carrying no route, account, user or timing that the
+surrounding span does not already have. The old pattern also logged twice (service layer
+and app layer) and, at `app/account.go:41`, discarded the real error and replaced it with
+a guess, so a TiDB connection failure was reported as a membership problem.
+
+An absence of logging in the service layer is therefore deliberate. The information is in
+the span.

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -59,3 +59,27 @@ Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are r
     same pass — it kept its white card and its own blue palette through the redesign and
     now looks like a different product (see the `--color-info` note in
     `pages/dev/design-system.tsx`).
+37. **Threshold-based alerting, once there are baselines to set thresholds from.**
+    Deliberately deferred when the observability stack was designed (see
+    [ADR-0007](./docs/adr/0007-observability-otel-grafana-cloud.md)): alert thresholds picked
+    before anyone knows Big Shop's actual error rate and latency distribution are usually
+    wrong in both directions, and on a project with an on-call rota of one person, an
+    alert that has been learned-to-ignore is worse than no alert.
+
+    Two rules are wanted, both symptom-based rather than cause-based:
+    - **Backend 5xx rate** above a floor, across `bigshop-api` and `bigshop-web` together.
+    - **Frontend error rate spike** from Faro.
+
+    Explicitly *not* wanted as alerts, however tempting: DB latency, cold-start frequency,
+    per-endpoint p99 regression, LLM failure rate, OpenAI spend. Those are causes you look
+    at on a dashboard *after* something fires, not things that should wake anyone up.
+
+    **The trigger is data, not a date** — roughly two weeks of production telemetry, i.e.
+    enough to know what a normal day's error rate and p99 look like. Nothing here is
+    blocked on more instrumentation; the traces, metrics and logs it needs all land with
+    the initial work.
+
+    Not deferred, and already shipped alongside the instrumentation: the synthetic
+    uptime check on `/health`, plus the fix making `/health` actually query TiDB rather
+    than unconditionally writing `ok`. That one is a binary up/down signal, so "wait for
+    baselines" never applied to it.

--- a/specs/api-hosting-migration.md
+++ b/specs/api-hosting-migration.md
@@ -18,8 +18,11 @@ Three facts make this migration small:
 - **It's already containerized.** `netlify-functions/recipes/Dockerfile.dev` plus the
   `api` service in `docker-compose.yml` build and run it, and the e2e suite depends on
   that working.
-- **Nothing else in the repo talks to the Lambda directly.** `lib/api-client.ts` and
-  `lib/dave/tools.ts` both go through `NEXT_PUBLIC_API_HOST`.
+- **Everything reaches the API through `NEXT_PUBLIC_API_HOST`.** Nothing constructs a
+  Lambda URL of its own. There are four consumers, and **three of them run server-side**:
+  `lib/api-client.ts` (browser), `lib/dave/tools.ts`, `lib/authenticate.ts` and
+  `lib/recipe-import/known-names.ts`. See Phase 4 — that split is the migration's main
+  correctness trap.
 
 And three make it necessary:
 
@@ -33,7 +36,7 @@ And three make it necessary:
 
 Two pre-existing defects surface here and are fixed as part of the work:
 
-- `app.go:170` sets `AllowedOrigins: {"*"}` with `AllowCredentials: true`. The CORS spec
+- `app.go:211` sets `AllowedOrigins: {"*"}` with `AllowCredentials: true`. The CORS spec
   forbids that pairing, so it does not do what it appears to.
 - `.github/workflows/ci.yml` triggers on `pull_request` and `workflow_dispatch` only.
   `go fmt`, `go test` and both drift checks live in `build.sh`, i.e. they run **only** in
@@ -132,8 +135,24 @@ One frontend deploy changes two values:
 
 - `NEXT_PUBLIC_API_HOST` → `/api/bigshop` (relative — same origin via the rewrite)
 - `API_HOST_INTERNAL` → `https://<app>.fly.dev/api/bigshop`, a new **server-side-only**
-  variable for `lib/dave/tools.ts`, so Dave's several-per-turn tool calls go straight to
-  Frankfurt instead of us-east-2 → Netlify edge → Frankfurt.
+  variable (no `NEXT_PUBLIC_` prefix, and it must never acquire one).
+
+**All three server-side consumers must switch to `API_HOST_INTERNAL`**, not just Dave.
+A relative `NEXT_PUBLIC_API_HOST` is meaningless in a Node process, so any that is missed
+breaks outright rather than merely running slowly:
+
+| Consumer | Runs | Why it matters |
+| --- | --- | --- |
+| `lib/api-client.ts` | Browser | Stays on the relative path — this is the one that should |
+| `lib/dave/tools.ts` | Netlify fn | Several calls per turn; avoids us-east-2 → edge → Frankfurt |
+| `lib/authenticate.ts` | Netlify fn | **On the critical path of every authenticated Next.js route** — it authenticates by calling `GET /account` on the Go API |
+| `lib/recipe-import/known-names.ts` | Netlify fn | Forwards the caller's header to read canonical Ingredient/Unit names |
+
+`lib/authenticate.ts` deserves particular attention: it was added by #71 and means every
+authenticated Next.js API route now makes a *synchronous* call to the Go API before doing
+its own work. Post-migration that is a transatlantic hop from us-east-2 to Frankfurt on
+every such request. Going direct rather than via the proxy removes one leg of it; removing
+the other would mean moving those routes, which is out of scope.
 
 `e2e/env.ts`'s `API_HOST` changes to the new base path in the same PR.
 
@@ -196,16 +215,14 @@ Deliberately a separate PR, days later:
 - `docs/openapi.yaml` and `types/api.d.ts` are generated and drift-checked. A base path
   change means regenerating both; the drift check will catch it if you forget, but only
   once the check is running in its new home.
-- `lib/dave/tools.ts` currently reads `NEXT_PUBLIC_API_HOST` for server-side calls. It
-  must switch to `API_HOST_INTERNAL`, which has no `NEXT_PUBLIC_` prefix and must not
-  acquire one — it should never reach the browser bundle.
-- A **relative** `NEXT_PUBLIC_API_HOST` (`/api/bigshop`) works for the browser but not for
-  anything server-side, which is precisely why Dave needs its own absolute variable. Check
-  every consumer of `NEXT_PUBLIC_API_HOST` for server-side use before assuming a relative
-  value is safe.
+- **A relative `NEXT_PUBLIC_API_HOST` (`/api/bigshop`) works in the browser and nowhere
+  else.** Three server-side consumers must move to `API_HOST_INTERNAL` — see the table in
+  Phase 4. This list was wrong in the first draft of this spec (it named two consumers;
+  there are four) and grew again when #71 added `lib/authenticate.ts`, so re-grep for
+  `NEXT_PUBLIC_API_HOST` at implementation time rather than trusting the table.
 - The Netlify proxy has a **26 second ceiling**. Comfortable for CRUD; worth remembering
   if any endpoint ever grows slow.
 - `docker-compose.yml`, `dev-full.sh` and the e2e stack already run the API as a plain
   server and need no structural change — only the base path in `e2e/env.ts`.
-- Keep `/health`'s no-auth carve-out (`app.go:179`). It now backs a Fly health check as
+- Keep `/health`'s no-auth carve-out (`app.go:219`). It now backs a Fly health check as
   well as the uptime monitoring in `observability.md`.

--- a/specs/api-hosting-migration.md
+++ b/specs/api-hosting-migration.md
@@ -42,18 +42,41 @@ Two pre-existing defects surface here and are fixed as part of the work:
 
 ## Proposed approach
 
-### Phase 0 — Settle the one unknown, before anything else
+### Phase 0 — DONE. The unknown is settled: `Authorization` is forwarded
 
-**Does Netlify forward the `Authorization` header through a `status = 200` rewrite to an
-external origin?** Netlify's docs do not say, and the entire API is bearer-authenticated.
+**Answered empirically on 2026-08-05**, via a throwaway branch deploy (PR #74, since
+closed) carrying the exact rewrite this migration proposes — `/api/bigshop/*`,
+`status = 200`, `force = true` — pointed at an echoing origin. Netlify's docs do not
+answer this, and the one support-forum thread asking it was closed without a staff reply,
+so measurement was the only route.
 
-Deploy any trivial echo service, add a rewrite, and `curl` it with a bearer token through
-`www.bigshop.life`. This is an afternoon at most and it gates the whole design.
+| Question | Result |
+| --- | --- |
+| `Authorization` forwarded to an external origin? | **Yes**, intact |
+| Arbitrary custom headers (`traceparent`, `X-Probe-Custom`)? | **Yes**, verbatim |
+| `PUT` / `PATCH` / `DELETE` proxied? | **Yes**, all 200 |
+| Method, body and `Content-Type` preserved on POST? | **Yes**, body round-tripped exactly |
+| Genuine rewrite rather than a 302? | **Yes**, 0 redirects, URL unchanged |
 
-**If it fails**, the fallback is `api.bigshop.life` pointed straight at Fly — which costs
-CORS preflights on mutations and requires fixing the wildcard-plus-credentials config
-above, but is otherwise equivalent and is arguably *faster* for UK users. Do not proceed
-past Phase 1 without an answer.
+**The `api.bigshop.life` subdomain fallback is therefore not needed**, and same-origin is
+confirmed rather than assumed. Every route family the API actually uses — `apiGet` plus
+`apiMutate`'s four verbs in `lib/api-client.ts` — is covered by the methods tested.
+
+Netlify adds several headers on the way through, visible at the origin:
+
+- `x-nf-client-connection-ip` — the real client IP survives the proxy, so rate limiting or
+  abuse handling at the origin remains possible.
+- `x-nf-request-id` — correlates a request with Netlify's own logs. Worth putting on spans;
+  noted in [`observability.md`](./observability.md).
+- `x-nf-netlify-proxy` — a **signed JWT** (`iss: netlify`, `sub: proxy`, carrying
+  `request_id` and `client_ip`). This means the Fly origin could verify that traffic
+  arrived via Netlify with no shared secret to manage — a cheaper mechanism than the JWS
+  signing ADR-0006 considered and rejected. It does **not** change that decision: Dave's
+  server-side calls address Fly directly and would not carry it, so the origin must accept
+  unsigned traffic anyway. Recorded because it is the obvious thing to reach for later.
+- `x-country`, `x-nf-account-tier`.
+- Netlify **rewrites `Accept` to `*/*,image/webp`**. See "Things to get right" — Huma
+  negotiates on `Accept`.
 
 ### Phase 1 — Make it deployable
 
@@ -162,8 +185,13 @@ Deliberately a separate PR, days later:
 
 ## Things to get right when building this
 
-- **Phase 0 gates everything.** Do not build a Dockerfile before knowing whether the
-  proxy forwards `Authorization`.
+- **Phase 0 is done** — see above. Nothing is blocked on it.
+- **Netlify rewrites the `Accept` header to `*/*,image/webp` through the proxy.** Huma
+  does content negotiation on `Accept`, so confirm during Phase 3's verification that
+  responses still come back as JSON rather than something else. It should be fine — `*/*`
+  is present and Huma resolves that to JSON — but it is a header the API's framework
+  actually reads, mutated by an intermediary, which is exactly the shape of bug
+  `follow-ups.md` #12 records being caught only by e2e.
 - **Phase 2 before Phase 3.** There must be no window in which the Go checks run nowhere.
 - `docs/openapi.yaml` and `types/api.d.ts` are generated and drift-checked. A base path
   change means regenerating both; the drift check will catch it if you forget, but only

--- a/specs/api-hosting-migration.md
+++ b/specs/api-hosting-migration.md
@@ -1,0 +1,183 @@
+# Move the Go API off Netlify Functions onto Fly.io in Frankfurt
+
+Decisions and rationale: [ADR-0006](../docs/adr/0006-go-api-leaves-netlify-functions.md).
+This spec covers the *how*. Do this before [`observability.md`](./observability.md) —
+that spec's design assumes the API is a long-lived process.
+
+## Current state (why this isn't greenfield)
+
+The Go API is one AWS Lambda behind Netlify Functions. `main.go`'s `init()` builds a
+negroni router via `app.GetRouter("/.netlify/functions/recipes")` and `main()` branches
+three ways: `openapi` (print spec, exit), `dev` (plain `http.Server` on `:8080`), and
+default (`lambda.Start`).
+
+Three facts make this migration small:
+
+- **The server already exists.** The `dev` branch runs the *same* router as an ordinary
+  HTTP server. Production and local currently differ only in how the router is invoked.
+- **It's already containerized.** `netlify-functions/recipes/Dockerfile.dev` plus the
+  `api` service in `docker-compose.yml` build and run it, and the e2e suite depends on
+  that working.
+- **Nothing else in the repo talks to the Lambda directly.** `lib/api-client.ts` and
+  `lib/dave/tools.ts` both go through `NEXT_PUBLIC_API_HOST`.
+
+And three make it necessary:
+
+- Netlify's functions region defaults to `cmh` (us-east-2) and region selection is
+  Pro/Enterprise. TiDB is `eu-central-1`. Every query is transatlantic, several
+  sequentially per request.
+- Netlify's Lambda compatibility mode — which is what `lambda.Start` +
+  `events.APIGatewayProxyRequest` is — stops being accepted for deploys on 1 July 2027.
+- No Netlify tier exposes Lambda layers or extensions, so there is no collector sidecar
+  and no post-response flush at any price.
+
+Two pre-existing defects surface here and are fixed as part of the work:
+
+- `app.go:170` sets `AllowedOrigins: {"*"}` with `AllowCredentials: true`. The CORS spec
+  forbids that pairing, so it does not do what it appears to.
+- `.github/workflows/ci.yml` triggers on `pull_request` and `workflow_dispatch` only.
+  `go fmt`, `go test` and both drift checks live in `build.sh`, i.e. they run **only** in
+  Netlify's deploy build. Remove Go from Netlify without addressing this and they stop
+  running entirely.
+
+## Proposed approach
+
+### Phase 0 — Settle the one unknown, before anything else
+
+**Does Netlify forward the `Authorization` header through a `status = 200` rewrite to an
+external origin?** Netlify's docs do not say, and the entire API is bearer-authenticated.
+
+Deploy any trivial echo service, add a rewrite, and `curl` it with a bearer token through
+`www.bigshop.life`. This is an afternoon at most and it gates the whole design.
+
+**If it fails**, the fallback is `api.bigshop.life` pointed straight at Fly — which costs
+CORS preflights on mutations and requires fixing the wildcard-plus-credentials config
+above, but is otherwise equivalent and is arguably *faster* for UK users. Do not proceed
+past Phase 1 without an answer.
+
+### Phase 1 — Make it deployable
+
+- Production `Dockerfile` (multi-stage, static build, no `air`, non-root) alongside the
+  existing `Dockerfile.dev`.
+- `fly.toml`: one `shared-cpu-1x` machine, **512MB** (Go plus the collector sidecar that
+  `observability.md` adds later), region `fra`, `auto_stop_machines = false`.
+- `DSN` as a Fly secret. `main.go:37`'s TiDB TLS config is unchanged — it pins
+  `gateway01.eu-central-1` and Fly reaches it identically, over the public endpoint.
+  Note Fly runs its own hardware, so `fra` is the same *metro* as TiDB's AWS
+  `eu-central-1`, not the same provider network — the hop is Frankfurt peering at
+  ~1–5ms rather than intra-AWS at ~0.5–1ms. Accepted in ADR-0006; no private
+  networking or PrivateLink is available or attempted.
+- Change the router base path from `/.netlify/functions/recipes` to **`/api/bigshop`**,
+  then regenerate both derived artefacts:
+  `go run . openapi > ../../docs/openapi.yaml` and `npm run generate:api-types`.
+- Fly health check on `/health`.
+
+### Phase 2 — Move the checks before removing them
+
+- Add a `go` job to `ci.yml`: `go fmt ./...`, `go test ./... -v`, the `openapi.yaml` drift
+  check, and the existing `api.d.ts` drift check.
+- **Add `push: branches: [master]` to `ci.yml`'s triggers.** Without this, the checks
+  currently guaranteed by Netlify's deploy build would only run on PRs.
+- `build.sh` reduces to `npm run package`. Remove `GO_VERSION` from `netlify.toml`.
+- New `deploy-api.yml`: on push to master, gated on CI, builds the image and runs
+  `fly deploy`.
+
+Phase 2 lands *before* Phase 3 so there is never a window where the Go checks run nowhere.
+
+### Phase 3 — Dual run
+
+Deploy to Fly and add the rewrite while the frontend still points at the Lambda:
+
+```toml
+[[redirects]]
+  from = "/api/bigshop/*"
+  to = "https://<app>.fly.dev/api/bigshop/:splat"
+  status = 200
+  force = true
+```
+
+Nothing is live — no client requests that path yet. Both APIs serve the same production
+TiDB, so there is no data migration and no divergence.
+
+Verify against real production data: an authenticated `GET /api/bigshop/recipes` through
+`www.bigshop.life`, a write, and `/health`. Compare a shopping-list generate's latency
+against the Lambda's for the same account.
+
+### Phase 4 — Cut over
+
+One frontend deploy changes two values:
+
+- `NEXT_PUBLIC_API_HOST` → `/api/bigshop` (relative — same origin via the rewrite)
+- `API_HOST_INTERNAL` → `https://<app>.fly.dev/api/bigshop`, a new **server-side-only**
+  variable for `lib/dave/tools.ts`, so Dave's several-per-turn tool calls go straight to
+  Frankfurt instead of us-east-2 → Netlify edge → Frankfurt.
+
+`e2e/env.ts`'s `API_HOST` changes to the new base path in the same PR.
+
+Rollback is reverting those values and redeploying. The Lambda is still there, still
+serving its old path, untouched.
+
+### Phase 5 — Tidy up, after a cooling-off period
+
+Deliberately a separate PR, days later:
+
+- Delete the `lambda.Start` branch from `main()`, plus `aws-lambda-go` and
+  `aws-lambda-go-api-proxy` from `go.mod`. The `dev` branch becomes the only server path,
+  so production and local run identical code.
+- Rename `netlify-functions/recipes/` → `api/`. Update `docker-compose.yml`, `build.sh`,
+  `scripts/build-local.sh`, `CLAUDE.md`, `technical-architecture.md`.
+- Fix the CORS config to a real origin allowlist.
+
+## Decisions made (grilled — do not re-litigate without a load-bearing reason)
+
+- **Fly.io, `fra`, one always-on machine.** Not Netlify Pro (costs ~4× and fixes less —
+  no sidecar at any tier, flush remains, deadline remains). Not a Hetzner/EC2 VPS (cheaper
+  but OS, TLS, patching and deploy tooling all become ours). Not auto-stop — cold starts
+  are what we are migrating away from.
+- **Netlify keeps everything else**: the Next.js site, SSR, the four LLM API routes,
+  branch deploys.
+- **Same origin via a 200 rewrite**, not a subdomain — preserves the no-CORS property.
+  Subdomain is the documented fallback if Phase 0 fails.
+- **Base path `/api/bigshop`.** `/api/*` alone would swallow the five Next.js routes.
+  No version segment; `/api/bigshop/v1` remains available later at the cost of one
+  regeneration.
+- **The Fly origin stays publicly reachable**, guarded by the Auth0 JWT validation that
+  already guards every route bar `/health`. No JWS signing — it is defence in depth over
+  an already-authenticated API, and buying it would mean either slowing Dave down or
+  maintaining a second auth path.
+- **Dual-run cutover**, flipped by env var, with the Lambda left deployed for a
+  cooling-off period. Not big-bang.
+- **Go checks move to `ci.yml` wholesale**, with a push trigger added.
+
+## Explicitly out of scope
+
+- Per-branch API deploys. Branch deploys will proxy to the single production API instance.
+  This is a real, accepted degradation — see ADR-0006's consequences.
+- Moving the Next.js LLM routes anywhere. They stay Netlify Functions in us-east-2; their
+  latency is dominated by OpenAI calls measured in seconds.
+- Multi-instance or multi-region Fly deployment. One machine; revisit if deploy blips
+  become annoying.
+- Any observability work. That is [`observability.md`](./observability.md), and it depends
+  on this landing first.
+
+## Things to get right when building this
+
+- **Phase 0 gates everything.** Do not build a Dockerfile before knowing whether the
+  proxy forwards `Authorization`.
+- **Phase 2 before Phase 3.** There must be no window in which the Go checks run nowhere.
+- `docs/openapi.yaml` and `types/api.d.ts` are generated and drift-checked. A base path
+  change means regenerating both; the drift check will catch it if you forget, but only
+  once the check is running in its new home.
+- `lib/dave/tools.ts` currently reads `NEXT_PUBLIC_API_HOST` for server-side calls. It
+  must switch to `API_HOST_INTERNAL`, which has no `NEXT_PUBLIC_` prefix and must not
+  acquire one — it should never reach the browser bundle.
+- A **relative** `NEXT_PUBLIC_API_HOST` (`/api/bigshop`) works for the browser but not for
+  anything server-side, which is precisely why Dave needs its own absolute variable. Check
+  every consumer of `NEXT_PUBLIC_API_HOST` for server-side use before assuming a relative
+  value is safe.
+- The Netlify proxy has a **26 second ceiling**. Comfortable for CRUD; worth remembering
+  if any endpoint ever grows slow.
+- `docker-compose.yml`, `dev-full.sh` and the e2e stack already run the API as a plain
+  server and need no structural change — only the base path in `e2e/env.ts`.
+- Keep `/health`'s no-auth carve-out (`app.go:179`). It now backs a Fly health check as
+  well as the uptime monitoring in `observability.md`.

--- a/specs/native-app-wrapper.md
+++ b/specs/native-app-wrapper.md
@@ -1,0 +1,315 @@
+# Distributing Big Shop as a native app — what it would take
+
+**Status:** Spec only. Nothing built, nothing decided.
+**Date:** 2026-08-01
+**Scope:** Wrapping the existing webapp natively for App Store (and Play Store)
+distribution, while keeping the webapp itself as a first-class distribution channel
+off the same codebase.
+
+> **If you read one thing, read §1 and §7.** §1 is the good news: Big Shop's
+> architecture is already almost exactly the shape a Capacitor wrapper wants — a
+> client-rendered SPA talking to a remote HTTPS API. §7 is the bad news: the hard
+> parts aren't the wrapper, they're Auth0-in-a-webview, Apple's Guideline 4.2
+> "minimum functionality" bar, and two compliance blockers (in-app account deletion,
+> and Sign in with Apple) that are requirements rather than nice-to-haves.
+
+---
+
+## 1. Where the codebase already stands
+
+This matters more than the tooling choice, so it goes first. I read the app rather
+than assuming.
+
+| Property | Current state | Implication for wrapping |
+|---|---|---|
+| Rendering | Every route behind `/` is client-rendered. `pages/_app.tsx`'s `InnerApp` gates on `isAuthenticated` and returns nothing until Auth0 resolves — no server data is used to render app screens | ✅ It's effectively already an SPA. A static bundle in a webview behaves identically |
+| Server-side data fetching | `getServerSideProps` appears in exactly two files, `pages/dev/api-docs.tsx` and `pages/dev/design-system.tsx`, both dev-only by design | ✅ Neither should ship in a store binary anyway |
+| Data layer | TanStack Query → Go API over HTTPS at `NEXT_PUBLIC_API_HOST` | ✅ Works unchanged from a webview; it's just a cross-origin fetch |
+| Auth | `@auth0/auth0-react` SPA SDK, already configured with `useRefreshTokens={true}` and `cacheLocation="localstorage"` (`pages/_app.tsx:82`) | ⚠️ Those two settings are *exactly* what native needs — but the redirect and token-storage strategy still need reworking. See §4 |
+| `next/image` | Not used anywhere | ✅ Removes the usual `output: 'export'` blocker |
+| PWA manifest | Already present and standalone-capable (`public/manifest.json`), with 192/512 icons and apple-touch-icon wired up in `components/layout/index.tsx` | ✅ The PWA-only option (§3, Option A) is essentially already shipped |
+| Dynamic routes | `pages/recipes/[id]/index.tsx`, `.../edit.tsx` | ⚠️ The one real static-export problem. See §2 |
+| LLM features | Four Next.js API routes (`parse-recipe-url`, `parse-recipe-text`, `recipe-image`, `dave/chat`) holding `OPENAI_API_KEY` server-side | ⚠️ Cannot ship inside the binary. Must stay hosted. See §2 |
+| Camera | `<input type="file" accept="image/*" capture="environment">` at `pages/recipes/new.tsx:320-327` | Works in a webview, but replacing it with a native picker is the cheapest win against Guideline 4.2 (§7) |
+
+**Read:** the wrapper itself is a small amount of work. The cost is concentrated in
+auth, compliance, and the release process — not in getting the app to render.
+
+---
+
+## 2. Build-target work: getting a static bundle out of Next.js
+
+The native shell needs a directory of static assets. That means `output: 'export'`,
+which forces four changes.
+
+### 2.1 Dynamic routes — the only structural change
+
+With the Pages Router, `output: 'export'` requires `getStaticPaths` to enumerate every
+path at build time. Recipe IDs are per-account, database-backed, and unknowable at
+build time, so `/recipes/[id]` cannot be exported as-is.
+
+Three ways out, in order of preference:
+
+1. **Query-param route** — move to `/recipes/view?id=123` and `/recipes/edit?id=123`,
+   reading via `router.query`. Smallest change, one file each, works identically on
+   web and native. Costs you the pretty URL on web (mitigable with a Netlify rewrite
+   so public URLs are unchanged and only the native build uses the flat form).
+2. **Client-side route shim** — export a single catch-all shell and resolve the ID in
+   the client. More machinery, keeps URLs.
+3. **Keep two route trees**, one per target. Rejected — it's the version of this that
+   rots.
+
+I'd take (1). It's the only item in this whole spec that touches product URLs, so
+it's worth deciding early.
+
+### 2.2 The `pages/api/*` routes stay hosted
+
+`output: 'export'` drops API routes entirely. That's correct here — they hold
+`OPENAI_API_KEY` and must never be in a client binary. The native app points at
+`https://www.bigshop.life/api/*` exactly as it points at the Go API today.
+
+Consequence worth stating plainly: **the native app is not usable offline for recipe
+import or Dave.** Only the Shopping List and cached recipes could work offline (§6).
+
+### 2.3 Excluding dev-only surface from the binary
+
+`pages/dev/api-docs.tsx` and `pages/dev/design-system.tsx` should be excluded from the
+native build — they use `getServerSideProps` (incompatible with export) and shouldn't
+be in a shipped app regardless. A side benefit: `swagger-ui-react` is a heavyweight
+dependency used only by the api-docs page, and dropping it meaningfully shrinks the
+bundle you're asking users to download.
+
+### 2.4 A platform seam
+
+The user requirement is one codebase, two targets. That wants a small abstraction —
+something like `lib/platform/` exposing `camera.ts`, `auth.ts` and `storage.ts`, each
+resolving to a web or native implementation at build time. Call sites (`new.tsx`'s
+image handler, the auth hook) then don't branch on platform themselves.
+
+This is deliberately a thin seam: three modules, each with one obvious interface. If
+it grows past that, the wrapper is leaking and it's worth re-reading this section.
+
+---
+
+## 3. The four options
+
+| | A. PWA only | B. Capacitor over remote URL | C. Capacitor over bundled export | D. React Native rewrite |
+|---|---|---|---|---|
+| **What it is** | What you have now — installable from Safari | Native shell whose webview loads `bigshop.life` | Native shell with the built web app inside the binary; API calls go out to the hosted backends | Native UI, shared API only |
+| **Store presence** | ❌ None | ✅ (high rejection risk) | ✅ | ✅ |
+| **Effort** | Zero | ~2–3 days | ~2–3 weeks | Months |
+| **Guideline 4.2 risk** | n/a | **High** — this is the textbook rejection case | Manageable with native features (§7) | None |
+| **Ship a web fix instantly** | ✅ | ✅ | ⚠️ Needs a release, or OTA (§8) | ❌ |
+| **Works offline** | Partially | ❌ Not at all | ✅ Shell always; data with §6 | ✅ |
+| **Native camera / share / push** | ❌ (push only on iOS 16.4+, installed) | ✅ via plugins | ✅ via plugins | ✅ |
+| **Feels native** | Somewhat | Somewhat | Somewhat | ✅ |
+
+**Recommendation: C.** B looks tempting for the effort saving but it is the specific
+pattern Apple rejects, it breaks completely without signal, and the saving is a couple
+of days. D is not justified by anything in the current product — there's no
+performance problem, no animation-heavy surface, no deep OS integration in the app
+today that a webview can't reach.
+
+A is worth taking seriously as a *decision*, not a default: if the goal is "people can
+install it on their phone", A already does that for free. The App Store buys you
+discoverability, a trust signal, and push — and costs you everything in §7 and §8. If
+you can't name which of those three you're buying, C isn't worth it yet.
+
+---
+
+## 4. Auth0 in a native webview — the highest-risk area
+
+Everything else here is predictable work. This is the part that bites.
+
+**What already helps:** `useRefreshTokens={true}` and `cacheLocation="localstorage"`
+are both already set in `pages/_app.tsx`. Native has no third-party cookies, so
+silent-auth-via-iframe cannot work — the refresh-token path you're already on is the
+only one that does. That's a genuine head start.
+
+**What has to change:**
+
+1. **Origin and callback URL.** A Capacitor webview's origin is `capacitor://localhost`
+   (iOS) / `https://localhost` (Android), not `https://www.bigshop.life`. The current
+   `redirect_uri: process.env.NEXT_PUBLIC_HOST` (`pages/_app.tsx:79`, and again in
+   `components/identity/create/index.tsx:12`) is wrong for native. Needs a
+   platform-resolved value, plus new entries in the Auth0 application's Allowed
+   Callback/Logout URLs and Allowed Web Origins.
+
+2. **Login must not happen in the embedded webview.** Google explicitly blocks OAuth in
+   embedded webviews (`disallowed_useragent`), and Auth0's own guidance for
+   Capacitor is to hand off to the system browser. The fix is to override the SDK's
+   `openUrl` to use `@capacitor/browser`, so login runs in
+   `ASWebAuthenticationSession` (iOS) / Custom Tabs (Android), then deep-link back via
+   `@capacitor/app`'s `appUrlOpen` listener and call `handleRedirectCallback`. This is
+   a documented pattern, not an invention — but it's the fiddliest part of the build.
+
+3. **Token storage.** Refresh tokens in webview `localStorage` are weaker than they
+   need to be on a device. Supply a custom cache backed by Capacitor Preferences or,
+   better, a secure-storage plugin (Keychain / Android Keystore). Contained work —
+   the SDK takes a `cache` option — but it's a security decision worth making
+   deliberately rather than inheriting the web default.
+
+4. **Long-backgrounded sessions.** A native app gets resumed weeks later far more often
+   than a browser tab does. Refresh token rotation and absolute expiry need testing
+   against that, with a clean re-auth path rather than a blank gated screen — note
+   `InnerApp` currently renders nothing at all when unauthenticated (`pages/_app.tsx:22`),
+   which is fine on web where a redirect follows immediately, and much worse as a
+   cold-start experience in an app.
+
+5. **Deep-link registration** — associated domains / custom URL scheme, plus an
+   `apple-app-site-association` file if you want universal links.
+
+**Budget this at half the total engineering time of the whole project.** It is the
+thing most likely to eat a week you didn't plan for.
+
+---
+
+## 5. Native capabilities worth adding
+
+Two purposes: making the app worth installing, and clearing Guideline 4.2 (§7).
+
+| Capability | Plugin | Value | Effort |
+|---|---|---|---|
+| **Share-sheet ingest** — share a recipe URL from Safari/Instagram straight into Big Shop | Share extension (iOS, native code) + `@capacitor/app` | **Highest.** `parse-recipe-url` already exists; this is the missing front door to it, and it's the single most compelling reason for this app to be native | Medium–high (requires a real iOS extension target) |
+| Native camera | `@capacitor/camera` | Replaces `pages/recipes/new.tsx`'s file input. Better UX, direct 4.2 answer | Low — one component, one platform module |
+| Push notifications | `@capacitor/push-notifications` | Needs a server-side sender and a reason to notify. Don't build it without a product reason | Medium |
+| Haptics / status bar / splash | `@capacitor/haptics`, `@capacitor/status-bar`, `@capacitor/splash-screen` | Cheap polish that materially changes "is this a website?" | Very low |
+| Offline shopping list | See §6 | High product value — the supermarket-with-no-signal case | High |
+
+Share-sheet ingest and offline list are the two that make this a better product rather
+than the same product in a different box. If neither is in scope, reconsider Option A.
+
+---
+
+## 6. Offline support (optional phase, high value)
+
+The actual use case is standing in a supermarket with one bar of signal. Today
+TanStack Query holds everything in memory with no persistence, so a cold start
+offline shows nothing.
+
+What it takes:
+- `@tanstack/query-persist-client` + an async storage persister, so the Shopping List
+  and recipe list survive a cold start.
+- `onlineManager` wired to Capacitor's network status.
+- A mutation queue with `queryClient.setMutationDefaults` so ticking items off while
+  offline replays on reconnect.
+- A conflict story. This is the hard bit and it's a *product* question, not a technical
+  one: the Shopping List is a shared account resource (CLAUDE.md is explicit that it's
+  "one mutable resource shared by the whole account"), so two people shopping
+  simultaneously offline will diverge. `shopping_list_event` being an append-only log
+  is a genuine asset here — it's closer to a CRDT-friendly shape than the `list` table
+  is.
+
+**Do not fold this into the wrapper phase.** It's independently valuable, it's the
+largest single work item in this document, and it can ship to the webapp too.
+
+---
+
+## 7. App Store compliance — the requirements, including two blockers
+
+### 7.1 Blocker: in-app account deletion (Guideline 5.1.1(v))
+
+Apps that support account creation **must** support account deletion in-app. I grepped
+`pages/account.tsx` — it handles invites, and there is no delete-account path anywhere
+in the app. This needs building: a frontend flow, a Go API endpoint, and a decision
+about what deletion means when an `account` is shared between users (does deleting the
+last user delete the account's recipes and list? what about a user leaving a shared
+account?).
+
+That last question is a real domain design problem, not a checkbox. Budget for it.
+
+### 7.2 Blocker (conditional): Sign in with Apple (Guideline 4.8)
+
+If the Auth0 tenant has any third-party social login enabled (Google, Facebook, etc.),
+Apple requires an equivalent privacy-preserving option — in practice, Sign in with
+Apple. **Action: check which connections are enabled on the `dev-x-n37k6b` tenant
+before scoping anything else.** If it's email/password only, this evaporates. If Google
+is on, add an Apple connection in Auth0 plus an Apple Services ID and key.
+
+I flagged this as conditional because I can't see the tenant config from the repo, but
+it's the single most common cause of a surprise rejection for an app in this shape.
+
+### 7.3 Guideline 4.2 — minimum functionality
+
+"Your app should include features, content, and UI that elevate it beyond a repackaged
+website." A webview pointing at a site is the canonical rejection. The defence is the
+§5 list — native camera, share extension, haptics, offline — and framing the app in
+review notes around what it does on-device. Option C plus two or three items from §5
+clears this comfortably; Option B likely doesn't.
+
+### 7.4 Everything else
+
+- **Privacy manifest** (`PrivacyInfo.xcprivacy`), required since May 2024, declaring
+  API usage reasons (file timestamps, user defaults) and any tracking.
+- **Privacy nutrition labels** in App Store Connect. Note this app sends recipe photos
+  and text to OpenAI — that's third-party data sharing and must be disclosed. Worth a
+  look at whether the current privacy policy says so.
+- **Permission usage strings** — `NSCameraUsageDescription`, `NSPhotoLibraryUsageDescription`.
+- **Age rating, support URL, privacy policy URL** — all mandatory fields.
+- **Screenshots** for required device sizes, plus a 1024×1024 icon. The current
+  `public/static/icon512.png` is too small; you'll need a fresh 1024 master.
+- **Export compliance** — routine HTTPS-only declaration.
+
+### 7.5 Cost
+
+Apple Developer Program is $99/year, Google Play is a one-off $25. First review is
+typically 24–48h; rejections cost a round trip each.
+
+---
+
+## 8. What changes about how you work
+
+This is the part that's easy to underestimate, and it's permanent.
+
+- **Two distribution channels, different latencies.** The webapp deploys on push. The
+  native app needs a build, a submission and a review. A bug fixed in five minutes on
+  web takes a day or more to reach app users.
+- **Mitigation: OTA JS updates.** Apple's Guideline 3.3.2 permits updating interpreted
+  code that doesn't change the app's primary purpose, which is what tools like
+  `@capgo/capacitor-updater` (self-hostable) or Ionic Appflow Live Updates (paid) do.
+  This is close to essential if you want to keep the current pace of change. Worth
+  scoping in phase 1, not bolted on later.
+- **Version skew.** Once binaries are in the wild, an old app version will call the
+  current Go API. Today every client is served fresh from Netlify, so the API has never
+  had to be backwards-compatible with an old frontend. That's a new constraint on API
+  changes, and the OpenAPI spec being generated from `app.go` (already the case) helps.
+- **A second CI path.** iOS builds need macOS runners; the existing e2e workflow on
+  `ubuntu-latest` won't cover it. Playwright continues to test the web build, which
+  remains a good proxy since it's the same bundle — but nothing in the current suite
+  tests the native shell, and the auth flow (§4) is precisely what it can't reach.
+- **Local dev gets a third mode** alongside `npm run dev` and `npm run dev:full`:
+  a Capacitor sync + open-in-Xcode loop.
+
+---
+
+## 9. Suggested phasing
+
+Each phase is independently shippable, and phases 0 and 1 are the cheap way to find out
+whether the auth work is as bad as §4 suggests before committing to the rest.
+
+| Phase | Work | Rough effort |
+|---|---|---|
+| **0. Prove the export** | `output: 'export'` behind a flag, resolve `/recipes/[id]` (§2.1), exclude `pages/dev/*`, verify the bundle runs from `file://` | 1–2 days |
+| **1. Shell + auth** | Add Capacitor, iOS project, system-browser auth handoff, deep links, secure token storage. **Highest risk — do it before committing to the rest** | 3–6 days |
+| **2. Compliance blockers** | Account deletion (frontend + Go endpoint + shared-account semantics), Sign in with Apple if needed | 3–5 days |
+| **3. Native features** | Camera, haptics/splash/status bar, then the share extension | 4–6 days |
+| **4. Release pipeline** | Certs, App Store Connect, TestFlight, privacy manifest, screenshots, OTA updates | 2–4 days + review latency |
+| **5. Offline (optional)** | Query persistence, mutation queue, conflict handling | 5–10 days |
+
+**Phases 0–4: roughly 3–4 weeks of focused work**, plus $99/year and permanent release
+overhead. Phase 5 is a further 1–2 weeks and is the phase that makes it a better product.
+
+---
+
+## 10. Open questions
+
+1. **Which Auth0 connections are enabled?** Decides whether §7.2 is a blocker or a
+   non-issue. Cheapest thing to check, highest scope impact.
+2. **What does account deletion mean** for a shared `account` with multiple
+   `account_user` rows? Needs a product answer before §7.1 can be built.
+3. **Is discoverability, trust, or push the reason for the App Store?** If none of them,
+   the PWA already does the job (§3, Option A).
+4. **Android too?** Capacitor makes it near-free once iOS is done, and Play review is
+   far more forgiving. Probably yes, but it doubles the store-listing chores.
+5. **Do you want pretty recipe URLs preserved on web** while the native build uses
+   query params (§2.1)? Affects whether a Netlify rewrite is in scope.

--- a/specs/observability.md
+++ b/specs/observability.md
@@ -114,7 +114,7 @@ time goes. Private source map upload so stack traces de-minify.
 - **Grafana synthetic check on `/health`**, ~1/min, with one contact point. Free tier
   allows 100k API test executions/month.
 
-Threshold-based alerting is deliberately **not** here — see `follow-ups.md` #36. It is
+Threshold-based alerting is deliberately **not** here — see `follow-ups.md` #37. It is
 triggered by roughly two weeks of production data, not by a date.
 
 ## Decisions made (grilled — do not re-litigate without a load-bearing reason)
@@ -147,7 +147,7 @@ triggered by roughly two weeks of production data, not by a date.
 - Profiling (Pyroscope), even though the local LGTM image includes it.
 - Tail sampling, and any collector processing beyond redaction and forwarding.
 - Extracting a shared Go module or npm package for instrumentation.
-- Threshold-based alert rules — `follow-ups.md` #36.
+- Threshold-based alert rules — `follow-ups.md` #37.
 
 ## Things to get right when building this
 

--- a/specs/observability.md
+++ b/specs/observability.md
@@ -151,6 +151,10 @@ triggered by roughly two weeks of production data, not by a date.
 
 ## Things to get right when building this
 
+- **Put `x-nf-request-id` on the server span** for any request arriving via the Netlify
+  proxy. It is the only handle that correlates a Big Shop trace with Netlify's own request
+  logs, and it costs one attribute. Confirmed present at the origin during the Phase 0
+  probe in [`api-hosting-migration.md`](./api-hosting-migration.md).
 - **Telemetry must never affect the application.** Exporter errors swallowed, flushes
   bounded, the SDK's default `ErrorHandler` replaced so it does not spam logs, and no
   telemetry initialisation that can `log.Fatal` the way `main.go`'s DB ping does.

--- a/specs/observability.md
+++ b/specs/observability.md
@@ -1,0 +1,173 @@
+# Observability: OpenTelemetry traces, metrics and logs to Grafana Cloud
+
+Decisions and rationale: [ADR-0007](../docs/adr/0007-observability-otel-grafana-cloud.md)
+(architecture) and [ADR-0008](../docs/adr/0008-what-telemetry-does-not-carry.md)
+(content and cardinality rules).
+
+**Depends on [`api-hosting-migration.md`](./api-hosting-migration.md) landing first.**
+Phases 2–4 below assume the Go API is a long-lived process on Fly with a collector
+sidecar available. Attempting them against the Lambda would produce a materially different
+and worse design.
+
+## Current state (why this isn't greenfield)
+
+There is no instrumentation. What exists instead:
+
+- **70 `log.*` calls in the Go API**, 26 of them a bare `log.Println(err)` immediately
+  before returning a 500 — carrying no route, account, user or timing.
+- **Double logging.** The service layer logs *and* returns; the app layer logs again. Every
+  DB error appears twice (`service/invite.go:20-21` then `app/invites.go:34`).
+- **A swallowed error.** `app/account.go:41` logs *any* error from `GetAccountID` as
+  `"current user is not associated with an account"` and discards the real `err`, so a
+  TiDB connection failure is reported to you, and to the user, as a membership problem.
+- **A health check that checks nothing.** `app.go:52` writes `ok` unconditionally. It only
+  detects a TiDB outage indirectly, because `main.go:68` `log.Fatalf`s on a failed ping
+  during `init()` and kills the process. **A database that dies while a container is warm
+  leaves `/health` returning `ok` while every real endpoint 500s.**
+- 15 `console.*` calls in the frontend, and no client error reporting of any kind.
+
+Goals, in the order they matter: know when it's broken; reconstruct what happened after
+the fact. Long-horizon product questions ("is Dave used more than three months ago") are
+**out of scope** and belong to Google Analytics — which is what makes Grafana Cloud Free's
+14-day retention a non-issue rather than a constraint.
+
+## Proposed approach
+
+### Phase 1 — Vertical slice against local LGTM
+
+Add `grafana/otel-lgtm` to `docker-compose.yml` (Collector, Tempo, Loki, Prometheus,
+Grafana in one image; OTLP on 4318, Grafana on 3000 — no clash, `dev-full.sh` serves the
+web app on 3001).
+
+Then instrument exactly **one** Go route end to end with all three signals, exporting to
+`localhost:4318`:
+
+- Resource attributes: `service.namespace=bigshop`, `service.name=bigshop-api`,
+  `deployment.environment.name`, `service.version` (git sha).
+- One server span per request with `account.id`, `user.sub`, route, status.
+- `otelsql` child spans for each query.
+- `slog` via `otelslog` so log lines carry `trace_id`.
+- One metric: the HTTP duration histogram.
+
+Verify in local Grafana that a trace, its logs and its metric all correlate. Nothing
+touches production.
+
+### Phase 2 — Production, and the checkpoint
+
+Deploy the same single route to Fly with the **OTel Collector as a sidecar** in the Fly
+app, Go exporting to `localhost:4318`, collector forwarding to Grafana Cloud
+(eu-central-1). Grafana credentials live in collector config, not application code.
+
+**Exit criteria — do not proceed until all three pass:**
+
+1. A trace from production appears in Tempo, with correlated logs in Loki and a metric in
+   Mimir, all filterable by `service.namespace=bigshop`.
+2. Request latency is statistically unchanged versus before instrumentation. It should be
+   — the Go export is a background batch, off the request path — and if it isn't,
+   something is misconfigured.
+3. **Failure injection**: point the collector at a blackholed endpoint and confirm the API
+   keeps serving normally and drops telemetry silently. A dead collector must never be a
+   retry storm or a request-path failure.
+
+### Phase 3 — Widen the Go API, and the log cleanup
+
+- Instrument every route via middleware rather than per-handler code.
+- **Error-recording middleware at the Huma boundary**: `span.RecordError` +
+  `span.SetStatus` on any returned error. Captures 100% of handler errors with no
+  per-call-site work.
+- Service layer stops logging and wraps instead: `fmt.Errorf("adding invite: %w", err)`.
+- **Delete the 26 bare `log.Println(err)` calls** and every other line the span makes
+  redundant. Convert only those carrying genuine extra context to `slog`. Net result is
+  fewer lines than we started with.
+- Fix `app/account.go:41` to preserve the real error.
+- **Fix `/health` to `SELECT 1`.** It now backs a Fly health check, a Grafana synthetic
+  check, and the `log.Fatalf`-on-init behaviour that currently masks the gap.
+- Remaining metrics: import-outcome counter (source × result), LLM token counter
+  (model × direction).
+
+### Phase 4 — Next.js functions, and propagation
+
+Instrument SSR and the four API routes via `instrumentation.ts`, and propagate
+`traceparent` from `pages/api/dave/chat.ts` through `lib/dave/tools.ts` into the Go API —
+so a Dave turn is one trace spanning both runtimes and every tool call.
+
+**These are still Lambdas, so this is the one place a synchronous flush survives.** It
+must be configured against the SDK's defaults, which are actively dangerous here — see
+ADR-0007. Specifically: retries disabled, a ~250ms exporter timeout overriding the 10s
+default, a bounded context on every `ForceFlush` (never `context.Background()`), the three
+providers flushed **concurrently** rather than sequentially, and a package-level circuit
+breaker that stops flushing after N consecutive failures for the rest of that container's
+life.
+
+Metrics only leave a Lambda on `ForceFlush` — the `PeriodicReader` never fires in a frozen
+process — so the metrics flush is not optional on this side.
+
+### Phase 5 — Browser
+
+Grafana Faro for errors, logs and web vitals. **No browser spans and no propagation from
+the client** — the backend hop is where the causality lives; browser tracing is where the
+time goes. Private source map upload so stack traces de-minify.
+
+### Phase 6 — Dashboards, and the uptime check
+
+- A service dashboard per runtime, plus a Faro frontend view.
+- **Grafana synthetic check on `/health`**, ~1/min, with one contact point. Free tier
+  allows 100k API test executions/month.
+
+Threshold-based alerting is deliberately **not** here — see `follow-ups.md` #36. It is
+triggered by roughly two weeks of production data, not by a date.
+
+## Decisions made (grilled — do not re-litigate without a load-bearing reason)
+
+- **All three signals, correlated, from the start.** Not signal-by-signal.
+- **100% sampling.** Head sampling would discard exactly the rare failure being
+  investigated, and the volume does not require it.
+- **Two export paths, deliberately asymmetric**: background batch from Go (long-lived
+  process), synchronous bounded flush from the Netlify functions (still Lambdas). The
+  awkward pattern is confined to four routes where it is proportionally noise.
+- **Collector sidecar in the Fly app**, chosen over no collector. Credentials, redaction
+  and routing move out of application code.
+- **Grafana Cloud Free, eu-central-1, permanent.** One stack, shared across future
+  projects via `service.namespace`. The region cannot be changed after creation.
+- **Faro, not Sentry.** One platform; frontend sessions correlate with backend traces in
+  one view. Accepts the loss of session replay, release-regression detection and any
+  triage workflow.
+- **Local LGTM in docker-compose for dev and e2e.** No Grafana Cloud credentials outside
+  production; free-tier quota untouched by development.
+- **Content and cardinality rules per ADR-0008**: pseudonymous IDs but no content, no
+  unbounded metric labels, no service-layer logging.
+- **No shared instrumentation library.** The reusable asset is the convention plus this
+  repo as a worked reference. Revisit at project two.
+- **Uptime check ships now; threshold alerts wait for baselines.**
+
+## Explicitly out of scope
+
+- Product analytics and any question with a horizon beyond 14 days — Google Analytics.
+- Browser spans and client-to-server trace propagation.
+- Profiling (Pyroscope), even though the local LGTM image includes it.
+- Tail sampling, and any collector processing beyond redaction and forwarding.
+- Extracting a shared Go module or npm package for instrumentation.
+- Threshold-based alert rules — `follow-ups.md` #36.
+
+## Things to get right when building this
+
+- **Telemetry must never affect the application.** Exporter errors swallowed, flushes
+  bounded, the SDK's default `ErrorHandler` replaced so it does not spam logs, and no
+  telemetry initialisation that can `log.Fatal` the way `main.go`'s DB ping does.
+- **Flush the three providers concurrently** on the Netlify side. Sequential is three
+  round trips for no benefit — the single biggest avoidable cost in the design.
+- **`account.id` belongs on spans, never on metrics.** ADR-0008 exists because this looks
+  like an inconsistency and is not. Roughly 970 series against a 10k ceiling; adding
+  account cardinality blows it.
+- **Delta temporality on the Netlify metrics**, explicitly configured. Cumulative is the
+  Prometheus default and is wrong for a process that dies constantly.
+- Metrics on the Go side keep cumulative — it is a long-lived process, which is the case
+  cumulative is designed for. The two runtimes differ here on purpose.
+- `CONTEXT.md` gets **no changes**. Span, trace, exporter and temporality are general
+  programming concepts, not Big Shop domain vocabulary, and the glossary explicitly
+  excludes those.
+- Adding a third compose service makes CLAUDE.md's multi-worktree
+  `COMPOSE_PROJECT_NAME` trap slightly easier to fall into. The e2e stack already pins its
+  own project name; check `dev-full.sh` does the right thing with the new service.
+- Faro's source map upload needs wiring into the Netlify build, not just configured in
+  Grafana.

--- a/specs/supermarket-ordering-research.md
+++ b/specs/supermarket-ordering-research.md
@@ -1,0 +1,718 @@
+# Automatically ordering the Shopping List from a UK supermarket — research findings
+
+**Status:** Research only. No code written, nothing decided.
+**Date:** 2026-07-28, extended 2026-07-29 to cover the whole retailer landscape.
+**Method:** Hands-on exploration of seven UK grocery sites (all unauthenticated) via
+browser automation and plain HTTP, plus a read of the Big Shop Shopping List
+implementation.
+
+> **If you read one thing, read §9.** Tesco was the wrong first target. Ocado and
+> Morrisons are dramatically more open — no bot wall on reads, structured product data
+> including pack size and stock status, an anonymous basket, terms that *permit*
+> personal-use ordering, and better search relevance. Parts 0–8 are the Tesco deep-dive
+> that established the evaluation criteria; §9 applies them across the field.
+
+---
+
+## 0. Read this first: the blocker that outranks all six obstacles
+
+*(This section is about **Tesco specifically**. See §9 — it does not generalise; Ocado's
+terms are materially different.)*
+
+Tesco's General Terms & Conditions contain an explicit, recently-worded prohibition.
+Verbatim, from <https://www.tesco.com/shop/zone/general-terms-and-conditions>:
+
+> Prohibited automated access: you must not use any automated system, software, or
+> process (including bots, crawlers, scrapers, or AI tools) to access, extract, or
+> collect data from this Site for any purpose without our prior written consent.
+
+This is not boilerplate that happens to catch us by accident — "AI tools" is called
+out by name, and the clause covers *access*, not just bulk extraction. The feature as
+described is squarely inside it.
+
+It is also **actively enforced**, not just asserted (see §2): Tesco runs Akamai Bot
+Manager, and a plain `curl` — even with a browser User-Agent — gets a `403` from the
+Akamai edge for *every* URL including `/robots.txt`. Only a real browser gets through.
+
+And there is no sanctioned alternative: Tesco has **no public ordering API**. The old
+Tesco Labs developer portal is unmaintained and stopped issuing subscriptions; what it
+did offer was product/pricing data, never order placement.
+([IT Pro](https://www.itpro.com/607668/online-grocery-shopping-gets-the-tesco-api-treatment),
+[Tesco Labs devportal](https://devportal.tescolabs.com/))
+
+### What this means practically
+
+There are three postures, and they are genuinely different:
+
+| Posture | Description | Assessment |
+|---|---|---|
+| **A. Server-side fleet** | Big Shop runs headless browsers in the cloud that log in as users and drive tesco.com | Requires defeating Akamai to work at all. Don't build this. It's the clause's central target, it needs active evasion, and it puts *users'* Tesco accounts at risk of suspension, not just ours. |
+| **B. Local assistant** | Automation runs on the user's own machine, in their own browser, on their own account, at their instigation | Still literally covered by the clause ("without our prior written consent"), but needs no evasion, extracts nothing at scale, and the blast radius is one user acting on their own account. This is the only technically viable shape. |
+| **C. Ask Tesco** | Write to Tesco for the written consent the clause anticipates | Slow, likely to be declined, but it's the only route that makes A legitimate. Worth one email before investing in B. |
+
+My recommendation is to **treat C as a prerequisite for any hosted version, and scope
+any MVP to B** — and to go into B knowing it's a personal-use tool that can't become a
+public product feature without Tesco's sign-off. Everything below assumes B.
+
+I've written up the technical findings in full regardless, because they're what you
+need to make that call with your eyes open. But I'd flag that the "is this a product?"
+question is now the top of the risk list, above every obstacle you listed.
+
+---
+
+## 1. How tesco.com is actually built
+
+Useful news: the site is **server-rendered on full page navigations**, so the data you
+need is in the HTML. There's no SPA state to reverse-engineer for reads.
+
+### URL structure (stable, deep-linkable)
+
+The site self-describes its routes in a `<script type="asparagus-data">` blob (Tesco's
+micro-frontend router config), including which routes require auth. 72 routes; the
+relevant ones:
+
+| URL | Auth | Notes |
+|---|---|---|
+| `/shop/en-GB/search?query=<q>` | open | Full SSR results |
+| `/shop/en-GB/products/<tpnc>` | open | Product detail page |
+| `/shop/en-GB/trolley` | **AUTH** | The basket |
+| `/shop/en-GB/slots/delivery/<date?>` | **AUTH** | Slot picker, date is deep-linkable |
+| `/shop/en-GB/slots/collection/<date?>` | **AUTH** | |
+| `/shop/en-GB/favourites` | **AUTH** | Previously bought — see §5 |
+| `/shop/en-GB/orders` | **AUTH** | Order history |
+| `/account/auth/en-GB/login?from=<encoded-url>` | — | **Login preserves a `from=` redirect target** |
+
+Note `/groceries/...` URLs still route but now redirect to `/shop/...`. Use `/shop/`.
+
+That `from=` parameter is the single most useful thing for handoff: you can hand the
+user a link that lands them on their trolley or a specific slot date *after* login.
+
+### Product identity is clean
+
+Every product detail page carries schema.org JSON-LD:
+
+```json
+{ "@type": "Product",
+  "name": "Tesco British Chicken Breast Fillets 650G",
+  "sku": "294007923",           // TPNC — the id used in /products/<id> URLs
+  "gtin13": "05057008546325",
+  "brand": { "name": "TESCO" },
+  "offers": { "price": 4.9, "priceCurrency": "GBP",
+              "availability": "http://schema.org/InStock" } }
+```
+
+Search pages carry an `ItemList` of product URLs (ordered), so ranking is recoverable
+without DOM parsing.
+
+### Extraction from search results is robust
+
+Don't parse CSS classes. The accessible names are stable and semantic:
+
+- `a[href*="/products/"]` → product id + title
+- `button[aria-label^="add "]` → the add control; its aria-label is
+  `add 1 Tesco Chicken Breast Fillets 320g` — i.e. **quantity and exact product title
+  in the accessible name**. This is a gift for both automation and verification.
+- Price (`£4.90`) and unit price (`£7.54/kg`) are in the tile text.
+
+A working extraction over `search?query=self+raising+flour` returned, per tile:
+`{id, title, price, unit, buttons}` with no fragile selectors.
+
+---
+
+## 2. Obstacle 6 (permissions/browser) — answer first, because it constrains everything
+
+**You cannot do this from a Netlify Function.** Evidence:
+
+```
+$ curl -s -o /dev/null -w "%{http_code}" https://www.tesco.com/robots.txt
+403
+$ curl ... -A "Mozilla/5.0 ... Chrome/150.0.0.0 ..." https://www.tesco.com/shop/en-GB/search?query=milk
+403
+```
+
+The 403 comes from Akamai (`errors.edgesuite.net` reference). Spoofing the User-Agent
+changes nothing, which means the check is on TLS/HTTP fingerprint, not headers.
+
+Cookies observed on a normal browser session confirm the stack:
+`_abck`, `bm_sz`, `bm_mi`, `bm_so`, `bm_sv`, `bm_lso` — Akamai Bot Manager. The site
+continuously POSTs sensor telemetry to obfuscated, rotating paths
+(`/nfohUyNUP/ruQ5R2/wsTy/...`), which is the standard Bot Manager beacon.
+
+Inside a real Chrome session, same-origin `fetch()` **does** work — I pulled eight
+search result pages programmatically from the page context. So the boundary isn't
+"scripted vs. human", it's "inside a genuine browser session vs. outside one".
+
+### Consequences for architecture
+
+- Reads (search, product lookup) can't be done from the Go Lambda or a Next.js API
+  route. They must happen in a real browser.
+- That browser should be **the user's**, on their machine — which also solves auth,
+  payment, and the basket-handoff problem for free (§3, §4).
+- Shape: a local Playwright script or a browser extension, driven by the user, talking
+  to Big Shop's existing API for the list. Not a hosted service.
+- I'd steer away from "remote browser + we send them a link to it" (Browserbase /
+  Steel / browserless style). It's the worst of both worlds: it's posture A legally, it
+  needs the user to type their Tesco password into a browser they don't control, and it
+  puts a fresh datacentre IP in front of Akamai and RBA every single run.
+
+---
+
+## 3. Obstacle 1 (authentication) — harder than "ask the user to log in"
+
+The login page is at `/account/auth/en-GB/login`, **email-first** (enter email → Next →
+second step). I did not attempt to sign in, so the second step is unverified from here.
+
+Two cookies on the login page tell the real story:
+
+- `auth_segment_allow_rba_elevation` — **risk-based authentication**. New device, new
+  IP, or unusual behaviour triggers step-up verification (typically an emailed OTP).
+- `auth_segment_new_reset_password_journey`, `auth_segment_pwcheck` — active
+  experimentation on the auth journey, so the flow is a moving target.
+
+**Implication:** a fresh browser profile looks like a new device *every run* and will
+likely eat an OTP challenge every run. That makes "spin up a clean browser and log in"
+unworkable as a routine flow. You want a **persistent browser profile** the user logs
+into once, so the session and device trust survive between shops. With local Playwright
+that's `launchPersistentContext(userDataDir)`.
+
+**Do not** store the user's Tesco credentials in Big Shop. There's no need to: the user
+logs in themselves, in their own browser, once.
+
+### A hard finding: there is no anonymous basket
+
+I clicked "Add" on a product while signed out. It does not add — it **redirects to
+`/account/auth/en-GB/login?from=<the search page>`**. The header shows a basket widget
+with "£0.00 Guide price" and "Grocery basket empty", but it's decorative until you're
+authenticated.
+
+This kills any design of the form "build the basket anonymously, then hand the user a
+link to adopt it". Every single add requires an authenticated session.
+
+The flip side is genuinely good news for §4: because there's no anonymous basket, **the
+basket is server-side and account-scoped**. Items added by an automated session on the
+user's account will be visible when the user opens tesco.com on their phone. The
+handoff works.
+
+---
+
+## 4. Obstacles 2 & 3 (slots and payment) — your MVP instincts are right
+
+Both are correct calls, and the URL structure supports them cleanly.
+
+**Slots.** `/shop/en-GB/slots/delivery/<date>` is deep-linkable and auth-gated. So:
+send the user to `/account/auth/en-GB/login?from=%2Fshop%2Fen-GB%2Fslots%2Fdelivery`,
+let them pick, then resume. You need to store enough state to resume — see §7.
+
+One thing to verify before building: **whether Tesco requires a slot to be booked
+before items can be added, or only before checkout.** I couldn't test this signed out.
+Historically Tesco lets you fill a trolley first and prompts for a slot at checkout, but
+it also shows "Reserve a slot for either home delivery or collection" prominently in the
+basket sidebar. If a slot *is* required first, the state machine gets an extra
+mandatory pause at the front, which changes the UX materially. Worth checking with a
+real account before designing around it.
+
+Also worth knowing: slot availability is itself a scarce resource — popular slots go
+days ahead. A flow that says "we'll build your basket now, you book a slot later" can
+leave the user with a basket and no slot for four days.
+
+**Payment.** Handing over at the basket is right, and the mechanism is
+`https://www.tesco.com/shop/en-GB/trolley`. Never automate checkout. Do not store card
+details. This also keeps the user as the one who actually places the order, which
+matters for both the T&C exposure and for trust.
+
+---
+
+## 5. Obstacle 4 (inexact ingredients) — the real engineering problem
+
+This is where the actual product quality lives, and it's worse than it looks. I ran a
+set of realistic queries against live search. Results, top 5 each:
+
+| Query | Top results (rank 1 →) |
+|---|---|
+| `olive oil` | **Olly's Garlic & Basil Olives**, Olly's Piri Piri Olives, Olly's Chimichurri Olives, *Tesco Olive Oil 1L* (rank 4) |
+| `garlic` | **Heinz Tomato & Garlic Marinara Sauce**, Freeze-Dried Chopped Garlic, Garlic & Coriander Naan, *Tesco Large Garlic* (rank 4) |
+| `free range eggs` | **Two Chicks Liquid Egg Whites**, *Tesco Medium Free Range Eggs 12 Pack* (rank 2) |
+| `self raising flour` | Stockwell & Co. SR Flour 1.5Kg, … then **Shredded Wheat Bitesize *Raisin*** and **Cinnamon & *Raisin* Loaf** at ranks 9–10 |
+| `chicken breast` | Good top-5, but the 51 results include **cat food** ("Untamed Chicken Breast in Gravy Cat Food") and turkey mince |
+| `2 cloves of garlic, crushed` | **TESCO Finest One Clove Garlic**, Surya Crushed Garlic, Tesco Large Garlic |
+| `400g tin chopped tomatoes` | **Tesco Italian Finely Chopped Tomatoes 400G**, Napolina Chopped Tomatoes 400G, … |
+| `fresh parsley, chopped` | **Tesco Fresh Cut Flat Leaf Parsley 30G**, Curled Leaf Parsley 30g, … |
+
+### Four findings that should shape the design
+
+**1. Rank 1 is unreliable — never auto-accept it.** "olive oil" → olives and "garlic" →
+marinara sauce are not edge cases; they're the two most common cooking ingredients in
+the list. The top slots appear to carry sponsored/promoted placements.
+
+**2. Counter-intuitively, the *raw* recipe string often beats the cleaned noun.**
+`2 cloves of garlic, crushed` returns actual garlic at rank 1, while bare `garlic`
+returns marinara sauce. Tesco's search is doing something reasonable with the extra
+tokens. So: **don't strip the ingredient down before searching.** Try the fuller string.
+
+**3. Including pack size in the query is the single biggest quality win.**
+`400g tin chopped tomatoes` returned 13 total results, essentially all correct.
+`1 tbsp soy sauce` returned 785 results but a clean top 4. Compare bare `garlic`'s 72
+results with junk at the top. Big Shop already has exactly this data — the combined
+`Amount` carries `{quantity, unit, baseQuantity, baseUnit}` — so we can synthesise
+`"400g chopped tomatoes"` rather than searching `"chopped tomatoes"`.
+
+**4. HTTP status is not a validity signal.** Queries containing punctuation or leading
+quantities (`2 cloves of garlic, crushed`, `fresh parsley, chopped`, `1 tbsp soy sauce`)
+returned **HTTP 404 with a complete, correct results page in the body**. Any
+implementation that checks `res.ok` before parsing will silently drop the best queries.
+This is exactly the class of bug `CLAUDE.md` already warns about with `use-http` — parse
+the body, don't trust the shared success flag.
+
+### Proposed matching approach
+
+A three-stage pipeline, reusing what's already here:
+
+1. **Query synthesis** — build the search string from the combined `Amount`
+   (`baseQuantity` + `baseUnit` + ingredient name), not the bare ingredient name.
+2. **Candidate retrieval** — take the top ~20 tiles with title, price, unit price, id.
+3. **LLM re-rank** — one call scoring candidates against the ingredient *and* the
+   required quantity. This is the same shape as `lib/recipe-import/extract.js`
+   (structured outputs, `lib/openai-client.js`), so it fits the existing pattern. It
+   returns a chosen product **plus a confidence**, and below a threshold the item goes
+   to a review queue instead of the basket.
+
+**Quantity → pack count is a second, separate problem.** The user needs 400g of chicken;
+Tesco sells 320g, 650g, 1kg packs. Two sub-problems:
+- *Rounding policy.* Round up, presumably — but 400g needed vs. a 1kg pack is a lot of
+  waste, and `formatDisplayQuantity` in `internal/pkg/service/list.go:391` already
+  encodes a "round up to a whole" rule for relative units. Reuse the thinking.
+- *Extracting pack size from the product title.* Titles embed it inconsistently:
+  `650G`, `1KG`, `2.272L, 4 Pints`, `12 Pack`, `4 X 400G`, `270G-470G` (variable
+  weight). The `£/kg` unit price is a more reliable derivation: `price ÷ unitPrice` =
+  pack weight. Prefer that, fall back to title parsing.
+
+**Where this data should live.** The really valuable asset here is a **learned mapping
+from Big Shop ingredient → Tesco TPNC**, cached per account. Once a user has confirmed
+"my olive oil is `Tesco Olive Oil 1L` / id 254656652", we never search for it again.
+That turns a flaky LLM-search problem into a lookup after two or three shops, and it's
+personalised (their brand, their pack size). This is the piece I'd build first — the
+search fallback is only for the cold path.
+
+The `favourites` route (`/shop/en-GB/favourites`, auth-gated) and order history are the
+obvious bootstrap: seed the mapping from what the user already buys, before ever
+searching.
+
+---
+
+## 6. Obstacle 5 (out of stock / missing) — thinking beyond "leave it on the list"
+
+I couldn't exercise the out-of-stock path signed out. What's known:
+
+- The JSON-LD `offers.availability` field is `http://schema.org/InStock`, so there's a
+  machine-readable availability signal on the PDP.
+- Tesco's own substitution mechanism happens at *picking* time, not basket time — the
+  user opts in/out per order and approves substitutes at the door. So "out of stock now"
+  and "unavailable at delivery" are different failures, and the second one can't be
+  solved at basket-build time at all.
+
+Better than leaving it silently on the list:
+
+- **Split the outcome into three buckets, and show them.** Added / needs-review /
+  not-found. The user's whole reason for using this is to not think about it, so
+  silently leaving items behind is the failure mode that erodes trust fastest.
+- **Ask the LLM for a substitute in the same re-rank call** — if `fresh dill` is
+  unavailable, `dried dill` is usually fine and the model knows that. Present it as a
+  suggestion, don't auto-add.
+- **Never silently downgrade.** Substituting Finest for value brand, or 1kg for 400g,
+  without saying so, is the thing that makes people stop trusting an auto-ordering tool.
+
+---
+
+## 7. What this needs from the Big Shop side
+
+Good news: the read side is already the right shape.
+
+- `GET /shopping-list` returns `ShoppingList{Recipes, Ingredients, Extras}` where each
+  `ListIngredient` has `Amounts[]` of `{quantity, unit, baseQuantity, baseUnit}`,
+  plus `department` and `isBought`. `baseQuantity`/`baseUnit` are exactly what §5 needs
+  for query synthesis. (`netlify-functions/recipes/internal/pkg/common/types.go`)
+- The combining work is done and lives in Go
+  (`internal/pkg/service/list.go`, `CombineIngredients` / `ApplyDisplayUnits`).
+
+What's missing:
+
+1. **Items have no id.** `ListIngredient` is keyed by name in a map, and one *item* can
+   be several `list` rows (per `docs/adr/0005`). Any Tesco mapping table needs a stable
+   key — name-per-account works, but it's worth deciding deliberately rather than
+   inheriting it.
+2. **A new persistence concern**: `ingredient → tesco_tpnc` mapping, and an "order
+   attempt" record to survive the login/slot pauses. Both are new tables + Go routes.
+   Migrations are applied **manually, in order** here — no runner in the deploy.
+3. **Nothing long-running can live in the existing deployment.** `netlify.toml` has no
+   `[functions]` block, so the default 10s synchronous timeout applies everywhere; the
+   Go Lambda's `dev` mode even sets 3s read/write timeouts. The one existing async job
+   (`pages/api/recipe-image.ts` + Netlify Blobs + a 2s `refetchInterval` poll in
+   `pages/recipes/new.tsx`) is a fire-and-forget promise that *isn't guaranteed to
+   complete* on Lambda, since the container can be frozen after the response. Don't
+   extend that pattern to something that takes minutes and spends the user's money.
+
+   Since §2 already forces the browser onto the user's machine, this resolves itself:
+   the long-running part runs locally, and Big Shop only stores results.
+
+### Sketch of the flow
+
+```
+Big Shop list ──GET /shopping-list──> local runner (Playwright, persistent profile)
+                                          │
+              ┌───────────────────────────┤
+              │  for each item:           │
+              │   cached TPNC? ──yes──> add to basket
+              │        │no               │
+              │   search (full string +   │
+              │    pack size) → top 20 →  │
+              │    LLM re-rank →          │
+              │      confident? ──> add + cache mapping
+              │      unsure?    ──> review queue
+              └───────────────────────────┤
+                                          ▼
+                          report: added / review / not-found
+                                          ▼
+                     hand off: tesco.com/shop/en-GB/trolley
+                     (user books slot, checks, pays)
+```
+
+Pauses (login, slot booking) are handled by the runner being interactive and local —
+which is much simpler than the resumable server-side state machine you'd need for a
+hosted version.
+
+---
+
+## 8. Open questions worth answering before building
+
+1. **The T&C question (§0).** Personal tool, or product? If product, this doesn't ship
+   without Tesco's written consent, and that changes whether any of the below matters.
+2. **Does Tesco require a slot before adding items, or only at checkout?** Needs a real
+   account to test. Changes the state machine.
+3. **What does the "Add" control look like once an item is in the basket?** It becomes a
+   quantity stepper; setting quantity 3 is presumably click-add-three-times or type into
+   the stepper. Unverified — needs a logged-in session.
+4. **Does the basket survive between sessions on the same account?** Almost certainly
+   yes given there's no anonymous basket, but it's load-bearing for the handoff.
+5. **Clubcard prices** are shown as separate offers with validity windows tied to
+   *delivery date* ("Offer valid for delivery from 24/06/2026 until 25/08/2026"). If we
+   ever surface price, we'd be quoting a number that depends on a slot not yet booked.
+6. **Scope of the first version.** Given §5, I'd argue the highest-value thing isn't
+   auto-ordering at all — it's the **ingredient → product mapping**, built once
+   interactively. Auto-ordering on top of a confirmed mapping is comparatively easy;
+   auto-ordering on top of live search is a coin flip per item.
+
+---
+
+---
+
+# Part 2 — The rest of the field
+
+## 9. Landscape summary
+
+Every retailer was tested the same way: plain `curl` against a real search URL, then a
+real browser, then an anonymous add-to-basket, then a read of the terms.
+
+| Retailer | Plain `curl` | Bot defence | Anonymous basket | Structured data | T&C automation clause |
+|---|---|---|---|---|---|
+| **Ocado** | ✅ 200, 1.7MB SSR | AWS/CloudFront, not blocking reads | ✅ **works** | ⭐ Redux store, full entities | **None found** (62k chars) |
+| **Morrisons** | ✅ 200, 1.4MB SSR | same as Ocado | untested | ⭐ identical to Ocado | not found |
+| **Iceland** | ✅ 200, 2MB SSR | none seen | untested | unexamined | not found |
+| **Tesco** | ❌ 403 everything | Akamai Bot Manager | ❌ → login | JSON-LD only | ⛔ **explicit ban** |
+| **Sainsbury's** | ❌ 403 | Akamai Bot Manager | ❌ → login | unexamined | unexamined |
+| **Waitrose** | ❌ connection fails | Akamai | ❌ didn't add | `__PRELOADED_STATE__` | unexamined |
+| **Asda** | ❌ 403 | Cloudflare | untested | unexamined | ⛔ robots bans **ClaudeBot** by name |
+
+**There is no official ordering API anywhere in UK grocery.** Confirmed across sources:
+no OAuth, no REST, no webhooks, from any of Tesco, Sainsbury's, Asda, Morrisons or
+Ocado. Every working integration in existence is reverse-engineered.
+
+The field splits cleanly into two groups, and the split is not subtle.
+
+### The Akamai group — Tesco, Sainsbury's, Waitrose (+ Asda on Cloudflare)
+
+Effectively identical postures. Sainsbury's is Tesco with the names changed: same
+Akamai Bot Manager cookies (`_abck`, `bm_sz`, `bm_so`, `bm_sv`), same obfuscated
+rotating sensor beacon (`POST /1iEi9OjwQ0/dwGFIipPQJ/...`), 403 to `curl`, and adding
+to trolley signed-out redirects to `account.sainsburys.co.uk/gol/login`. Waitrose refuses
+`curl` at the connection layer entirely and didn't add anonymously either.
+
+**Asda deserves a specific call-out.** Its `robots.txt` carries Cloudflare Content
+Signals `search=yes, ai-train=no, use=reference`, and then explicitly disallows, by
+name: `ClaudeBot`, `GPTBot`, `CCBot`, `Google-Extended`, `Bytespider`, `Amazonbot`,
+`Applebot-Extended`, `meta-externalagent`, `CloudflareBrowserRenderingCrawler`. That is
+as clear a "no" to AI agents as a site can give without a lawyer. Asda is off the table.
+
+### The Ocado group — Ocado and Morrisons
+
+Morrisons runs the **Ocado Smart Platform**. Not "similar to" — identical: same
+`__INITIAL_STATE__` Redux shape, same `productEntities`, same `/products/<slug>/<id>`
+URLs, same `?q=` search param, same `robots.txt` structure down to the shared
+`# Internal URLs` comment. **One adapter covers both retailers.**
+
+And it's about to cover a third: **Asda announced in May 2026 that it is adopting
+Ocado's front-end webshop**, in-store fulfilment and last-mile software, rolling out
+from **2027**. So the OSP stack is on track to be *the* dominant UK online grocery
+platform — Ocado + Morrisons + Asda. An OSP adapter is the highest-leverage thing to
+build in this space, and it gets more valuable over time rather than less.
+
+---
+
+## 10. Ocado in detail — why it's a different proposition
+
+### It answers your obstacles far better than Tesco
+
+**Obstacle 6 (browser access).** Plain `curl` gets `200` and 1.7MB of server-rendered
+HTML from `https://www.ocado.com/search?q=olive+oil`. No Akamai, no fingerprint wall on
+reads. This is the constraint that forced everything else on Tesco, and on Ocado it
+simply isn't there for search and product data.
+
+**Obstacle 1 (auth).** **The anonymous basket works.** I added a product signed-out and
+the trolley went to £4.90 with a working quantity stepper — and it persisted across
+navigations. Tesco bounces you to login on the very first add; Ocado does not. Login is
+needed for slots and availability ("To see current availability and delivery slots,
+please log in or register to shop"), but *basket construction does not require it*.
+
+That reshapes the whole MVP. You can build the basket without ever touching the user's
+credentials, then hand off. What you can't do is transfer an anonymous basket to their
+account — that still needs them logged in — so the realistic flow is still
+"user is logged in, we fill the trolley", but the failure mode is far gentler.
+
+**Obstacle 4 (matching).** Two big wins.
+
+*Search relevance is simply better.* The query that broke Tesco worst — `olive oil`,
+which returned three brands of **olives** before any oil — returns nothing but olive oil
+on Ocado, top to bottom. `chicken breast` returned six clean, correct results.
+
+*And the product data is properly structured.* Each entity in `__INITIAL_STATE__`:
+
+```json
+{
+  "productId": "78bbc081-d803-4bb8-a9cc-1a7df31f08c7",
+  "retailerProductId": "654207011",
+  "name": "Mr Organic Extra Virgin Olive Oil",
+  "brand": "Mr Organic",
+  "available": true,
+  "size": { "value": "750ml" },
+  "categoryPath": ["Food Cupboard", "Oils, Fats & Vinegars", "Extra Virgin Olive Oil"],
+  "price": {
+    "current": { "amount": "11.50", "currency": "GBP" },
+    "original": { "amount": "14.50", "currency": "GBP" },
+    "unit": { "label": "fop.price.per.litre",
+              "current": { "amount": "15.33", "currency": "GBP" } }
+  },
+  "quantityInBasket": 0,
+  "featuredProductCampaign": { "source": "CITRUS_AD", "campaignName": "CitrusAdCampaign" }
+}
+```
+
+Compare what Tesco forced (§5): deriving pack weight from `price ÷ unitPrice`, parsing
+`4 X 400G` and `270G-470G` out of product titles, and no way at all to tell a sponsored
+placement from an organic result. Ocado hands you:
+
+- **`size.value`** — explicit pack size. The §5 title-parsing problem disappears.
+- **`categoryPath`** — a real taxonomy. You can constrain candidates to
+  `Oils, Fats & Vinegars` before ranking, which fixes the "garlic → marinara sauce"
+  class of error structurally rather than by asking an LLM to notice.
+- **`available`** — machine-readable stock status (obstacle 5).
+- **`price.unit.label`** — a typed unit (`per.litre`), not a string to regex.
+- **`featuredProductCampaign` / `CITRUS_AD`** — **sponsored results are labelled**, so
+  you can drop them. This was invisible on Tesco and was polluting its top slots.
+- **`quantityInBasket`** — basket state inline, so verification is free.
+
+This meaningfully shrinks the LLM's job. On Tesco the model had to do relevance,
+category sanity-checking, pack-size extraction *and* quantity maths from noisy strings.
+On Ocado it only has to pick between pre-filtered, correctly-categorised candidates
+whose sizes are already parsed.
+
+### The terms are materially different
+
+Ocado's consumer purchase T&Cs run to ~62,000 characters and contain **zero** matches
+for robot, spider, scrape, crawl, automated, bot, data mining or systematic access. The
+nearest relevant clause is:
+
+> You are permitted to use the material data and content only for your personal use in
+> placing orders through the Website, and you may not otherwise copy, reproduce,
+> transmit, publish, display, distribute, commercially exploit, use or create derivative
+> works of any material, data and content on the Website without our prior written
+> permission.
+
+Read carefully, this **affirmatively permits** the thing you want to do — "personal use
+in placing orders through the Website" — while restricting *republishing or commercially
+exploiting* the catalogue. It regulates what you do with the data, not how you access it.
+That is close to the opposite of Tesco's clause.
+
+**The caveat that follows from it:** a personal tool placing your own orders sits inside
+the permitted use. A hosted Big Shop feature that caches Ocado's catalogue across many
+users, or builds a product on their data, would run at "commercially exploit / create
+derivative works" and needs written permission. **The line here is personal-vs-commercial,
+not manual-vs-automated** — which is a much more workable line than Tesco's.
+
+### One honest complication: robots.txt
+
+Ocado's `robots.txt` allows product pages and publishes sitemaps, and — unlike Asda —
+does **not** block ClaudeBot or GPTBot. But under the heading
+`# Disallow user-specific, transactional, and low-value pages` it disallows exactly the
+paths this feature needs:
+
+```
+Disallow: /search
+Disallow: /basket
+Disallow: /lists
+Disallow: /favorites
+Disallow: /orders
+Disallow: /delivery/home/slots
+Disallow: /api/
+```
+
+I'd report this straight rather than spin it. Two things are true at once: these are the
+paths we'd use, and `robots.txt` is addressed to *crawlers* building indexes, with a
+stated rationale here of "low-value transactional pages" — i.e. crawl-budget management,
+not an anti-automation stance. Whether it binds a user-directed agent doing that user's
+own shopping is genuinely unsettled, and Ocado's own terms explicitly permit personal-use
+ordering. **That's my reading, not a legal opinion, and it's the weakest link in the
+Ocado case** — worth a lawyer's eye before anything ships publicly.
+
+Practical consequence: prefer `/products/<slug>/<id>` (allowed) over `/search`
+(disallowed) wherever the mapping is already known — which is exactly what the cached
+ingredient→product mapping from §5 gives you. Search is the cold path only.
+
+---
+
+## 11. Prior art
+
+[`abracadabra50/uk-grocery-cli`](https://github.com/abracadabra50/uk-grocery-cli) (MIT,
+~70 stars, active) is doing precisely this: multi-supermarket grocery automation for UK,
+explicitly "built for AI agents", with an MCP server. Its independently-reached
+conclusions match mine almost exactly:
+
+- "UK supermarkets offer zero APIs… none of them provide developer APIs."
+- Sainsbury's via reverse-engineered REST; Ocado via internal JSON API + SSR scraping;
+  Tesco via browser automation, with a warning that "Tesco uses Akamai bot detection,
+  which can block automated form filling."
+- Legal section restricts use to personal shopping, "not intended for commercial
+  scraping or data collection."
+
+One discrepancy worth noting: it describes Ocado as sitting behind AWS WAF bot
+detection, and reports slot booking and checkout as incomplete for that reason. My own
+testing found no blocking on **reads** — plain `curl` returned 200 throughout. Both can
+be true: the WAF may gate writes, or trigger on volume rather than on a single request.
+Treat "Ocado reads are open" as verified and "Ocado writes are open" as unverified.
+
+### 11.1 Why we should not simply adopt it
+
+Read at source (~5,800 LOC, MIT, `src/providers/`), four things disqualify it as a
+drop-in — though one part is well worth stealing.
+
+**1. It does not solve our actual problem.** There is **no ingredient→product matching
+logic anywhere in the codebase** — no ranking, no fuzzy matching, no pack-size or
+quantity reasoning, no confidence scoring. `docs/SMART-SHOPPING.md`, which sounds like
+it might be that, is a static markdown list of the "Dirty Dozen" for an LLM to read.
+The tool is pure transport: search, basket, slots, checkout. Everything in §5 — the part
+that's actually hard, and the part that determines whether the feature is any good —
+would still be ours to build.
+
+**2. Its `Product` type discards exactly what makes Ocado worth targeting.**
+`mapEntity()` in `src/providers/ocado.ts` flattens the rich entity down to
+`{name, price, unit_price, in_stock, size, rating}` and **drops `categoryPath` and
+`featuredProductCampaign`**. Those are two of the three reasons §10 recommends Ocado:
+the taxonomy that structurally fixes "garlic → marinara sauce", and the flag that lets
+us drop CitrusAd sponsored placements. As written, sponsored results come back as
+ordinary ranked products. It also sets `unit_price.measure` from `size.value` ("750ml")
+rather than the actual unit label (`per.litre`), conflating pack size with price basis.
+
+**3. Its Tesco support works by defeating bot detection.** `src/providers/tesco/auth.ts`
+uses `playwright-extra` with `puppeteer-extra-plugin-stealth`, plus
+`--disable-blink-features=AutomationControlled`. That is anti-detection tooling, and its
+whole purpose is to make automation not look like automation. Using someone else's
+evasion code does not change our position with respect to Tesco's explicit T&C ban (§0)
+— it just moves the evasion into a dependency. **§0's recommendation stands unchanged.**
+It also implements real checkout (`src/browser/tesco-checkout.ts`), placing live orders
+off regex-scraped page text like `/(?:order total|total)[:\s]*£(\d+\.?\d*)/i`.
+
+**4. Credential handling is incompatible with Big Shop.** It accepts passwords via a
+`--password` CLI flag (shell history, process listings), via `GROC_PASSWORD` /
+`SAINSBURYS_PASSWORD` env vars, and — most significantly — its MCP `grocery_login` tool
+takes `email` and `password` as **tool arguments**, so credentials pass through the
+agent's context window. Fine for a personal CLI you run yourself; not something to embed
+in a hosted product.
+
+**Maturity, for the record:** 51 commits, 32 of them in one burst in Feb 2026, then a
+trickle; effectively one contributor (33 of 51 commits); not published to npm (the
+`groc` package on npm is an unrelated documentation tool), so it installs from git.
+That's a thin single-maintainer dependency for code that spends the user's money.
+
+### 11.2 What to take from it
+
+The **Ocado provider is genuinely good and worth using as a reference** — it
+independently arrived at the same approach §10 describes: fetch the SSR listing page,
+extract `productEntities`, use DOM anchor order as the site's own ranking, and fail
+loudly when `productEntities` is absent because that means a WAF challenge or an expired
+session rather than zero results. That last detail is a nice touch we should copy.
+
+MIT licence means we can vendor and adapt it. The sensible use is: **take the Ocado
+fetch-and-parse approach, keep the fields it drops, write our own matching layer, and
+ignore the Tesco and checkout code entirely.**
+
+---
+
+## 12. Revised recommendation
+
+**Target Ocado, not Tesco.** On every axis that matters it's better: no bot wall on
+reads, an anonymous basket, structured product data with pack size and stock status,
+labelled sponsored results, better search relevance, and terms that permit personal-use
+ordering instead of banning automated access. One adapter also covers Morrisons today
+and, from 2027, Asda.
+
+Revised from §0's conclusion: the Tesco write-up recommended scoping to a local tool
+because the T&C clause and Akamai left no other option. **For Ocado the constraint is
+different in kind** — the line is personal vs. commercial use rather than manual vs.
+automated. A personal tool is comfortably inside their terms; a hosted multi-user
+product would need Ocado's written permission, and is worth actually asking for, since
+the ask is far more reasonable than the equivalent Tesco ask.
+
+Unchanged from Part 1: build the **cached ingredient→product mapping** first (§5). It
+matters even more here, because it keeps you on allowed `/products/` paths and off
+`/search`.
+
+Sequenced:
+
+1. **Ocado adapter, read-only.** Search → parse `__INITIAL_STATE__` → filter
+   `featuredProductCampaign` → constrain by `categoryPath` → rank. Verifiable against
+   the real site with no account and no writes.
+2. **Mapping table + review UI.** Confirm matches once, per ingredient, per account.
+3. **Basket writes**, in a real browser with the user's session. Verify the anonymous
+   basket finding still holds for a logged-in account, and check whether the WAF gates
+   writes (§11).
+4. **Hand off** at the trolley for slot and payment, exactly as Part 1 concluded.
+
+Do not build the Tesco adapter. Do not build Asda.
+
+### Still open
+
+- Does Ocado's WAF gate *writes*? (§11 discrepancy — the single most important unknown.)
+- Morrisons anonymous basket and T&Cs — untested; likely mirrors Ocado given shared platform.
+- Iceland — `curl`-accessible with 2MB SSR, but `robots.txt` disallows `/search`,
+  `/basket`, `/checkout`. Small range; probably not worth an adapter.
+- Ocado's £40 minimum spend and slot scarcity — product constraints, not technical ones.
+
+---
+
+## Sources
+
+**Part 1 — Tesco**
+- [Tesco General Terms & Conditions](https://www.tesco.com/shop/zone/general-terms-and-conditions) — the automated-access clause
+- [Online grocery shopping gets the Tesco API treatment | IT Pro](https://www.itpro.com/607668/online-grocery-shopping-gets-the-tesco-api-treatment)
+- [Tesco Labs Developer Portal](https://devportal.tescolabs.com/) — unmaintained, no ordering API
+
+**Part 2 — the field**
+- [Ocado T&Cs: Purchase (Consumer and Business Customers)](https://www.ocado.com/content/terms-conditions-purchase-consumer) — the personal-use clause
+- [Asda partners with Ocado Group to enhance online grocery service](https://corporate.asda.com/newsroom/2026/29/05/asda-partners-with-ocado-group-to-enhance-online-grocery-service) — front-end webshop, from 2027
+- [UK grocer Asda taps Ocado to revamp online business | Yahoo Finance](https://finance.yahoo.com/sectors/technology/articles/asda-taps-ocado-automation-uk-062358067.html)
+- [abracadabra50/uk-grocery-cli](https://github.com/abracadabra50/uk-grocery-cli) — MIT, prior art
+- [Supermarket Sweep: How APIs Are Shaking up Grocery | Nordic APIs](https://nordicapis.com/supermarket-sweep-how-apis-are-shaking-up-grocery-store-business-models/)
+- `robots.txt` for ocado.com, groceries.morrisons.com, groceries.asda.com, iceland.co.uk
+
+**Direct observation**
+- Live exploration of tesco.com (2026-07-28) and ocado.com, groceries.morrisons.com,
+  sainsburys.co.uk, waitrose.com, groceries.asda.com, iceland.co.uk (2026-07-29), all
+  unauthenticated. No account was logged into and no order was placed.


### PR DESCRIPTION
Design-only — no application code changes. Three ADRs and two specs.

This started as "set up an observability stack" and grew a second, larger conclusion: most of what made the observability design awkward — no collector sidecar available, a synchronous flush on every request, a permanent region choice driven by flush latency, a July 2027 deprecation deadline — was downstream of **the API being a Lambda**, not of anything about telemetry.

## The headline isn't observability

Netlify's functions run in `us-east-2` (region selection is Pro/Enterprise); TiDB is in `eu-central-1`. Every query is transatlantic at ~90ms, and the data-heavy paths issue several sequentially.

Moving the API into the same metro as its database is worth roughly **300–500ms per request** — an order of magnitude more than instrumentation was ever going to deliver, and something instrumenting the current setup would only have documented in detail.

It's also a small change: `main.go` already runs the same router as a plain `http.Server` in its `dev` branch, and the service is already containerized for docker-compose and e2e.

## What's here

| File | What it decides |
|---|---|
| `docs/adr/0006-go-api-leaves-netlify-functions.md` | Go API → Fly.io `fra`, proxied by Netlify via a 200 rewrite to stay same-origin |
| `docs/adr/0007-observability-otel-grafana-cloud.md` | OTel → Grafana Cloud Free `eu-central-1`; two asymmetric export paths; the exporter defaults that could take the site down |
| `docs/adr/0008-what-telemetry-does-not-carry.md` | Pseudonymous IDs but no content; no unbounded metric labels; no service-layer logging |
| `specs/api-hosting-migration.md` | The migration, phased. **Do this first** |
| `specs/observability.md` | The instrumentation, phased. Depends on the above |
| `follow-ups.md` #36 | Threshold alerting deferred until ~2 weeks of baseline data |

`CONTEXT.md` is deliberately unchanged — span, trace, exporter and temporality are general programming concepts, not Big Shop domain vocabulary, and the glossary excludes exactly that.

## Things worth knowing before implementing

- **Phase 0 of the migration gates everything.** Whether Netlify forwards `Authorization` through a 200 rewrite is undocumented, and the whole API is bearer-authenticated. An afternoon to settle with an echo service and a `curl`; the subdomain fallback is written up.
- **The OTLP exporter's defaults are dangerous on Lambda** — retries on, 10s per-attempt timeout. Left alone, a Grafana Cloud outage takes Big Shop down. ADR-0007 records the four mitigations.
- **`ci.yml` runs on `pull_request` only.** `go fmt`, `go test` and both drift checks currently live in `build.sh`, i.e. they run only in Netlify's deploy build. The spec moves them to CI *before* removing Go from Netlify, and adds a push trigger.
- Two pre-existing defects get fixed along the way: `app.go:170`'s `AllowedOrigins: {"*"}` with `AllowCredentials: true` (forbidden by the CORS spec), and `/health` returning `ok` unconditionally while claiming to serve uptime monitors.

## Known limitation, stated rather than hidden

Fly runs its own hardware; TiDB Cloud is on AWS. So `fra` and `eu-central-1` are the same **metro**, not the same provider network — ~1–5ms over Frankfurt peering rather than ~0.5–1ms intra-AWS. That's ~10–25ms of the ~500ms recovered, and buying it back would mean an AWS-native host that either costs materially more or hands back the ops burden. Recorded in ADR-0006.

Branch deploys also degrade: they'll proxy to the single production API instance rather than being a complete isolated stack. Accepted, and recorded in ADR-0006's consequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)