### PR TITLE
Rework the marketing page around what it's actually for

### DIFF
--- a/follow-ups.md
+++ b/follow-ups.md
@@ -95,3 +95,43 @@ Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are r
     in exactly that shape, so the stopgap is more load-bearing than it was — which
     sharpens the question of whether steps should be stored as structured data, rather
     than settling it.
+
+42. **Onboarding: the empty account, not the pitch, is what loses people.** Raised while
+    reviewing the marketing page (2026-08-06). The page itself now says the right things,
+    but the funnel behind it is: read the page → sign up through Auth0 → land in an
+    account holding **nothing**. Every claim the page makes — the adding-up, the aisle
+    order, "2 tins" — needs several Recipes to be visible at all, so the first session
+    delivers none of it and asks for data entry instead. No amount of copy fixes that;
+    this is where the work is.
+
+    A bucket rather than a single task. Two concrete pieces are worth doing first:
+
+    - **Let someone import a recipe before they have an account.** A URL box on the
+      logged-out homepage that runs the real extractor and shows what came back — name,
+      ingredients, method — with "save it" as the thing that triggers signup. It answers
+      the biggest unspoken objection ("will it work on the sites *I* use?") by letting
+      them test it rather than be told, and it means the first thing in the account is a
+      recipe they chose. `pages/api/parse-recipe-url.ts` already does the work; what is
+      missing is an unauthenticated path to it and, necessarily, rate limiting — it is an
+      LLM call on a public endpoint, so this cannot ship without a per-IP cap and a
+      sensible cost ceiling. It also needs a real failure state rather than silence: #40
+      is fixed, but #41 found 12 URLs the extractor still cannot read (dead links,
+      paywalls, bot protection), and a public try-it box that returns nothing at all for
+      one of those is worse than no box — it reads as "this doesn't work" on the one
+      screen where that conclusion is fatal.
+    - **Never show an empty collection.** Seed a new Account with a small set of good
+      Recipes — clearly marked as samples, deletable in one action — so the very first
+      thing a user can do is tick three boxes and see a real combined list. The seeding
+      mechanics already exist for local dev (`docker/mysql-seed/dev-seed.sql`); what does
+      not exist is a production path, or a decision on where the sample Recipes come from
+      and who owns them. Note the interaction with the Global Catalog: sample Recipes
+      create real Ingredient Lines, so whatever is chosen should use Ingredients that are
+      already well-curated rather than introducing new ones.
+
+    Other onboarding threads not designed yet, listed so they are not re-discovered:
+    what the first run of `/list` shows when nothing is selected; whether the invite flow
+    should be offered during onboarding rather than buried in `/account`, given that a
+    shared list is the strongest reason to keep using it; and whether the one-shot
+    onboarding screen in `pages/index.tsx` (shown once, then marked onboarded in the
+    background) is worth keeping at all if the two items above land — it currently exists
+    only to say "you're in" to someone who has nowhere to go yet.

--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -83,8 +83,7 @@
 }
 
 .logIn:focus-visible,
-.primary:focus-visible,
-.secondary:focus-visible {
+.primary:focus-visible {
   outline: 2px solid var(--spot);
   outline-offset: 3px;
 }
@@ -174,29 +173,20 @@
   transform: translateY(-1px);
 }
 
-.secondary {
-  font-family: inherit;
-  font-size: var(--text-base);
-  font-weight: 500;
-  color: var(--ink);
-  background: none;
-  border: 0;
-  border-bottom: 1px solid var(--rule);
-  border-radius: 0;
-  padding: 14px 2px;
-  cursor: pointer;
-  transition: border-color 0.18s ease, color 0.18s ease;
-}
-
-.secondary:hover {
-  color: var(--spot);
-  border-bottom-color: var(--spot);
-}
-
 .footnote {
-  font-size: var(--text-sm);
+  font-size: var(--text-base);
+  line-height: 1.55;
   color: var(--ink-soft);
+  max-width: 34em;
   margin: 0;
+}
+
+/* "Free" is the strongest word on the page and was previously set in the same
+   grey as the rest of the footnote. Full ink, and the heading face. */
+.free {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  color: var(--ink);
 }
 
 /* ---------- hero card ----------
@@ -329,6 +319,50 @@
   border-left: 2px solid var(--claret);
 }
 
+/* ---------- what it's actually for ----------
+   Sits between the hero and the Method, so it has to read as the reason for
+   what follows rather than as another feature grid. Deliberately unlike the
+   two-tier "fiddly bits" notes it could otherwise be confused with: no top
+   rules on each item, larger type, and a single hairline splitting the pair on
+   wide screens. */
+
+.whySection {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: clamp(var(--space-5), 4vw, 56px) clamp(var(--space-4), 5vw, 60px) clamp(var(--space-6), 6vw, 80px);
+  border-top: 1px solid var(--rule);
+}
+
+.why {
+  display: grid;
+  gap: var(--space-6);
+}
+
+.reasonTitle {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: clamp(26px, 3.4vw, 38px);
+  line-height: 1.08;
+  letter-spacing: -0.035em;
+  margin: 0 0 var(--space-3);
+  text-wrap: balance;
+}
+
+/* The admission is set back in soft ink so the claim after it carries the
+   weight - it's a concession, not half the headline. */
+.concession {
+  color: var(--ink-soft);
+  font-weight: 500;
+}
+
+.reasonBody {
+  font-size: var(--text-md);
+  line-height: 1.7;
+  color: var(--ink-soft);
+  margin: 0;
+  max-width: 46ch;
+}
+
 /* ---------- method ---------- */
 
 .methodSection,
@@ -420,9 +454,42 @@
 
 /* ---------- notes ---------- */
 
+/* Two tiers: the two reasons someone switches, set large and ruled like a
+   standfirst, then the four reassurance notes in the smaller hanging grid. */
+.leadNotes {
+  display: grid;
+  gap: var(--space-5) clamp(var(--space-5), 5vw, 70px);
+  margin-bottom: var(--space-6);
+}
+
+.leadNote {
+  border-top: 2px solid var(--ink);
+  padding-top: var(--space-3);
+}
+
+.leadNoteTitle {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: clamp(var(--text-lg), 2.6vw, 30px);
+  line-height: 1.12;
+  letter-spacing: -0.03em;
+  margin: 0 0 var(--space-2);
+  max-width: 18ch;
+}
+
+.leadNoteBody {
+  font-size: var(--text-md);
+  line-height: 1.65;
+  color: var(--ink-soft);
+  margin: 0;
+  max-width: 44ch;
+}
+
 .notes {
   display: grid;
   gap: var(--space-5) clamp(var(--space-5), 5vw, 70px);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--rule);
 }
 
 .noteTitle {
@@ -447,6 +514,78 @@
   max-width: 46ch;
 }
 
+/* ---------- colophon ----------
+   The print-page equivalent of an "about the publisher" note: who made this and
+   why it gets better with use. Set on the deeper paper so it reads as an aside
+   rather than another feature section. */
+
+.colophonSection {
+  background: var(--paper-deep);
+  border-block: 1px solid var(--rule);
+  padding: clamp(var(--space-6), 6vw, 80px) clamp(var(--space-4), 5vw, 60px);
+}
+
+.colophon {
+  display: grid;
+  gap: var(--space-5) clamp(var(--space-5), 5vw, 70px);
+  max-width: 1240px;
+  margin: 0 auto;
+}
+
+.colophonTitle {
+  font-family: var(--font-heading);
+  font-style: italic;
+  font-weight: 600;
+  font-size: clamp(var(--text-lg), 2.4vw, 26px);
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  margin: 0 0 var(--space-2);
+  color: var(--claret);
+}
+
+.colophonBody {
+  font-size: var(--text-base);
+  line-height: 1.7;
+  color: var(--ink-soft);
+  margin: 0;
+  max-width: 52ch;
+}
+
+/* ---------- questions ---------- */
+
+.questionsSection {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: clamp(var(--space-6), 6vw, 80px) clamp(var(--space-4), 5vw, 60px);
+}
+
+.questions {
+  display: grid;
+  gap: var(--space-5) clamp(var(--space-5), 5vw, 70px);
+  margin: 0;
+}
+
+.question {
+  padding-bottom: var(--space-4);
+  border-bottom: 1px dotted var(--rule);
+}
+
+.questionTitle {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: var(--text-md);
+  letter-spacing: -0.01em;
+  margin: 0 0 var(--space-2);
+}
+
+.questionBody {
+  font-size: var(--text-base);
+  line-height: 1.65;
+  color: var(--ink-soft);
+  margin: 0;
+  max-width: 52ch;
+}
+
 /* ---------- closer + footer ---------- */
 
 .closer {
@@ -467,6 +606,12 @@
 .closerHeading em {
   font-style: italic;
   color: var(--spot);
+}
+
+.closerFootnote {
+  font-size: var(--text-base);
+  color: var(--ink-soft);
+  margin: var(--space-4) 0 0;
 }
 
 .footer {
@@ -498,8 +643,29 @@
   .sources {
     grid-template-columns: repeat(3, 1fr);
   }
-  .notes {
+  .notes,
+  .leadNotes,
+  .colophon,
+  .questions {
     grid-template-columns: repeat(2, 1fr);
+  }
+  .why {
+    grid-template-columns: 1fr 1px 1fr;
+    /* Halved from the row gap: it lands on both sides of the 1px rule, so the
+       gap between the two texts is twice whatever is set here. */
+    column-gap: clamp(var(--space-4), 3vw, 44px);
+  }
+  /* Hairline between the pair, drawn as a grid track so it spans whichever of
+     the two columns is taller. */
+  .why::before {
+    content: '';
+    grid-column: 2;
+    grid-row: 1;
+    background: var(--rule);
+  }
+  .reason:last-child {
+    grid-column: 3;
+    grid-row: 1;
   }
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,11 +18,32 @@ import type { User } from '../types/models';
 // An already-onboarded user never sees any of it: the effect below redirects
 // them to /list, exactly as this page did before it was rewritten.
 
+// The two human needs underneath the mechanics: the deciding, and the buying
+// twice. Both are written as a concession followed by the real claim - saying
+// what it can't do first is what makes the second half believable, and it keeps
+// us off the two claims we can't back. We have no price data and no receipts,
+// so nothing here says "save money"; the money point is waste avoided, which is
+// mechanically true of combining, rather than savings earned, which isn't ours
+// to claim. Same for time: no minutes, because the time it gives back is spent
+// deciding, not chopping.
+const why = [
+  {
+    concession: 'It won’t do the cooking.',
+    claim: 'It’ll stop the deciding.',
+    body: 'Deciding is the part that actually takes the time. Everything you’ve liked before is in one place, tagged and searchable, so choosing five meals for the week is five ticks — not half an hour of “I don’t mind, what do you fancy?” on a Sunday night.',
+  },
+  {
+    concession: 'It doesn’t make food cheaper.',
+    claim: 'It stops you buying it twice.',
+    body: 'Three jars of cumin. A second bag of rice. The mid-week top-up trip that somehow costs forty quid. Buying for the whole week in one go, off a list that has already added everything up, is the cheap way to shop — this is the thing that makes actually doing it possible.',
+  },
+];
+
 const method = [
   {
     n: '01',
     title: 'Put a recipe in',
-    body: 'Paste a link from any recipe site, photograph a page of a cookbook, or type it out. It gets read, pulled apart into ingredients and method, and filed.',
+    body: 'Paste a link from any recipe site, photograph a page of a cookbook, or type it out. It’s read for you and comes back as ingredients, method and tags — ready to cook from, and ready to shop from.',
   },
   {
     n: '02',
@@ -32,34 +53,61 @@ const method = [
   {
     n: '03',
     title: 'Take the list to the shop',
-    body: 'Every ingredient across every chosen recipe, added up into one line each and sorted into the order you walk the aisles. Tick things off as they go in the trolley.',
+    body: 'Every ingredient across every chosen recipe, added up into one line each and sorted into the order you walk the aisles. Tick things off as they go in the trolley — and whoever else is shopping sees them go.',
+  },
+];
+
+// The two that actually make someone switch get the large treatment; the rest
+// are reassurance and sit in a smaller grid underneath.
+const leadNotes = [
+  {
+    title: 'Nobody comes home with a second bag of rice',
+    body: 'Invite whoever you shop with by email. Same recipes, same list, same ticked boxes — updating in both your pockets while you’re stood in different aisles.',
+  },
+  {
+    title: 'It does the adding up',
+    body: 'Three recipes wanting onions is one line saying how many onions. Where two amounts genuinely can’t be added — 50 g and 2 tbsp of flour — you get one line carrying both, not two lines to hunt for.',
   },
 ];
 
 const notes = [
   {
-    title: 'It does the adding up',
-    body: 'Three recipes wanting onions is one line saying how many onions. Where two amounts genuinely can’t be added — 50 g and 2 tbsp of flour — you get one line carrying both, not two lines to hunt for.',
-  },
-  {
     title: 'It knows what a tin is',
     body: 'A tin of chopped tomatoes is 400 g, a clove is 5 g, a potato is about 180 g. So the list says “2 tins”, which is a thing you can pick up, with the raw total kept alongside.',
   },
   {
-    title: 'One list per household',
-    body: 'Invite whoever you shop with by email. Same recipes, same list, same ticked boxes — so nobody comes home with a second bag of rice.',
-  },
-  {
-    title: 'Room for the non-recipe things',
+    title: 'Bin bags too',
     body: 'Bin bags, milk, the birthday card. Add extras straight to the list and they sit alongside everything the recipes asked for.',
   },
   {
-    title: 'Your own collection, searchable',
-    body: 'Everything you’ve saved in one place, searchable by name and filterable by tag — so “that lentil thing we had in March” is findable.',
+    title: '“That lentil thing we had in March”',
+    body: 'Everything you’ve saved in one place, searchable by name and filterable by tag — so the one you can only half remember is still findable.',
   },
   {
-    title: 'And Dave, if you’re stuck',
-    body: 'A chat that can only see your recipes. It remembers what you cooked recently and what you keep going back to, and will build the list for you.',
+    title: 'Ask what’s for dinner',
+    body: 'Dave only knows your kitchen — your recipes, what you cooked recently, what you keep going back to. Ask what to cook this week and it’ll build the list for you.',
+  },
+];
+
+// Objections in the order they actually occur to someone reading this page,
+// answered immediately before the last ask. Nothing here promises anything the
+// app doesn't already do - notably there is no export yet, so nothing claims one.
+const questions = [
+  {
+    q: 'Do I have to type all my recipes in?',
+    a: 'No. Paste a link and the page is read for you; photograph a cookbook and so is that. Typing is the fallback rather than the default — and even then you can paste the whole ingredient list in one lump instead of a row at a time.',
+  },
+  {
+    q: 'Will it work with the sites I use?',
+    a: 'It reads the page itself rather than following rules written for a handful of named sites, so it isn’t limited to a supported list. When a page does defeat it, what it did get still opens in the form and you fill in the rest.',
+  },
+  {
+    q: 'Can I share it with the person I shop with?',
+    a: 'Yes — invite them by email and you have one collection and one list between you, ticked boxes and all. That’s the whole point of it, not an extra.',
+  },
+  {
+    q: 'What does it cost?',
+    a: 'Nothing. There’s no card to enter, no trial counting down, and no plan to be upgraded to.',
   },
 ];
 
@@ -156,7 +204,7 @@ const Index = () => {
         <meta charSet="utf-8" />
         <meta
           name="description"
-          content="Big Shop keeps your recipes in one place and turns the ones you're cooking this week into a single shopping list - ingredients added up across every dish and sorted by aisle."
+          content="Big Shop keeps your recipes in one place and turns the ones you're cooking this week into a single shopping list - ingredients added up across every dish and sorted by aisle. Free, and shared with whoever you shop with."
         />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="theme-color" content="#faf5ee" />
@@ -189,7 +237,7 @@ const Index = () => {
         <main id="top">
           <section className={styles.hero}>
             <div className={styles.heroCopy}>
-              <p className={styles.eyebrow}>Recipes &amp; the weekly shop</p>
+              <p className={styles.eyebrow}>The shop you do every week</p>
               <h1 className={styles.display}>
                 Start with one recipe.
                 <br />
@@ -198,6 +246,7 @@ const Index = () => {
               <p className={styles.standfirst}>
                 Big Shop keeps your recipes together, and turns the ones you’ve chosen this week into a
                 single shopping list &mdash; ingredients added up across every dish and sorted by aisle.
+                One decision on Sunday, one trip, nothing bought twice.
               </p>
               {onboarding ? (
                 <div className={styles.actions}>
@@ -205,11 +254,16 @@ const Index = () => {
                 </div>
               ) : (
                 <>
+                  {/* One action only. Anyone who already has an account has the
+                      Log in button in the header, three inches up. */}
                   <div className={styles.actions}>
-                    <button type="button" className={styles.primary} onClick={signUp}>Get started</button>
-                    <button type="button" className={styles.secondary} onClick={logIn}>I already have an account</button>
+                    <button type="button" className={styles.primary} onClick={signUp}>Add your first recipe</button>
                   </div>
-                  <p className={styles.footnote}>Free. No app to install. Works on the phone in your hand at the shop.</p>
+                  <p className={styles.footnote}>
+                    <strong className={styles.free}>Free.</strong>{' '}
+                    No card, no app to install &mdash; it works on the phone that’s already in your
+                    hand at the shop.
+                  </p>
                 </>
               )}
             </div>
@@ -236,6 +290,20 @@ const Index = () => {
             </div>
           </section>
 
+          <section className={styles.whySection}>
+            <h2 className={styles.sectionHeading}>What it’s actually for</h2>
+            <div className={styles.why}>
+              {why.map((item) => (
+                <article key={item.claim} className={styles.reason}>
+                  <h3 className={styles.reasonTitle}>
+                    <span className={styles.concession}>{item.concession}</span> {item.claim}
+                  </h3>
+                  <p className={styles.reasonBody}>{item.body}</p>
+                </article>
+              ))}
+            </div>
+          </section>
+
           <section className={styles.methodSection}>
             <h2 className={styles.sectionHeading}>Method</h2>
             <ol className={styles.method}>
@@ -256,7 +324,7 @@ const Index = () => {
             <div className={styles.sources}>
               <article className={styles.source}>
                 <h3>A link</h3>
-                <p>Any recipe site. The page is read for you and comes back as name, ingredients, method and tags.</p>
+                <p>Any recipe site. The page is read for you and comes back as name, ingredients, method and tags &mdash; with American cups and ounces turned into grams on the way in.</p>
               </article>
               <article className={styles.source}>
                 <h3>A photograph</h3>
@@ -270,7 +338,15 @@ const Index = () => {
           </section>
 
           <section className={styles.notesSection}>
-            <h2 className={styles.sectionHeading}>Notes</h2>
+            <h2 className={styles.sectionHeading}>The fiddly bits</h2>
+            <div className={styles.leadNotes}>
+              {leadNotes.map((note) => (
+                <article key={note.title} className={styles.leadNote}>
+                  <h3 className={styles.leadNoteTitle}>{note.title}</h3>
+                  <p className={styles.leadNoteBody}>{note.body}</p>
+                </article>
+              ))}
+            </div>
             <div className={styles.notes}>
               {notes.map((note) => (
                 <article key={note.title} className={styles.note}>
@@ -279,6 +355,44 @@ const Index = () => {
                 </article>
               ))}
             </div>
+          </section>
+
+          <section className={styles.colophonSection}>
+            <div className={styles.colophon}>
+              <article>
+                <h2 className={styles.colophonTitle}>Built for one household’s weekly shop</h2>
+                {/* Deliberately no longer lists the pains - the "What it's
+                    actually for" band does that far better, and repeating them
+                    here made this read as a weaker second attempt. What's left
+                    is the thing that band can't say: who built it, and what it
+                    refuses to become. */}
+                <p className={styles.colophonBody}>
+                  There’s no growth team here, and no roadmap of things nobody asked for. It does
+                  recipes, and the list that falls out of them, and it does those properly. It isn’t
+                  going to become your calendar, your macros tracker or your fridge.
+                </p>
+              </article>
+              <article>
+                <h2 className={styles.colophonTitle}>It gets better as more people cook</h2>
+                <p className={styles.colophonBody}>
+                  How much a tin holds, what a potato weighs, which aisle a thing lives in &mdash;
+                  that’s one shared reference rather than something every kitchen re-enters. Worked
+                  out once, and every list after it is that bit more accurate.
+                </p>
+              </article>
+            </div>
+          </section>
+
+          <section className={styles.questionsSection}>
+            <h2 className={styles.sectionHeading}>Questions</h2>
+            <dl className={styles.questions}>
+              {questions.map((item) => (
+                <div key={item.q} className={styles.question}>
+                  <dt className={styles.questionTitle}>{item.q}</dt>
+                  <dd className={styles.questionBody}>{item.a}</dd>
+                </div>
+              ))}
+            </dl>
           </section>
 
           <section className={styles.closer}>
@@ -290,7 +404,12 @@ const Index = () => {
             {onboarding ? (
               <Link href="/list" className={styles.primary}>Start building your shopping list</Link>
             ) : (
-              <button type="button" className={styles.primary} onClick={signUp}>Get started</button>
+              <>
+                <button type="button" className={styles.primary} onClick={signUp}>Start with one recipe</button>
+                <p className={styles.closerFootnote}>
+                  <strong className={styles.free}>Free.</strong> One recipe is enough to make a list.
+                </p>
+              </>
             )}
           </section>
         </main>


### PR DESCRIPTION
## What

The logged-out homepage described what the software does and never what your week is like afterwards. Every claim on it was a mechanism — combining, aisle order, "2 tins" — which is why it was credible, and also why it never said anything a person wants.

The main addition is a **"What it's actually for"** band between the hero and the Method, carrying the two things Big Shop is really bought for: the deciding, and the buying twice.

> **It won't do the cooking.** It'll stop the deciding.
> **It doesn't make food cheaper.** It stops you buying it twice.

Both halves are concession-then-claim. Saying what it can't do first is what makes the second half believable, and it keeps the page off the two claims we can't back:

- **No money claim.** There's no price data, no receipts and no supermarket integration, so the money point is *waste avoided* — mechanically true of combining across recipes — rather than *savings earned*, which belongs to meal planning as a behaviour and not to us. It also avoids recruiting readers who then expect price comparison (`specs/supermarket-ordering-research.md` is unshipped).
- **No minutes.** The time it gives back is spent deciding, not chopping. "Saves you 40 minutes a week" is exactly the unfalsifiable line the rest of the page's specificity would collide with.

Both constraints are recorded as a comment above the copy so they survive the next edit.

## The rest — emphasis, not new material

- **One CTA in the hero, not two.** "I already have an account" duplicated the header's Log in button three inches away, and a second action of near-equal weight only slows the first one down. "Get started" → "Add your first recipe", naming a first step small enough to say yes to.
- **"Free" moves out of grey footnote text into full ink.** It's the strongest word on the page and it was set like a disclaimer.
- **The six equal Notes become two-tier.** The two reasons someone actually switches (one shared list; the adding up) set large, the four reassurance notes smaller underneath and retitled so they survive a skim.
- **New Questions section** answering the four objections in the order they occur, immediately before the last ask. It promises nothing the app doesn't do — notably there's no export yet, so nothing claims one.
- **New colophon**: who built it, what it won't become, and the fact that the shared catalogue makes every list after yours more accurate. That last one is a real consequence of [ADR-0001](../blob/master/docs/adr/0001-global-ingredient-catalog.md) and we'd never said it.
- Small truthful additions: URL import mentions cups and ounces coming back as grams; step 03 lands the shared-list benefit at the moment it's felt.
- Removes the now-dead `.secondary` button styles.

## Follow-up #42

The page can only do so much. The funnel behind it still lands a new user in an account holding **nothing**, where every claim made here needs several recipes before it's visible at all. Follow-up #42 records that as a bucket — public try-before-signup parsing, and seeding a new account so nobody ever sees an empty collection — along with the constraints found while looking (rate limiting an LLM call on a public endpoint; the interaction between sample recipes and the Global Catalog; the need for a real failure state, since #41 found 12 URLs the extractor still can't read even now #40 is fixed).

## Testing

`npm run typecheck`, `npm run lint`, `npm run test` (144 passing) and `npm run build` all clean. Reviewed rendered at 1280px and 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
