### PR TITLE
Keep every ingredient, and group pantry staples on the list instead

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,6 +71,14 @@ A quantity paired with a Unit ("400 gram", "2 tablespoon"). An Ingredient Line c
 **Shopping Precision**:
 The rounding a Shopping List Amount is shown at — the list is an instruction to someone in a shop, not the result of a calculation, so "4.444444 teaspoon" is arithmetically honest and useless. The Unit picks the granularity, and anything not weighed on a scale rounds *up*, since rounding down means going home without enough: a Relative Unit to a whole (you can't buy 1.75 tins), a measuring spoon to a quarter (a cook can measure ¼ tsp, not 0.3 tsp), and a weight or volume to nearest at a precision scaled to its size — never so coarse that a real amount rounds away to zero. Applied once, when the list is read, so the stored totals stay exact.
 
+**Pantry Staple**:
+A near-universal store-cupboard basic — salt, pepper, cooking oil, flour, butter, sugar — that the Shopping List groups into its own collapsed section instead of listing among the things you actually went out for. A property of the Ingredient (`ingredient.pantry_staple`), not of an Amount: a staple is a staple whatever quantity a Recipe calls for.
+
+Purely presentational, and deliberately so. Recipe Import used to solve the same problem by omitting these from the Recipe outright whenever the amount looked like seasoning, which made a Recipe permanently wrong about its own contents and — the reason it changed — looked exactly like a failed extraction from the cook's side. Now every Ingredient reaches the Recipe and the list, the flag is applied when the list is read (so flagging an Ingredient improves a list already generated), and the shopper is always shown the group and its count.
+
+Whether the group is open is a **per-User** preference (`user.show_pantry_staples`), not per-Account: the Shopping List is shared, but two people shopping off one list needn't agree about whether the salt is showing. The browser also caches it in `localStorage` and paints from that, so the first render never waits on a request — the server is the source of truth, the cache is only what makes it instant. See `hooks/use-synced-flag.ts`.
+_Avoid_: Pantry Item, Basic (neither says it's still on the list, only grouped)
+
 **Department**:
 The aisle-style grouping a Shopping List Item is shown under (e.g. "vegetables", "meat and fish", "other"). One per Ingredient (many-to-one), not many-to-many — the join table (`ingredient_department`) is looser than this rule today, which is a defect (an Ingredient with two Department rows would silently duplicate that Ingredient Line wherever it's read), not an intended feature.
 
@@ -83,6 +91,10 @@ _Avoid_: Scraping (see URL Import — the old per-site scraper approach this rep
 - **Photo Import**: user uploads a photo of a recipe; GPT-4 Vision extracts it as a Processing Job, since the extraction call runs too long for a synchronous Lambda response.
 - **Manual Entry**: user fills fields directly — but can still paste freeform multiline ingredient text into a bulk box that gets LLM-parsed into structured Ingredient Lines, rather than typing one row per ingredient.
 _Avoid_: Camera (UI label for Photo Import's tab; "Photo Import" is the canonical term)
+
+The bulk box is an **explicit enumeration**, and the extractor is told so (`source: 'ingredient-list'`, `lib/recipe-import/paste.js`): every non-blank line comes back as an Ingredient Line, and none of it is a title or a method. URL and Photo Import are the opposite — a whole page or photo to find the recipe inside — so they alone get the rules for picking a title and method out of surrounding noise. Applying those to the bulk box loses lines the cook deliberately typed: a first line reading "Jerk marinade: 120ml" gets taken as the dish's name, and the route keeps only `ingredients`, so it vanishes with nothing shown.
+
+**No Import Source omits an Ingredient.** Extraction proposes `pantryStaple` alongside the other catalog metadata; grouping is the Shopping List's job (see Pantry Staple).
 
 **Processing Job**:
 The async unit of work behind Photo Import specifically (not used by URL Import or Manual Entry, which respond synchronously). The client polls for completion rather than waiting on one request, because Netlify Functions' Lambda-based execution can't hold a request open long enough for a Vision call to finish.

--- a/components/recipe-form/Form.test.tsx
+++ b/components/recipe-form/Form.test.tsx
@@ -162,6 +162,40 @@ describe('Form', () => {
     expect(screen.getByLabelText('Ingredients')).toHaveValue('');
   });
 
+  // Rules the client out of the "pasted six lines, got three" report: whatever
+  // the route returns is appended in full, and a repeat parse adds to the list
+  // rather than replacing it. The ingredients that went missing were never in
+  // the response - see lib/recipe-import/extract.test.ts.
+  it('appends every ingredient the route returns, across repeated parses', async () => {
+    mockedNextApiPost.mockResolvedValueOnce({
+      ingredients: [
+        { name: 'tomato ketchup', quantity: '120', unit: 'millilitre' },
+        { name: 'pineapple juice', quantity: '120', unit: 'millilitre' },
+        { name: 'soy sauce', quantity: '100', unit: 'millilitre' }
+      ]
+    });
+    await renderForm();
+
+    await userEvent.type(screen.getByLabelText('Ingredients'), 'Tomato ketchup: 120ml');
+    await userEvent.click(screen.getByText('Parse ingredients'));
+    await waitFor(() => expect(screen.getByText('soy sauce')).toBeInTheDocument());
+
+    mockedNextApiPost.mockResolvedValueOnce({
+      ingredients: [
+        { name: 'jerk marinade', quantity: '120', unit: 'millilitre' },
+        { name: 'brown sugar', quantity: '20', unit: 'gram' },
+        { name: 'oil', quantity: '22.5', unit: 'millilitre' }
+      ]
+    });
+    await userEvent.type(screen.getByLabelText('Ingredients'), 'Jerk marinade: 120ml');
+    await userEvent.click(screen.getByText('Parse ingredients'));
+
+    await waitFor(() => expect(screen.getByText('oil')).toBeInTheDocument());
+    for (const name of ['tomato ketchup', 'pineapple juice', 'soy sauce', 'jerk marinade', 'brown sugar']) {
+      expect(screen.getByText(name)).toBeInTheDocument();
+    }
+  });
+
   it('shows an error and keeps the typed text when bulk parsing fails', async () => {
     mockedNextApiPost.mockRejectedValue(new Error('Could not parse that'));
     await renderForm();

--- a/components/recipe-form/Form.tsx
+++ b/components/recipe-form/Form.tsx
@@ -205,13 +205,14 @@ export default function Form({initialRecipe = {}, mode = 'new'}: FormProps) {
   // while writing a recipe, and the server ignores them for any ingredient that
   // already has values.
   function appendIngredients(parsedIngredients: Partial<Ingredient>[]) {
-    const newIngredients = parsedIngredients.map(({ name, quantity, unit, baseUnit, displayUnit, unitSizes }) => ({
+    const newIngredients = parsedIngredients.map(({ name, quantity, unit, baseUnit, displayUnit, unitSizes, pantryStaple }) => ({
       name: (name || '').trim(),
       quantity: quantity || '',
       unit: unit || '',
       ...(baseUnit ? { baseUnit } : {}),
       ...(displayUnit !== undefined && displayUnit !== null ? { displayUnit } : {}),
       ...(unitSizes ? { unitSizes } : {}),
+      ...(pantryStaple ? { pantryStaple } : {}),
     }));
     setRecipe(prevRecipe => ({
       ...prevRecipe,

--- a/components/shopping-list/ShoppingList/index.module.css
+++ b/components/shopping-list/ShoppingList/index.module.css
@@ -23,6 +23,60 @@
   border-bottom: 1px solid var(--rule);
 }
 
+/* The staples group sits between the list proper and "Already bought": still
+   part of the list, visibly set apart from the things you actually came for. */
+.staplesContainer {
+  margin-top: var(--space-5);
+}
+
+.staplesToggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2) var(--space-2);
+  margin: 0 calc(var(--space-2) * -1);
+  width: calc(100% + var(--space-4));
+  border: none;
+  background: none;
+  border-bottom: 1px solid var(--rule);
+  border-radius: 2px;
+  cursor: pointer;
+  font-family: var(--font-heading);
+  font-size: var(--text-md);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--claret);
+  text-align: left;
+  transition: background-color 0.12s ease;
+}
+
+.staplesToggle:hover {
+  background: var(--paper-deep);
+}
+
+.staplesHint {
+  margin-left: auto;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: 400;
+  color: var(--ink-soft);
+}
+
+.staplesChevron {
+  flex-shrink: 0;
+  width: 0;
+  height: 0;
+  border-left: 5px solid currentColor;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  transition: transform 0.12s ease;
+}
+
+.staplesChevronOpen {
+  transform: rotate(90deg);
+}
+
 .item {
   display: flex;
   align-items: center;

--- a/components/shopping-list/ShoppingList/index.test.tsx
+++ b/components/shopping-list/ShoppingList/index.test.tsx
@@ -1,8 +1,51 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { createElement, type ComponentProps, type ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import ShoppingList from './index';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ListIngredient } from '../../../types/models';
+
+vi.mock('@hooks/use-auth', () => ({ default: vi.fn() }));
+// Mocked at the transport boundary, so the real useQuery/useMutation machinery
+// still runs - the same shape as components/recipe-form/Form.test.tsx.
+vi.mock('../../../lib/api-client', () => ({
+  apiGet: vi.fn(),
+  apiPatch: vi.fn()
+}));
+
+import useAuth from '@hooks/use-auth';
+import { apiGet, apiPatch } from '../../../lib/api-client';
+import ShoppingList from './index';
+
+const mockedUseAuth = useAuth as unknown as Mock;
+const mockedApiGet = apiGet as unknown as Mock;
+const mockedApiPatch = apiPatch as unknown as Mock;
+
+beforeEach(() => {
+  // The staples toggle caches in localStorage, so tests would otherwise leak
+  // their expanded state into each other.
+  window.localStorage.clear();
+  mockedUseAuth.mockReturnValue({
+    isAuthenticated: true,
+    getAccessTokenSilently: vi.fn(async () => 'test-token')
+  });
+  // The server always states the preference, including when it is false (it's
+  // a *bool in the Go type for exactly that reason) - so the mock does too. A
+  // mock that omitted it would hide the race the reconciliation guard exists
+  // to prevent, since an absent value makes the effect bail out early.
+  mockedApiGet.mockResolvedValue({ id: 'u1', email: 'a@b.c', showPantryStaples: false });
+  mockedApiPatch.mockImplementation(async (_path, _token, body) => ({ id: 'u1', email: 'a@b.c', ...(body as object) }));
+});
+
+// A fresh QueryClient per render keeps the ['user'] cache from bleeding
+// between tests.
+function renderList(props: ComponentProps<typeof ShoppingList>) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+  return render(<ShoppingList {...props} />, { wrapper: Wrapper });
+}
 
 // Extra Items carry no Amounts and placeholder department/recipe_id values in
 // the real API (see CONTEXT.md's Shopping List Item entry) - this mirrors
@@ -14,7 +57,7 @@ const ingredient = (overrides: Partial<ListIngredient> = {}): ListIngredient => 
 
 describe('ShoppingList', () => {
   it('shows an empty-basket illustration and no clear button when there is nothing to buy', () => {
-    render(<ShoppingList shoppingList={{}} extras={{}} buyIngredient={() => {}} clearList={() => {}} />);
+    renderList({ shoppingList: {}, extras: {}, buyIngredient: () => {}, clearList: () => {} });
 
     expect(screen.getByRole('img', { name: /empty shopping basket/i })).toBeInTheDocument();
     expect(screen.getByText(/your shopping list is empty/i)).toBeInTheDocument();
@@ -23,14 +66,12 @@ describe('ShoppingList', () => {
 
   it('lists unbought ingredients and extras, and calls buyIngredient with name/type on click', async () => {
     const buyIngredient = vi.fn();
-    render(
-      <ShoppingList
-        shoppingList={{ chicken: ingredient({ amounts: [{ quantity: '1', unit: 'kg' }], department: 'meat and fish' }) }}
-        extras={{ beer: ingredient() }}
-        buyIngredient={buyIngredient}
-        clearList={() => {}}
-      />
-    );
+    renderList({
+      shoppingList: { chicken: ingredient({ amounts: [{ quantity: '1', unit: 'kg' }], department: 'meat and fish' }) },
+      extras: { beer: ingredient() },
+      buyIngredient,
+      clearList: () => {}
+    });
 
     expect(screen.getByText('chicken')).toBeInTheDocument();
     expect(screen.getByText('beer')).toBeInTheDocument();
@@ -44,17 +85,15 @@ describe('ShoppingList', () => {
   });
 
   it('separates bought ingredients/extras into an "Already bought" section', () => {
-    render(
-      <ShoppingList
-        shoppingList={{
-          chicken: ingredient({ amounts: [{ quantity: '1', unit: 'kg' }], department: 'meat and fish' }),
-          rice: ingredient({ amounts: [{ quantity: '300', unit: 'gram' }], department: 'other', isBought: true })
-        }}
-        extras={{ beer: ingredient({ isBought: true }) }}
-        buyIngredient={() => {}}
-        clearList={() => {}}
-      />
-    );
+    renderList({
+      shoppingList: {
+        chicken: ingredient({ amounts: [{ quantity: '1', unit: 'kg' }], department: 'meat and fish' }),
+        rice: ingredient({ amounts: [{ quantity: '300', unit: 'gram' }], department: 'other', isBought: true })
+      },
+      extras: { beer: ingredient({ isBought: true }) },
+      buyIngredient: () => {},
+      clearList: () => {}
+    });
 
     expect(screen.getByText('Already bought')).toBeInTheDocument();
     const boughtSection = screen.getByText('Already bought').closest('div');
@@ -64,34 +103,172 @@ describe('ShoppingList', () => {
   });
 
   it('groups items sharing a department together rather than interleaving them', () => {
-    render(
-      <ShoppingList
-        shoppingList={{
-          carrot: ingredient({ amounts: [{ quantity: '2', unit: '' }], department: 'vegetables' }),
-          potato: ingredient({ amounts: [{ quantity: '1', unit: 'kg' }], department: 'vegetables' }),
-          chicken: ingredient({ amounts: [{ quantity: '1', unit: 'kg' }], department: 'meat and fish' })
-        }}
-        extras={{}}
-        buyIngredient={() => {}}
-        clearList={() => {}}
-      />
-    );
+    renderList({
+      shoppingList: {
+        carrot: ingredient({ amounts: [{ quantity: '2', unit: '' }], department: 'vegetables' }),
+        potato: ingredient({ amounts: [{ quantity: '1', unit: 'kg' }], department: 'vegetables' }),
+        chicken: ingredient({ amounts: [{ quantity: '1', unit: 'kg' }], department: 'meat and fish' })
+      },
+      extras: {},
+      buyIngredient: () => {},
+      clearList: () => {}
+    });
 
     const names = screen.getAllByRole('listitem').map(li => li.textContent ?? '');
     const vegetableIndices = ['carrot', 'potato'].map(name => names.findIndex(t => t.includes(name)));
     expect(Math.abs(vegetableIndices[0] - vegetableIndices[1])).toBe(1);
   });
 
+  // Pantry staples. The behaviour these lock in is the fix for a real
+  // complaint: Recipe Import used to drop salt/oil/sugar from a Recipe outright,
+  // which is indistinguishable from a failed extraction. They now reach the
+  // Shopping List like anything else and are grouped, never silently absent.
+  describe('pantry staples', () => {
+    const listWithStaples = {
+      chicken: ingredient({ amounts: [{ quantity: '1', unit: 'kg' }], department: 'meat and fish' }),
+      'olive oil': ingredient({ amounts: [{ quantity: '30', unit: 'millilitre' }], pantryStaple: true }),
+      salt: ingredient({ amounts: [{ quantity: '1', unit: 'pinch' }], pantryStaple: true })
+    };
+
+    const renderStaples = () => renderList({
+      shoppingList: listWithStaples, extras: {}, buyIngredient: () => {}, clearList: () => {}
+    });
+
+    it('keeps staples out of the main list but always says how many there are', () => {
+      renderStaples();
+
+      // The count is the point: hidden is fine, invisible is not.
+      expect(screen.getByRole('button', { name: /pantry staples \(2\)/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /pantry staples/i })).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.getByText('chicken')).toBeInTheDocument();
+    });
+
+    it('reveals the staples on click and keeps them in their own group', async () => {
+      renderStaples();
+      const toggle = screen.getByRole('button', { name: /pantry staples/i });
+
+      await userEvent.click(toggle);
+
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+      const group = document.getElementById('pantry-staples');
+      expect(group).toHaveTextContent('olive oil');
+      expect(group).toHaveTextContent('salt');
+      // Shown, but still not shuffled in among the things you came for.
+      expect(group).not.toHaveTextContent('chicken');
+    });
+
+    it('remembers the choice across a remount', async () => {
+      const { unmount } = renderStaples();
+      await userEvent.click(screen.getByRole('button', { name: /pantry staples/i }));
+      unmount();
+
+      renderStaples();
+
+      expect(screen.getByRole('button', { name: /pantry staples/i })).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    // The preference is stored on the User but painted from localStorage, so
+    // the first render never waits on a request. These pin down the contract
+    // between the two halves (hooks/use-synced-flag.ts).
+    it('saves the choice to the server as well as locally', async () => {
+      renderStaples();
+
+      await userEvent.click(screen.getByRole('button', { name: /pantry staples/i }));
+
+      await waitFor(() => expect(mockedApiPatch).toHaveBeenCalledWith(
+        '/user/preferences', 'test-token', { showPantryStaples: true }
+      ));
+      expect(window.localStorage.getItem('bigshop:show-pantry-staples')).toBe('true');
+    });
+
+    // Regression: between the click and the save resolving, the cache is ahead
+    // of the server on purpose. The first version of this hook reconciled
+    // whenever the two merely *differed*, so it reverted the toggle the instant
+    // you pressed it and flipped it back when the response arrived. Whether you
+    // saw it depended on a race with the request, so it passed locally and
+    // failed in e2e.
+    it('does not revert the toggle while the save is still in flight', async () => {
+      let resolveSave: (v: unknown) => void = () => {};
+      mockedApiPatch.mockReturnValue(new Promise(resolve => { resolveSave = resolve; }));
+      renderStaples();
+      const toggle = screen.getByRole('button', { name: /pantry staples/i });
+      // Let the server's "false" land first, so the stale value is in the cache
+      // and available to reconcile against.
+      await waitFor(() => expect(mockedApiGet).toHaveBeenCalled());
+
+      await userEvent.click(toggle);
+
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+      // Still open a tick later, with the request unresolved.
+      await new Promise(r => setTimeout(r, 20));
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+      resolveSave({ id: 'u1', email: 'a@b.c', showPantryStaples: true });
+      await waitFor(() => expect(toggle).toHaveAttribute('aria-expanded', 'true'));
+    });
+
+    // The reason for the localStorage layer at all: a preference read only from
+    // the server paints the default first and flips once the request lands,
+    // every visit, for everyone who chose the non-default.
+    it('paints the cached choice immediately, before the server answers', () => {
+      window.localStorage.setItem('bigshop:show-pantry-staples', 'true');
+      // Never resolves - the first paint must not be waiting on it.
+      mockedApiGet.mockReturnValue(new Promise(() => {}));
+
+      renderStaples();
+
+      expect(screen.getByRole('button', { name: /pantry staples/i })).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    // ...and the reason the server is still the source of truth: a choice made
+    // on another device has to arrive here. This is the one case where a flip
+    // is correct, because the value genuinely changed elsewhere.
+    it('adopts the server value when it disagrees with the local cache', async () => {
+      window.localStorage.setItem('bigshop:show-pantry-staples', 'false');
+      mockedApiGet.mockResolvedValue({ id: 'u1', email: 'a@b.c', showPantryStaples: true });
+
+      renderStaples();
+
+      await waitFor(() => expect(
+        screen.getByRole('button', { name: /pantry staples/i })
+      ).toHaveAttribute('aria-expanded', 'true'));
+      // Written back, so the next paint on this device is right first time.
+      expect(window.localStorage.getItem('bigshop:show-pantry-staples')).toBe('true');
+    });
+
+    // GET /user 404s for someone who reached the list before POST /user ever
+    // ran. Not a fault - there is simply nothing recorded, and the local value
+    // stands rather than being reset.
+    it('keeps the local choice when the server has no user to read', async () => {
+      window.localStorage.setItem('bigshop:show-pantry-staples', 'true');
+      mockedApiGet.mockRejectedValue(new Error('404'));
+
+      renderStaples();
+
+      await waitFor(() => expect(mockedApiGet).toHaveBeenCalled());
+      expect(screen.getByRole('button', { name: /pantry staples/i })).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('shows no staples group when nothing on the list is one', () => {
+      renderList({
+        shoppingList: { chicken: ingredient({ amounts: [{ quantity: '1', unit: 'kg' }] }) },
+        extras: {},
+        buyIngredient: () => {},
+        clearList: () => {}
+      });
+
+      expect(screen.queryByRole('button', { name: /pantry staples/i })).not.toBeInTheDocument();
+    });
+  });
+
   it('shows the clear-list control whenever there is anything on the list', async () => {
     const clearList = vi.fn();
-    render(
-      <ShoppingList
-        shoppingList={{ chicken: ingredient({ amounts: [{ quantity: '1', unit: 'kg' }], department: 'meat and fish' }) }}
-        extras={{}}
-        buyIngredient={() => {}}
-        clearList={clearList}
-      />
-    );
+    renderList({
+      shoppingList: { chicken: ingredient({ amounts: [{ quantity: '1', unit: 'kg' }], department: 'meat and fish' }) },
+      extras: {},
+      buyIngredient: () => {},
+      clearList
+    });
 
     expect(screen.getByText(/clear list and start over/i)).toBeInTheDocument();
   });

--- a/components/shopping-list/ShoppingList/index.tsx
+++ b/components/shopping-list/ShoppingList/index.tsx
@@ -4,7 +4,23 @@ import ClearList from './clear-list';
 import PageHeading from '@components/page-heading';
 import EmptyState from '@components/empty-state';
 import EmptyBasketIllustration from '@components/svg/empty-basket';
-import type { ListIngredient } from '../../../types/models';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import useSyncedFlag from '@hooks/use-synced-flag';
+import useUser from '@hooks/use-user';
+import useAuth from '@hooks/use-auth';
+import { apiPatch } from '../../../lib/api-client';
+import { queryKeys } from '../../../lib/query-keys';
+import type { ListIngredient, User } from '../../../types/models';
+
+// Per User, not per Account: the Shopping List itself is shared - you and
+// whoever you share it with see the same items - but whether the salt is
+// showing is about the list in your hand. Two people shopping off one list
+// shouldn't have to agree.
+//
+// Kept in localStorage as well as on the server, so the first paint is right
+// without waiting for a request. See use-synced-flag.ts for why the server is
+// still the source of truth.
+const SHOW_STAPLES_KEY = 'bigshop:show-pantry-staples';
 
 // Shopping order: non-perishables first, vegetables last since they bruise
 // if left sitting in the trolley/bags. Departments not in this list (or a
@@ -28,14 +44,51 @@ interface ShoppingListProps {
 }
 
 const ShoppingList = ({ shoppingList, extras, buyIngredient, clearList }: ShoppingListProps) => {
+  const user = useUser();
+  const { getAccessTokenSilently } = useAuth();
+  const queryClient = useQueryClient();
+
+  // Writes the preference through and seeds the cache with what came back, so
+  // the ['user'] query and localStorage agree without a refetch. No
+  // invalidation: the response *is* the new state, and re-reading it would only
+  // reintroduce the round trip this whole arrangement exists to paint through.
+  const preferenceMutation = useMutation({
+    mutationFn: async (showPantryStaples: boolean) => {
+      const token = await getAccessTokenSilently();
+      return apiPatch<User>('/user/preferences', token, { showPantryStaples });
+    },
+    onSuccess: (saved) => queryClient.setQueryData(queryKeys.user, saved),
+    // A view preference is not worth surfacing an error for: the toggle has
+    // already moved, and the next load reconciles against the server.
+    onError: (e) => console.error(e)
+  });
+
+  const [showStaples, setShowStaples] = useSyncedFlag(
+    SHOW_STAPLES_KEY,
+    false,
+    user?.showPantryStaples,
+    (next) => preferenceMutation.mutate(next)
+  );
 
   const boughtItems = Object.keys(shoppingList).filter((name => shoppingList[name].isBought));
   const boughtExtras = Object.keys(extras).filter((name => extras[name].isBought));
   const hasListItems = !!Object.keys(shoppingList).length || !!Object.keys(extras).length;
   const hasBoughtItems = !!boughtItems.length || !!boughtExtras.length;
 
-  const ingredients = Object.keys(shoppingList)
-    .filter((name => !shoppingList[name].isBought))
+  // Pantry staples split out of the main list rather than being filtered away.
+  // The server sends every Item and marks the staples (MarkPantryStaples in the
+  // Go API), so the toggle is instant and, crucially, the shopper can always see
+  // that the things exist. Recipe Import used to drop them from the Recipe
+  // outright, which was indistinguishable from having lost them.
+  //
+  // Staples stay grouped even with the toggle on: "show me the salt" is not the
+  // same as "shuffle the salt in among the things I actually came for".
+  const unbought = Object.keys(shoppingList).filter(name => !shoppingList[name].isBought);
+  const ingredients = unbought
+    .filter(name => !shoppingList[name].pantryStaple)
+    .sort(sortByDepartment(shoppingList));
+  const staples = unbought
+    .filter(name => shoppingList[name].pantryStaple)
     .sort(sortByDepartment(shoppingList));
 
   return (
@@ -64,6 +117,35 @@ const ShoppingList = ({ shoppingList, extras, buyIngredient, clearList }: Shoppi
           <Item type='extra' name={name} bought={false} handleClick={buyIngredient} key={i}/>
         ))}
       </ul>
+      {
+        !!staples.length && (
+          <div className={styles.staplesContainer}>
+            {/* A real button rather than <details>: the open state has to come
+                from localStorage so it survives a reload, and <details> owns
+                that itself. aria-expanded/aria-controls give it the same
+                semantics. */}
+            <button
+              type="button"
+              className={styles.staplesToggle}
+              aria-expanded={showStaples}
+              aria-controls="pantry-staples"
+              onClick={() => setShowStaples(!showStaples)}
+            >
+              <span className={`${styles.staplesChevron} ${showStaples ? styles.staplesChevronOpen : ''}`} aria-hidden="true" />
+              Pantry staples ({staples.length})
+              <span className={styles.staplesHint}>{showStaples ? 'hide' : 'show'}</span>
+            </button>
+            {/* Rendered either way so the count above is never the only evidence
+                these exist, and so a screen reader's tab order doesn't change
+                shape when the group opens. */}
+            <ul className={styles.shoppingList} id="pantry-staples" hidden={!showStaples}>
+              { staples.map((name, i) => (
+                <Item type='ingredient' name={name} item={shoppingList[name]} bought={false} handleClick={buyIngredient} key={i}/>
+              ))}
+            </ul>
+          </div>
+        )
+      }
       {
         hasBoughtItems && (
           <div className={styles.boughtContainer}>

--- a/docker/mysql-seed/dev-seed.sql
+++ b/docker/mysql-seed/dev-seed.sql
@@ -70,6 +70,20 @@ WHERE name = 'Black Pepper';
 UPDATE `ingredient` SET curated = TRUE
 WHERE name IN ('Olive Oil', 'Onion', 'Carrot', 'Chopped Tomatoes', 'Garlic Clove', 'Black Pepper');
 
+-- Pantry staples, mirroring migration 032 - inline for the same reason. Two of
+-- the ten seeded Ingredients, which is enough for the Shopping List's staples
+-- group to have something in it locally and in e2e: without any flagged rows
+-- the grouping is unreachable, and its tests would pass just as happily with
+-- the feature deleted.
+--
+-- Black Pepper is deliberately NOT flagged, even though migration 032 flags it
+-- in production. It is this seed's density/Display Unit exemplar - the one
+-- ingredient that exercises grams-through-a-density-back-into-teaspoons - and
+-- flagging it would bury that fixture inside a collapsed group, entangling
+-- every unit-conversion test with the staples UI for no gain.
+UPDATE `ingredient` SET pantry_staple = TRUE
+WHERE name IN ('Olive Oil', 'Salt');
+
 INSERT INTO `ingredient_unit_size` (ingredient_id, unit_id, size)
 SELECT i.id, u.id, v.size FROM `ingredient` i, `unit` u, (
   SELECT 'Onion' AS ing, '' AS un, 150 AS size

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -143,6 +143,8 @@ components:
           type: string
         name:
           type: string
+        pantryStaple:
+          type: boolean
         quantity:
           type: string
         unit:
@@ -204,6 +206,8 @@ components:
           type: string
         isBought:
           type: boolean
+        pantryStaple:
+          type: boolean
         recipe_id:
           format: int64
           type: integer
@@ -230,6 +234,21 @@ components:
       required:
         - IsBought
         - Name
+      type: object
+    PreferencesInputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /.netlify/functions/recipes/schemas/PreferencesInputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        showPantryStaples:
+          type: boolean
+      required:
+        - showPantryStaples
       type: object
     Recipe:
       additionalProperties: false
@@ -392,6 +411,8 @@ components:
         name:
           type: string
         onboarded:
+          type: boolean
+        showPantryStaples:
           type: boolean
       required:
         - email
@@ -893,6 +914,24 @@ paths:
       tags:
         - Units
   /user:
+    get:
+      operationId: get-user
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      summary: Get the signed-in user
+      tags:
+        - Users
     post:
       operationId: add-user
       requestBody:
@@ -934,6 +973,31 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
       summary: Mark the current user as onboarded
+      tags:
+        - Users
+  /user/preferences:
+    patch:
+      operationId: set-preferences
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PreferencesInputBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      summary: Update the signed-in user's view preferences
       tags:
         - Users
 servers:

--- a/e2e/api.ts
+++ b/e2e/api.ts
@@ -68,6 +68,17 @@ export async function clearShoppingList(request: APIRequestContext): Promise<voi
   await request.delete(`${API_HOST}/shopping-list/clear`);
 }
 
+// The Pantry Staples toggle is stored on the User, so under DISABLE_AUTH it is
+// one more piece of state shared by every test in the run - the same hazard the
+// Shopping List has. A test that cares which way the group starts has to say
+// so rather than inherit whatever the last one left behind.
+export async function setShowPantryStaples(request: APIRequestContext, show: boolean): Promise<void> {
+  const res = await request.patch(`${API_HOST}/user/preferences`, { data: { showPantryStaples: show } });
+  if (!res.ok()) {
+    throw new Error(`Failed to set showPantryStaples: ${res.status()} ${await res.text()}`);
+  }
+}
+
 export async function addRecipesToList(request: APIRequestContext, ids: number[]): Promise<void> {
   const res = await request.post(`${API_HOST}/shopping-list`, { data: ids.map(String) });
   if (!res.ok()) {

--- a/e2e/shopping-list.spec.ts
+++ b/e2e/shopping-list.spec.ts
@@ -1,6 +1,7 @@
 import type { Page, APIRequestContext } from '@playwright/test';
 import { test, expect } from './fixtures';
-import { createRecipe, deleteRecipeById, clearShoppingList, addRecipesToList } from './api';
+import { createRecipe, deleteRecipeById, clearShoppingList, addRecipesToList, setShowPantryStaples } from './api';
+import { API_HOST } from './env';
 
 // Under DISABLE_AUTH every request resolves to the same dev Account, so the
 // Shopping List is one singleton mutable resource shared across this whole
@@ -225,6 +226,7 @@ test.describe('shopping list unit sizes and display units', () => {
   const tinRecipe = `E2E Tin Recipe ${runId}`;
   const spoonRecipe = `E2E Spoon Recipe ${runId}`;
   const pinchRecipe = `E2E Pinch Recipe ${runId}`;
+  const stapleRecipe = `E2E Staple Recipe ${runId}`;
   let ids: number[] = [];
 
   test.beforeAll(async ({ request }) => {
@@ -248,6 +250,12 @@ test.describe('shopping list unit sizes and display units', () => {
       ]}),
       await createRecipe(request, { name: pinchRecipe, ingredients: [
         { name: 'Black Pepper', quantity: '1', unit: 'gram' },
+      ]}),
+      // Olive Oil is flagged pantry_staple in dev-seed.sql; Chopped Tomatoes
+      // is not, so one Recipe covers both sides of the split.
+      await createRecipe(request, { name: stapleRecipe, ingredients: [
+        { name: 'Olive Oil', quantity: '2', unit: 'tablespoon' },
+        { name: 'Chopped Tomatoes', quantity: '1', unit: 'tin' },
       ]}),
     ];
   });
@@ -322,5 +330,64 @@ test.describe('shopping list unit sizes and display units', () => {
     const pepper = page.getByRole('checkbox', { name: 'Black Pepper' });
     await expect(pepper).toContainText('0.5 teaspoon');
     await expect(pepper).not.toContainText('0.4');
+  });
+
+  // Pantry staples. Recipe Import used to drop salt/oil/sugar from a Recipe
+  // outright when the amount looked like seasoning, which is indistinguishable
+  // from a failed extraction - the cook sees a Recipe missing lines and cannot
+  // tell "we decided you have this" from "we lost it". The Recipe now keeps
+  // everything and the Shopping List groups it instead.
+  //
+  // Worth an e2e test rather than only the component one: the flag is set
+  // server-side at read time from the ingredient catalog (MarkPantryStaples),
+  // so nothing but a run through the real API proves it survives the trip.
+  test('a pantry staple is grouped rather than dropped, and opens on request', async ({ page, request }) => {
+    // Collapsed to start with, whatever a previous test left on the User.
+    await setShowPantryStaples(request, false);
+    await selectOnly(page, request, stapleRecipe);
+
+    // Out of the main list, but its existence is stated, with a count.
+    const toggle = page.getByRole('button', { name: /pantry staples/i });
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.getByRole('checkbox', { name: 'Olive Oil' })).toBeHidden();
+    // The non-staple from the same Recipe is unaffected.
+    await expect(page.getByRole('checkbox', { name: 'Chopped Tomatoes' })).toBeVisible();
+
+    await toggle.click();
+
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    const oil = page.getByRole('checkbox', { name: 'Olive Oil' });
+    await expect(oil).toBeVisible();
+    // Grouped, not filtered: it carries a real Amount like any other Item, and
+    // the same rules apply to it - one contributing Unit was never ambiguous, so
+    // it stays tablespoons rather than being reduced to its base unit.
+    await expect(oil).toContainText('2 tablespoon');
+  });
+
+  // The toggle is cached in localStorage (so the first paint never waits on a
+  // request) but stored on the User. Clearing localStorage before reloading is
+  // what makes this test about the server half: with the cache gone, the group
+  // can only come back open if the preference survived on the User row.
+  test('the staples preference follows the user, not the browser', async ({ page, request }) => {
+    await setShowPantryStaples(request, false);
+    await selectOnly(page, request, stapleRecipe);
+    await page.getByRole('button', { name: /pantry staples/i }).click();
+    await expect(page.getByRole('button', { name: /pantry staples/i })).toHaveAttribute('aria-expanded', 'true');
+
+    // Wait for the write to land before throwing the cache away, or this races
+    // the PATCH rather than testing it. Deliberately not wrapped in a catch: a
+    // failing read here is a real failure, and swallowing it would just time
+    // out with "undefined" and say nothing about why.
+    await expect.poll(async () => {
+      const res = await request.get(`${API_HOST}/user`);
+      if (!res.ok()) throw new Error(`GET /user: ${res.status()} ${await res.text()}`);
+      return (await res.json()).showPantryStaples;
+    }).toBe(true);
+
+    await page.evaluate(() => window.localStorage.clear());
+    await page.reload();
+
+    // Nothing cached locally any more, so this is the server's answer.
+    await expect(page.getByRole('button', { name: /pantry staples/i })).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/hooks/use-local-storage-flag.ts
+++ b/hooks/use-local-storage-flag.ts
@@ -1,0 +1,71 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+// A boolean view preference kept in localStorage, for the ones that belong to a
+// device rather than to an Account - how *you* like the Shopping List laid out
+// on the phone in your hand, not something to sync to whoever you share the
+// list with.
+//
+// localStorage is an external store, so this reads it with the hook built for
+// that (see use-page-visibility.ts for the same reasoning). It matters more
+// here: the alternative is seeding useState from localStorage, which either
+// reads during the server render - where there is no localStorage - or renders
+// once with a guessed default and then flips. useSyncExternalStore takes the
+// server snapshot explicitly, so SSR and the first client render agree and
+// hydration doesn't warn.
+//
+// The `storage` event only fires in *other* tabs, so a local write has to
+// notify subscribers itself. Without that the component that just called
+// setFlag would never re-render.
+
+const listeners = new Set<() => void>();
+
+function notify() {
+  listeners.forEach(listener => listener());
+}
+
+function subscribe(onStoreChange: () => void) {
+  listeners.add(onStoreChange);
+  window.addEventListener('storage', onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+    window.removeEventListener('storage', onStoreChange);
+  };
+}
+
+// Reading localStorage throws in a browser with cookies/site-data blocked, and
+// a view preference is never worth taking the page down for.
+function read(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export default function useLocalStorageFlag(
+  key: string,
+  defaultValue: boolean
+): [boolean, (value: boolean) => void] {
+  const value = useSyncExternalStore(
+    subscribe,
+    () => {
+      const stored = read(key);
+      return stored === null ? defaultValue : stored === 'true';
+    },
+    // Server render: nothing is stored yet as far as this process knows, so the
+    // default is the only honest answer.
+    () => defaultValue
+  );
+
+  const setValue = useCallback((next: boolean) => {
+    try {
+      window.localStorage.setItem(key, String(next));
+    } catch {
+      // Still notify: the preference won't survive a reload, but the toggle
+      // has to work for the session the shopper is in.
+    }
+    notify();
+  }, [key]);
+
+  return [value, setValue];
+}

--- a/hooks/use-synced-flag.ts
+++ b/hooks/use-synced-flag.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react';
+import useLocalStorageFlag from './use-local-storage-flag';
+
+// A boolean preference stored on the server but painted from localStorage.
+//
+// The two-layer arrangement exists to get both halves of what a preference
+// should do:
+//
+//   - **No flip on first paint.** localStorage is synchronous, so the very
+//     first render already shows what you chose last time. A server-only
+//     preference cannot do this: the page has to paint *something* before the
+//     request resolves, so anyone whose preference differs from the default
+//     watches it flip, on every visit, forever.
+//   - **It follows you between devices.** localStorage alone cannot do this.
+//
+// So localStorage is a **cache**, not a second source of truth. The server value
+// wins whenever it arrives and disagrees, and is written back to the cache so
+// the next paint is right. That ordering is what keeps the two from fighting:
+// there is no "which one is newer" question to answer, because the cache never
+// claims to be authoritative.
+//
+// A flip is therefore still possible, but only when the value genuinely changed
+// somewhere else - you toggled it on your phone, and now the laptop catches up.
+// That is the sync working, not the problem this avoids.
+//
+// `remoteValue` is undefined until the server answers (or forever, if it never
+// does - see use-user.ts's 404 case), and while it is, the cached value stands
+// on its own.
+export default function useSyncedFlag(
+  key: string,
+  defaultValue: boolean,
+  remoteValue: boolean | undefined,
+  save: (value: boolean) => void
+): [boolean, (value: boolean) => void] {
+  const [cached, setCached] = useLocalStorageFlag(key, defaultValue);
+  const lastAdopted = useRef<boolean | undefined>(undefined);
+
+  // Genuinely "an external system changed, mirror it" - the case the codebase
+  // already treats as a legitimate effect (see pages/recipes/new.tsx's job
+  // polling).
+  //
+  // The guard is on the *server* value changing, not on it merely differing
+  // from the cache, and that distinction is load-bearing. Between the click and
+  // the save resolving, the cache is deliberately ahead of the server: reacting
+  // to "these differ" makes the effect revert the toggle the instant you press
+  // it, then flip it back when the response lands. That bug shipped in the
+  // first version of this hook and only surfaced under e2e, because whether you
+  // see it depends on a race with the request.
+  //
+  // Adopting only on change gets both cases right: a value the server has
+  // already told us about is not news, while one that genuinely changed
+  // elsewhere still wins.
+  useEffect(() => {
+    if (remoteValue === undefined || lastAdopted.current === remoteValue) return;
+    lastAdopted.current = remoteValue;
+    setCached(remoteValue);
+  }, [remoteValue, setCached]);
+
+  function setValue(next: boolean) {
+    // Cache first so the UI responds on the click rather than on the response,
+    // then tell the server. A failed save leaves the cache ahead of the server
+    // until the next load corrects it, which for a view preference is a better
+    // outcome than a toggle that doesn't move.
+    setCached(next);
+    save(next);
+  }
+
+  return [cached, setValue];
+}

--- a/hooks/use-user.ts
+++ b/hooks/use-user.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import useAuth from './use-auth';
+import { apiGet } from '../lib/api-client';
+import { queryKeys } from '../lib/query-keys';
+import type { User } from '../types/models';
+
+// The signed-in User, for the view preferences they carry.
+//
+// GET /user 404s for someone who reached an inner page before POST /user ever
+// ran for them, which is a real state rather than a fault - so this never
+// retries and callers treat `undefined` as "nothing recorded yet" and fall back
+// to whatever they were already showing.
+const useUser = () => {
+  const { getAccessTokenSilently, isAuthenticated } = useAuth();
+
+  const { data } = useQuery<User>({
+    queryKey: queryKeys.user,
+    enabled: isAuthenticated,
+    retry: false,
+    queryFn: async () => {
+      const token = await getAccessTokenSilently();
+      return apiGet<User>('/user', token);
+    }
+  });
+
+  return data;
+};
+
+export default useUser;

--- a/lib/openai-client.d.ts
+++ b/lib/openai-client.d.ts
@@ -1,0 +1,4 @@
+import { OpenAI } from 'openai';
+
+export const openai: OpenAI;
+export const EXTRACTION_MODEL: string;

--- a/lib/query-keys.ts
+++ b/lib/query-keys.ts
@@ -19,6 +19,7 @@ export const queryKeys = {
   tags: ['tags'] as const,
   units: ['units'] as const,
   invites: ['invites'] as const,
+  user: ['user'] as const,
   // Keyed per job and polled until it settles, so it is never shared between
   // call sites and never invalidated. Listed here only to keep this a
   // complete inventory of what is in the cache.

--- a/lib/recipe-import/extract.d.ts
+++ b/lib/recipe-import/extract.d.ts
@@ -9,10 +9,16 @@ export interface ExtractedIngredient {
   baseUnit?: string;
   displayUnit?: string;
   unitSizes?: Record<string, number>;
+  pantryStaple?: boolean;
 }
 
 export interface ExtractInput {
   type: 'text' | 'image';
+  // Which Import Source produced this input. It selects between two materially
+  // different prompts - see buildFieldRules in extract.js - so it is required
+  // rather than optional: a new Source that forgets it would silently get the
+  // scraped-page rules, which is the bug this distinction exists to fix.
+  source: 'ingredient-list' | 'page';
   text?: string;
   base64?: string;
 }

--- a/lib/recipe-import/extract.js
+++ b/lib/recipe-import/extract.js
@@ -30,6 +30,7 @@ const SCHEMA = {
           name: { type: 'string' },
           baseUnit: { type: ['string', 'null'] },
           displayUnit: { type: ['string', 'null'] },
+          pantryStaple: { type: 'boolean' },
           unitSizes: {
             type: 'array',
             items: {
@@ -43,7 +44,7 @@ const SCHEMA = {
             },
           },
         },
-        required: ['name', 'baseUnit', 'displayUnit', 'unitSizes'],
+        required: ['name', 'baseUnit', 'displayUnit', 'pantryStaple', 'unitSizes'],
         additionalProperties: false,
       },
     },
@@ -54,13 +55,37 @@ const SCHEMA = {
 
 const DEFAULT_UNITS = 'bottle,clove,gram,kilogram,litre,millilitre,packet,pinch,slice,tablespoon,teaspoon,tin';
 
-function buildInstructions(knownIngredients, knownUnits) {
-  return `
-    Read the following recipe content - it may be a freehand pasted ingredient list, text/HTML
-    scraped from a recipe web page, or an attached photo of a recipe (e.g. from a cookbook) - and
-    extract:
+// A hand-written ingredient list and a scraped page are read very differently,
+// and conflating them cost the cook one of six ingredients on a single paste
+// (see extract.test.ts). A page has a title, navigation and a method to tell
+// apart from the ingredients. A list typed into the Ingredients box has none of
+// that: it is an explicit enumeration, every line of it wanted, and the caller
+// keeps only `ingredients` - so a line read as the title is gone with nothing
+// shown to the cook.
+function buildFieldRules(source) {
+  if (source === 'ingredient-list') {
+    return `
+    Read the following ingredient list. The cook typed or pasted it straight into an "add
+    ingredients" box, so EVERY non-blank line is an ingredient - there is no title, no
+    navigation, and no method anywhere in it. Extract:
 
-    - name: the recipe's name/title. If this is just a pasted ingredient list with no title, use
+    - name: always an empty string.
+    - isVegetarian: true only if none of the ingredients are meat, poultry, fish, or a
+      meat/fish-derived product (e.g. gelatine, fish sauce, chicken stock).
+    - ingredients: an array of {name, quantity, unit}, with one entry for every non-blank line.
+      A line that also reads like a recipe's title or a component of one is still an ingredient
+      when it carries an amount - "Jerk marinade: 120ml" is 120 millilitres of jerk marinade,
+      not the name of the dish. The only lines to skip are bare section headings carrying no
+      amount at all (e.g. "For the sauce:").
+    - method: always an empty string.
+`;
+  }
+
+  return `
+    Read the following recipe content - it is text/HTML scraped from a recipe web page, or an
+    attached photo of a recipe (e.g. from a cookbook) - and extract:
+
+    - name: the recipe's name/title. If this is just an ingredient list with no title, use
       an empty string.
     - isVegetarian: true only if none of the ingredients are meat, poultry, fish, or a
       meat/fish-derived product (e.g. gelatine, fish sauce, chicken stock).
@@ -71,29 +96,25 @@ function buildInstructions(knownIngredients, knownUnits) {
       nested markdown list. The method must NOT use double quotes (") at any point - replace them
       with a single quote if needed, or omit them. If no method/instructions can be found (e.g. a
       bare ingredient list), return an empty string.
+`;
+}
 
+function buildInstructions(knownIngredients, knownUnits, source) {
+  return `${buildFieldRules(source)}
     These ingredients will later be combined across multiple recipes into a single shopping list,
     so consistent naming and units matter more than anything else - two ingredients that are the
     same thing must always end up with the exact same name and unit, or they won't combine.
 
-    Pantry staples:
-    - Omit these specific items entirely from the ingredients array when used in a small,
-      seasoning/background amount: salt, pepper, any cooking oil (olive oil, vegetable oil,
-      sunflower oil, etc), flour (plain flour, self-raising flour, etc), butter, and sugar
-      (caster sugar, brown sugar, etc). These are near-universal pantry basics, and listing
-      "1 tbsp olive oil" or "pinch of salt" on every recipe adds shopping-list noise for
-      something almost everyone already has. Do NOT extend this to any other ingredient no
-      matter how common it seems - keep garlic, onion, stock, spices, herbs, water, etc even in
-      small amounts.
-    - Only omit when the amount is small - roughly: oil up to 2-3 tbsp, salt/pepper any amount
-      (they're essentially always seasoning-scale), flour up to ~3 tbsp, butter up to ~2 tbsp or
-      a small knob, sugar up to ~2 tbsp. If one of these six is used in a larger quantity, it's a
-      primary ingredient rather than a pantry basic (e.g. "200g plain flour" in a cake, "150g
-      butter" in pastry, "100g sugar" in a dessert) - keep it, with its real quantity/unit as
-      normal, and it's still governed by the naming/unit rules below like any other ingredient.
-    - If genuinely unsure whether an amount counts as "small" for one of these six, err on the
-      side of keeping it in the list - a spare shopping list item is better than silently
-      dropping something the cook actually needs to buy.
+    Keep every ingredient:
+    - Never leave an ingredient out because it seems too ordinary to be worth buying. Salt,
+      pepper, cooking oil, flour, butter and sugar go in the list like anything else, at whatever
+      amount the recipe gives. The app groups store-cupboard basics together on the shopping list
+      itself, where the shopper can still see them and open them up, so they stay out of the way
+      without the recipe being wrong about what is in it. Mark them with pantryStaple below
+      rather than by omitting them.
+    - This used to work the other way round - those six were dropped outright at a small enough
+      amount - and it was a mistake: a missing ingredient looks exactly like a failed extraction,
+      and the cook has no way to tell which it was.
 
     Ingredient names:
     - Lowercase and singular, with no preparation notes ("chopped", "halved", "seeds removed",
@@ -142,6 +163,14 @@ function buildInstructions(knownIngredients, knownUnits) {
     - baseUnit: "millilitre" for things bought by volume (oils, stocks, milks, wines,
       juices, sauces thin enough to pour), "gram" for everything else. Use null if unsure -
       null means gram, which is right far more often than not.
+    - pantryStaple: true for a near-universal store-cupboard basic the shopper almost certainly
+      already has open: salt, pepper, cooking oils (olive, vegetable, sunflower, rapeseed),
+      flour, butter, and sugar. False for everything else, however common it looks - garlic,
+      onion, stock, tinned tomatoes, spices and dried herbs are all things a household runs out
+      of and has to replace. An oil bought for one dish's flavour (sesame, chilli, truffle) is
+      not a cooking oil, so false. When unsure, false: a staple wrongly flagged is tucked into a
+      collapsed group where it is easily missed, while an ordinary ingredient wrongly left out
+      of the group is just one more line on the list.
     - unitSizes: how much ONE of a unit of this ingredient is, expressed in its baseUnit.
       Only include entries that are genuinely useful:
         * unit "" (empty string, the bare count) - how much one of them is, in this
@@ -163,9 +192,9 @@ function buildInstructions(knownIngredients, knownUnits) {
       not set it without one. null for anything bought by weight or volume.
 
     Other rules:
-    - Preserve the original order of the ingredients.
+    - Preserve the original order of the ingredients.${source === 'ingredient-list' ? '' : `
     - Ignore anything that isn't part of the ingredient list or method (navigation, ads, comments,
-      related recipes, etc), if this looks like a full scraped page rather than a plain list.
+      related recipes, etc), if this looks like a full scraped page rather than a plain list.`}
   `;
 }
 
@@ -193,11 +222,12 @@ function buildRequestInput(input, instructions) {
     ];
   }
 
-  return `${instructions}\n\nRecipe content:\n${input.text}`;
+  const heading = input.source === 'ingredient-list' ? 'Ingredient list' : 'Recipe content';
+  return `${instructions}\n\n${heading}:\n${input.text}`;
 }
 
 export async function extractRecipe({ input, knownIngredients = [], knownUnits = [] }) {
-  const instructions = buildInstructions(knownIngredients, knownUnits);
+  const instructions = buildInstructions(knownIngredients, knownUnits, input.source);
 
   const response = await openai.responses.create({
     model: EXTRACTION_MODEL,
@@ -235,6 +265,10 @@ export async function extractRecipe({ input, knownIngredients = [], knownUnits =
         name,
         ...(proposal.baseUnit ? { baseUnit: proposal.baseUnit } : {}),
         ...(proposal.displayUnit !== null ? { displayUnit: proposal.displayUnit } : {}),
+        // Only ever carried when true: the server's classification acts on true
+        // alone, so a false is indistinguishable from no proposal and sending
+        // it would just be noise in every save payload.
+        ...(proposal.pantryStaple ? { pantryStaple: true } : {}),
         // Defensive: a malformed proposal must not throw out of extractRecipe and
         // take the whole import down with it. Classification is a bonus; losing it
         // is a missed improvement, losing the recipe is a failure.

--- a/lib/recipe-import/extract.test.ts
+++ b/lib/recipe-import/extract.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+
+vi.mock('../openai-client', () => ({
+  openai: { responses: { create: vi.fn() } },
+  EXTRACTION_MODEL: 'test-model'
+}));
+
+import { openai } from '../openai-client';
+import { extractRecipe } from './extract';
+import { textToInput } from './paste';
+import { htmlToInput } from './url';
+
+const create = (openai as unknown as { responses: { create: Mock } }).responses.create;
+
+function respondWith(payload: Record<string, unknown>) {
+  create.mockResolvedValue({
+    output_text: JSON.stringify({
+      name: '',
+      isVegetarian: false,
+      method: '',
+      newIngredients: [],
+      ...payload
+    })
+  });
+}
+
+// The instructions are the prompt string for a text input, and the first
+// content part for an image one.
+function instructionsSent(): string {
+  const { input } = create.mock.calls[0][0];
+  return typeof input === 'string' ? input : input[0].content[0].text;
+}
+
+beforeEach(() => {
+  create.mockReset();
+});
+
+// The bug report this file exists for: pasting
+//
+//   Jerk marinade: 120ml
+//   Tomato ketchup: 120ml
+//   Pineapple juice or orange juice (or both): 120ml
+//   Soy sauce: 80-120ml
+//   Brown sugar: 20g
+//   Oil: 22.5ml
+//
+// into the Ingredients box added only lines 2-4 on the first parse, line 1 on a
+// second parse of the same text, and lines 5-6 on a third. Nothing between the
+// model's reply and the form drops ingredients (the first test below), so the
+// omissions are the extraction itself - and the two mechanisms that make a line
+// vanish are both in the instructions.
+const JERK_PASTE = [
+  'Jerk marinade: 120ml',
+  'Tomato ketchup: 120ml',
+  'Pineapple juice or orange juice (or both): 120ml',
+  'Soy sauce: 80-120ml',
+  'Brown sugar: 20g',
+  'Oil: 22.5ml'
+].join('\n');
+
+describe('extractRecipe', () => {
+  it('returns every ingredient the model replied with', async () => {
+    respondWith({
+      ingredients: [
+        { name: 'jerk marinade', quantity: '120', unit: 'millilitre' },
+        { name: 'tomato ketchup', quantity: '120', unit: 'millilitre' },
+        { name: 'pineapple juice', quantity: '120', unit: 'millilitre' },
+        { name: 'soy sauce', quantity: '100', unit: 'millilitre' },
+        { name: 'brown sugar', quantity: '20', unit: 'gram' },
+        { name: 'oil', quantity: '22.5', unit: 'millilitre' }
+      ]
+    });
+
+    const { ingredients } = await extractRecipe({ input: textToInput(JERK_PASTE) });
+
+    expect(ingredients.map(i => i.name)).toEqual([
+      'jerk marinade', 'tomato ketchup', 'pineapple juice', 'soy sauce', 'brown sugar', 'oil'
+    ]);
+  });
+
+  // The first line went missing on its own, which the pantry-staples rule
+  // cannot explain - a marinade is not one of the six staples. What it is, is a
+  // plausible recipe title sitting on line 1 of a "Name: amount" list, and the
+  // instructions ask for a title. The paste box discards everything except
+  // `ingredients`, so a line read as the title is not merely mislabelled, it is
+  // gone with nothing shown to the cook.
+  it('tells the model a pasted list is all ingredients, so line 1 cannot be taken as the title', async () => {
+    respondWith({ ingredients: [] });
+
+    await extractRecipe({ input: textToInput(JERK_PASTE) });
+
+    expect(instructionsSent()).toMatch(/every non-blank line is an ingredient/i);
+  });
+
+  // The same instruction must NOT go out for a scraped page, where there really
+  // is a title, navigation and a method to tell apart from the ingredients.
+  it('leaves a scraped page free to have a title and a method', async () => {
+    respondWith({ ingredients: [] });
+
+    await extractRecipe({ input: htmlToInput('<html><title>Jerk chicken</title><body>1 onion</body></html>') });
+
+    expect(instructionsSent()).not.toMatch(/every non-blank line is an ingredient/i);
+    expect(instructionsSent()).toMatch(/the recipe's name\/title/);
+  });
+
+  // Lines 5 and 6 are brown sugar 20g (~1.5 tbsp) and oil 22.5ml (1.5 tbsp).
+  // Both are named pantry staples and both sat just under the "small amount"
+  // threshold the extractor used to drop them at - which also explains the third
+  // parse finally adding them, since the threshold was fuzzy enough to come out
+  // differently run to run.
+  //
+  // That judgement now lives on the Shopping List, which groups staples away
+  // behind a toggle (migration 032). So no Import Source may omit an ingredient
+  // any more: the Recipe stays complete, and the shopper can always see what was
+  // grouped.
+  it.each([
+    ['a pasted list', () => textToInput(JERK_PASTE)],
+    ['a scraped page', () => htmlToInput('<html><body>1 tbsp olive oil</body></html>')]
+  ])('does not ask the model to drop pantry staples from %s', async (_label, makeInput) => {
+    respondWith({ ingredients: [] });
+
+    await extractRecipe({ input: makeInput() });
+
+    expect(instructionsSent()).not.toMatch(/Pantry staples:/);
+    expect(instructionsSent()).toMatch(/Keep every ingredient:/);
+    // Flagged instead of dropped, which is what the Shopping List groups on.
+    expect(instructionsSent()).toMatch(/pantryStaple/);
+  });
+
+  // The flag has to survive the hop from the model's `newIngredients` metadata
+  // onto the ingredient itself, or the save payload never carries it and nothing
+  // is ever classified - the same silent-loss shape that cost two Import Sources
+  // their Unit Sizes.
+  it('carries a pantryStaple proposal onto the ingredient', async () => {
+    respondWith({
+      ingredients: [
+        { name: 'olive oil', quantity: '2', unit: 'tablespoon' },
+        { name: 'jerk marinade', quantity: '120', unit: 'millilitre' }
+      ],
+      newIngredients: [
+        { name: 'olive oil', baseUnit: 'millilitre', displayUnit: null, pantryStaple: true, unitSizes: [] },
+        { name: 'jerk marinade', baseUnit: 'millilitre', displayUnit: null, pantryStaple: false, unitSizes: [] }
+      ]
+    });
+
+    const { ingredients } = await extractRecipe({ input: htmlToInput('<html><body>x</body></html>') });
+
+    expect(ingredients[0]).toMatchObject({ name: 'olive oil', pantryStaple: true });
+    // false is not carried at all: classification only acts on true, so sending
+    // it would put a dead field in every save payload.
+    expect(ingredients[1]).not.toHaveProperty('pantryStaple');
+  });
+});

--- a/lib/recipe-import/paste.d.ts
+++ b/lib/recipe-import/paste.d.ts
@@ -1,3 +1,3 @@
 import type { ExtractInput } from './extract';
 
-export function textToInput(raw: string): ExtractInput;
+export function textToInput(raw: string): ExtractInput & { source: 'ingredient-list' };

--- a/lib/recipe-import/paste.js
+++ b/lib/recipe-import/paste.js
@@ -1,3 +1,7 @@
+// `source` matters as much as the text here: this is the Ingredients box on the
+// recipe form, where the cook has typed or pasted an explicit list of what they
+// want. The extractor treats that very differently from a scraped page - see
+// buildInstructions in extract.js.
 export function textToInput(raw) {
-  return { type: 'text', text: raw };
+  return { type: 'text', source: 'ingredient-list', text: raw };
 }

--- a/lib/recipe-import/photo.js
+++ b/lib/recipe-import/photo.js
@@ -1,3 +1,3 @@
 export function imageToInput(base64) {
-  return { type: 'image', base64 };
+  return { type: 'image', source: 'page', base64 };
 }

--- a/lib/recipe-import/url.js
+++ b/lib/recipe-import/url.js
@@ -26,7 +26,7 @@ export function htmlToInput(html) {
 
   const structured = recipeFromJsonLd(document);
   if (structured) {
-    return { type: 'text', text: structured.slice(0, MAX_TEXT_LENGTH) };
+    return { type: 'text', source: 'page', text: structured.slice(0, MAX_TEXT_LENGTH) };
   }
 
   // Read before the <head> goes: the title is often the only place the recipe's
@@ -35,7 +35,7 @@ export function htmlToInput(html) {
   document.querySelectorAll(NOISE_SELECTOR).forEach((el) => el.remove());
   const text = [title, document.structuredText].filter(Boolean).join('\n');
 
-  return { type: 'text', text: text.slice(0, MAX_TEXT_LENGTH) };
+  return { type: 'text', source: 'page', text: text.slice(0, MAX_TEXT_LENGTH) };
 }
 
 // Renders the page's schema.org Recipe as plain text, or null when the page has

--- a/migrations/032_pantry_staple.sql
+++ b/migrations/032_pantry_staple.sql
@@ -1,0 +1,65 @@
+-- Mark which Ingredients are pantry staples, so the Shopping List can group
+-- them away instead of the extractor dropping them from the Recipe.
+--
+-- Recipe Import used to omit salt, pepper, oil, flour, butter and sugar from a
+-- Recipe entirely when they were used at seasoning scale. That decision was
+-- right - nobody wants "1 tbsp olive oil" on every shopping list - but it was
+-- taken in the wrong place. An omitted Ingredient is indistinguishable from a
+-- failed extraction: the cook sees a Recipe missing three of its six lines and
+-- has no way to tell "we decided you have this" from "we lost it". It also made
+-- the Recipe itself permanently wrong, since nothing recorded what was dropped.
+--
+-- So the Recipe now keeps every Ingredient, and this flag moves the judgement to
+-- where it is a presentation choice that can be undone with one tap.
+--
+-- Deliberately a plain boolean rather than a per-Ingredient threshold. A "how
+-- small counts as seasoning" number is the more precise model - 200g of flour
+-- for a cake is a real purchase - but it is also a curated judgement per
+-- Ingredient, and grouping is now reversible in the UI, so being occasionally
+-- over-eager costs a tap rather than a missing ingredient.
+ALTER TABLE `ingredient` ADD COLUMN `pantry_staple` BOOLEAN NOT NULL DEFAULT FALSE
+  COMMENT 'a near-universal store-cupboard basic; the shopping list groups these away by default';
+
+-- The six categories the extractor used to drop, spelled out rather than
+-- matched with LIKE.
+--
+-- The two ways to be wrong here are not symmetrical. Flagging something that is
+-- not a staple hides a real purchase behind a collapsed group; failing to flag
+-- one just leaves it on the list, where it is mild noise. So this errs towards
+-- under-matching: '%oil%' would sweep up truffle oil and chilli oil, which are
+-- ingredients you go out and buy, and no pattern distinguishes them from the
+-- cooking oils. Anything missed can be added by a later migration.
+--
+-- `name` is matched case-insensitively by the column's collation, which is what
+-- lets one lowercase list cover both production's extractor-generated names and
+-- the title-cased ones in docker/mysql-seed/dev-seed.sql.
+--
+-- NOTE: matches only rows that already exist, so on a freshly provisioned
+-- database this updates nothing - migrations run before any seed data. The dev
+-- seed sets the flag inline for the same reason (see 028's note).
+UPDATE `ingredient` SET `pantry_staple` = TRUE WHERE name IN (
+  -- salt
+  'salt', 'sea salt', 'table salt', 'fine sea salt', 'flaky sea salt', 'kosher salt',
+  -- pepper
+  'pepper', 'black pepper', 'white pepper', 'ground black pepper',
+  'freshly ground black pepper', 'black peppercorn',
+  -- cooking oil (not the flavouring oils - see above)
+  'oil', 'cooking oil', 'olive oil', 'extra virgin olive oil', 'vegetable oil',
+  'sunflower oil', 'rapeseed oil', 'groundnut oil', 'canola oil',
+  -- flour
+  'flour', 'plain flour', 'all-purpose flour', 'self-raising flour', 'self raising flour',
+  'strong white flour', 'strong white bread flour',
+  -- butter
+  'butter', 'unsalted butter', 'salted butter',
+  -- sugar
+  'sugar', 'caster sugar', 'golden caster sugar', 'granulated sugar', 'brown sugar',
+  'light brown sugar', 'dark brown sugar', 'light brown soft sugar', 'demerara sugar',
+  'icing sugar'
+);
+
+-- `curated` is deliberately NOT set here. It means "a person chose this
+-- Ingredient's measurement metadata", and marking butter a staple says nothing
+-- about its Base Unit - setting it would silently freeze classification for
+-- every Ingredient in the list above. The flag protects itself instead:
+-- classification only ever sets it TRUE, so a re-proposal is a no-op and it can
+-- never be flipped back off by an import.

--- a/migrations/033_user_show_pantry_staples.sql
+++ b/migrations/033_user_show_pantry_staples.sql
@@ -1,0 +1,14 @@
+-- Whether this User wants the Shopping List's Pantry Staples group opened.
+--
+-- On `user` rather than `account` deliberately. The Shopping List itself is
+-- account-wide - you and whoever you share it with are looking at the same
+-- items - but how you like it laid out is yours. Two people shopping off one
+-- list should not have to agree about whether the salt is showing.
+--
+-- Defaults false, matching the collapsed-by-default group, so every existing
+-- row and every new one starts where the UI already starts.
+--
+-- The browser keeps a copy in localStorage and paints from it, so this column
+-- is the source of truth but not what the first render waits on - see
+-- hooks/use-synced-flag.ts.
+ALTER TABLE `user` ADD COLUMN `show_pantry_staples` BOOLEAN NOT NULL DEFAULT FALSE;

--- a/netlify-functions/recipes/internal/pkg/app/user.go
+++ b/netlify-functions/recipes/internal/pkg/app/user.go
@@ -50,6 +50,52 @@ func (a *App) addUser(ctx context.Context, input *UserInput) (*UserOutput, error
 	return &UserOutput{Body: *saved}, nil
 }
 
+// PreferencesInput carries the view preferences a user can change. Separate
+// from UserInput: this is the only body a client is allowed to set directly, so
+// name/email/onboarded can't be smuggled in through it.
+type PreferencesInput struct {
+	Body struct {
+		ShowPantryStaples bool `json:"showPantryStaples"`
+	}
+}
+
+// getUser returns the signed-in user, including their view preferences.
+//
+// The frontend previously only ever saw a User as the response body of POST
+// /user on the landing page, which left no way for any other page to read user
+// state at all.
+func (a *App) getUser(ctx context.Context, _ *struct{}) (*UserOutput, error) {
+	userID := ctx.Value(contextKey("userID")).(string)
+
+	user, err := service.GetUser(a.db, userID)
+	if err != nil {
+		// Also the no-rows case: someone who reached an inner page before POST
+		// /user ever ran for them. Not a server fault, and the client treats it
+		// as "no preferences recorded yet" rather than as an error.
+		log.Println("Error fetching user")
+		return nil, huma.Error404NotFound("user not found")
+	}
+
+	return &UserOutput{Body: *user}, nil
+}
+
+func (a *App) setPreferences(ctx context.Context, input *PreferencesInput) (*UserOutput, error) {
+	userID := ctx.Value(contextKey("userID")).(string)
+
+	if err := service.SetShowPantryStaples(a.db, userID, input.Body.ShowPantryStaples); err != nil {
+		log.Println("Error saving preferences")
+		return nil, huma.Error500InternalServerError("could not save preferences")
+	}
+
+	saved, err := service.GetUser(a.db, userID)
+	if err != nil {
+		log.Println("Error fetching saved user")
+		return nil, huma.Error500InternalServerError("Error fetching saved user")
+	}
+
+	return &UserOutput{Body: *saved}, nil
+}
+
 func (a *App) completeOnboarding(ctx context.Context, _ *struct{}) (*UserOutput, error) {
 	userID := ctx.Value(contextKey("userID")).(string)
 
@@ -117,6 +163,22 @@ func (a *App) registerUserRoutes(api huma.API) {
 		Summary:     "Add a user",
 		Tags:        []string{"Users"},
 	}, a.addUser)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-user",
+		Method:      http.MethodGet,
+		Path:        "/user",
+		Summary:     "Get the signed-in user",
+		Tags:        []string{"Users"},
+	}, a.getUser)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "set-preferences",
+		Method:      http.MethodPatch,
+		Path:        "/user/preferences",
+		Summary:     "Update the signed-in user's view preferences",
+		Tags:        []string{"Users"},
+	}, a.setPreferences)
 
 	huma.Register(api, huma.Operation{
 		OperationID: "complete-onboarding",

--- a/netlify-functions/recipes/internal/pkg/common/types.go
+++ b/netlify-functions/recipes/internal/pkg/common/types.go
@@ -57,6 +57,12 @@ type Ingredient struct {
 	// baseTotal.soleUnit and IngredientInfo.HasDisplayUnit.
 	DisplayUnit *string            `json:"displayUnit,omitempty"`
 	UnitSizes   map[string]float64 `json:"unitSizes,omitempty"`
+	// PantryStaple is Recipe Import proposing that this Ingredient is a
+	// store-cupboard basic. A plain bool rather than a pointer, unlike
+	// DisplayUnit above: classification only ever acts on true, so "false" and
+	// "not proposed" genuinely are the same thing here and there is no sentinel
+	// to collide with.
+	PantryStaple bool `json:"pantryStaple,omitempty"`
 }
 
 // Tag contains tag fields
@@ -107,6 +113,15 @@ type ListIngredient struct {
 	IsBought   bool     `json:"isBought"`
 	RecipeID   int      `json:"recipe_id"`
 	Department string   `json:"department"`
+	// PantryStaple marks a store-cupboard basic (salt, oil, flour...) that the
+	// frontend groups away by default. Set when the list is read, from the
+	// Global Catalog, so flagging an Ingredient improves a list that has already
+	// been generated - the same read-time principle as Display Units.
+	//
+	// omitempty, so every Item that isn't one is byte-for-byte unchanged; Huma
+	// infers required-ness from JSON tags, and a `false` here means exactly what
+	// an absent field means.
+	PantryStaple bool `json:"pantryStaple,omitempty"`
 }
 
 // User object
@@ -122,6 +137,21 @@ type User struct {
 	Name      string `json:"name,omitempty"`
 	Email     string `json:"email"`
 	Onboarded bool   `json:"onboarded,omitempty"`
+	// ShowPantryStaples is a view preference, not domain state: whether this
+	// User wants the Shopping List's Pantry Staples group opened. Server-managed
+	// like Onboarded above, hence omitempty for the same reason - it is never
+	// sent as input on POST /user or POST /invite, and Huma would otherwise mark
+	// it required on those bodies.
+	//
+	// A pointer, unlike Onboarded, because here `false` is a real answer that
+	// has to win. The client caches this value in localStorage and paints from
+	// the cache; reconciling means "the server said X, adopt it". With a plain
+	// bool, omitempty drops `false` from the JSON, so a preference turned *off*
+	// on another device arrives as absent - indistinguishable from "no answer
+	// yet" - and every other device keeps showing it on, forever. GetUser always
+	// sets it, so it is always present on output. Same reason Ingredient's
+	// DisplayUnit is a *string.
+	ShowPantryStaples *bool `json:"showPantryStaples,omitempty"`
 }
 
 // Account holds accounts and users

--- a/netlify-functions/recipes/internal/pkg/service/catalog.go
+++ b/netlify-functions/recipes/internal/pkg/service/catalog.go
@@ -33,6 +33,11 @@ type IngredientInfo struct {
 	// UnitSizes maps a Unit name to how much one of it is, in BaseUnit. Missing
 	// is a normal state: that Unit's Amounts simply won't combine yet.
 	UnitSizes map[string]float64
+	// PantryStaple marks a store-cupboard basic the Shopping List groups away by
+	// default. Purely presentational - it never affects combining or arithmetic,
+	// which is the whole point of moving the judgement here from Recipe Import
+	// (migration 032).
+	PantryStaple bool
 }
 
 // IngredientCatalog maps an Ingredient's name to its measurement metadata.
@@ -78,12 +83,13 @@ func GetIngredientCatalog(db *sql.DB, units UnitCatalog) (IngredientCatalog, err
 	catalog := make(IngredientCatalog)
 
 	baseUnits, err := db.Query(`
-		SELECT ingredient.name, base.name, display.name
+		SELECT ingredient.name, base.name, display.name, ingredient.pantry_staple
 		FROM ingredient
 		LEFT JOIN unit AS base ON base.id = ingredient.base_unit_id
 		LEFT JOIN unit AS display ON display.id = ingredient.display_unit_id
 		WHERE ingredient.base_unit_id IS NOT NULL
-		   OR ingredient.display_unit_id IS NOT NULL;
+		   OR ingredient.display_unit_id IS NOT NULL
+		   OR ingredient.pantry_staple;
 	`)
 	if err != nil {
 		return nil, err
@@ -93,7 +99,8 @@ func GetIngredientCatalog(db *sql.DB, units UnitCatalog) (IngredientCatalog, err
 	for baseUnits.Next() {
 		var ingredient string
 		var base, display sql.NullString
-		if err := baseUnits.Scan(&ingredient, &base, &display); err != nil {
+		var pantryStaple bool
+		if err := baseUnits.Scan(&ingredient, &base, &display, &pantryStaple); err != nil {
 			return nil, err
 		}
 		baseUnit := base.String
@@ -111,6 +118,7 @@ func GetIngredientCatalog(db *sql.DB, units UnitCatalog) (IngredientCatalog, err
 			BaseUnit:       baseUnit,
 			DisplayUnit:    display.String,
 			HasDisplayUnit: display.Valid,
+			PantryStaple:   pantryStaple,
 		}
 	}
 	if err := baseUnits.Err(); err != nil {

--- a/netlify-functions/recipes/internal/pkg/service/list.go
+++ b/netlify-functions/recipes/internal/pkg/service/list.go
@@ -348,6 +348,26 @@ func ApplyDisplayUnits(items map[string]*common.ListIngredient, units UnitCatalo
 	}
 }
 
+// MarkPantryStaples flags the Ingredient Items the Shopping List should group
+// away as store-cupboard basics.
+//
+// Marking rather than filtering, and here rather than in the frontend's own
+// data, because the shopper decides: the API sends the whole list every time and
+// the client shows or hides the group. A staple that were filtered out server
+// side could not be revealed without a round trip, and - the thing this feature
+// exists to fix - would be indistinguishable from one that had gone missing.
+//
+// Read time, alongside ApplyDisplayUnits, for the same reason: flagging an
+// Ingredient improves a Shopping List that has already been generated, instead
+// of only the next one.
+//
+// Pure: the catalog is a parameter.
+func MarkPantryStaples(items map[string]*common.ListIngredient, ingredients IngredientCatalog) {
+	for name, item := range items {
+		item.PantryStaple = ingredients.Get(name).PantryStaple
+	}
+}
+
 // amountInBaseUnits reduces a rendered Amount back to the Ingredient's Base
 // Unit, reporting false when there's no honest way to.
 func amountInBaseUnits(amount common.Amount, units UnitCatalog, info IngredientInfo) (float64, bool) {
@@ -577,6 +597,9 @@ func GetShoppingList(userID string, db *sql.DB) (*common.ShoppingList, error) {
 		return nil, err
 	}
 	ApplyDisplayUnits(ingredients, units, ingredientCatalog)
+	// Touches no Amounts, so its position relative to the two either side of it
+	// doesn't matter - it sits here because it reads the same catalog.
+	MarkPantryStaples(ingredients, ingredientCatalog)
 	// Last, so every Amount is rounded once, in its final Unit, rather than
 	// each conversion rounding on the way through.
 	RoundAmountsForShopping(ingredients, units)

--- a/netlify-functions/recipes/internal/pkg/service/pantry_test.go
+++ b/netlify-functions/recipes/internal/pkg/service/pantry_test.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"recipes/internal/pkg/common"
+	"testing"
+)
+
+// The Shopping List groups store-cupboard basics away instead of Recipe Import
+// dropping them, so what reaches the shopper has to be *marked*, never missing -
+// the whole point being that a shopper can tell "we grouped this" apart from
+// "we lost this" (migration 032).
+func TestMarkPantryStaples(t *testing.T) {
+	catalog := IngredientCatalog{
+		"olive oil": {BaseUnit: "millilitre", PantryStaple: true},
+		"salt":      {BaseUnit: "gram", PantryStaple: true},
+		"onion":     {BaseUnit: "gram", DisplayUnit: "", HasDisplayUnit: true},
+	}
+
+	list := map[string]*common.ListIngredient{
+		"olive oil":     {Amounts: []common.Amount{amount("30", "millilitre")}},
+		"salt":          {Amounts: []common.Amount{amount("1", "pinch")}},
+		"onion":         {Amounts: []common.Amount{amount("2", "")}},
+		"jerk marinade": {Amounts: []common.Amount{amount("120", "millilitre")}},
+	}
+
+	MarkPantryStaples(list, catalog)
+
+	want := map[string]bool{
+		"olive oil":     true,
+		"salt":          true,
+		"onion":         false,
+		"jerk marinade": false, // not in the catalog at all
+	}
+	for name, expected := range want {
+		if got := list[name].PantryStaple; got != expected {
+			t.Errorf("%s: expected PantryStaple %v but got %v", name, expected, got)
+		}
+	}
+}
+
+// Grouping is presentation. An Amount that reaches the shopper must be the same
+// number whether or not the Ingredient happens to be a staple - if flagging
+// something changed what you were told to buy, the flag would be a bug rather
+// than a view.
+func TestMarkPantryStaplesLeavesAmountsAlone(t *testing.T) {
+	list := items("olive oil", amount("30", "millilitre"), amount("2", "tablespoon"))
+	before := append([]common.Amount(nil), list["olive oil"].Amounts...)
+
+	MarkPantryStaples(list, IngredientCatalog{"olive oil": {BaseUnit: "millilitre", PantryStaple: true}})
+
+	got := list["olive oil"].Amounts
+	if len(got) != len(before) {
+		t.Fatalf("expected %d amounts but got %d", len(before), len(got))
+	}
+	for i := range before {
+		if got[i] != before[i] {
+			t.Errorf("amount %d: expected %v but got %v", i, before[i], got[i])
+		}
+	}
+}
+
+// Every Item is written on each pass, not only the staples. Otherwise an
+// Ingredient un-flagged in the catalog would keep a stale true from whatever
+// the caller had already put on the struct.
+func TestMarkPantryStaplesClearsAStaleFlag(t *testing.T) {
+	list := map[string]*common.ListIngredient{
+		"cumin": {Amounts: []common.Amount{amount("1", "teaspoon")}, PantryStaple: true},
+	}
+
+	MarkPantryStaples(list, IngredientCatalog{})
+
+	if list["cumin"].PantryStaple {
+		t.Error("expected an ingredient absent from the catalog not to be a pantry staple")
+	}
+}

--- a/netlify-functions/recipes/internal/pkg/service/recipe.go
+++ b/netlify-functions/recipes/internal/pkg/service/recipe.go
@@ -511,6 +511,9 @@ func classifyNewIngredients(recipe common.Recipe, db execer) {
 		if ingredient.DisplayUnit != nil {
 			setIngredientUnitColumn(db, "display_unit_id", *ingredient.DisplayUnit, ingredient.Name)
 		}
+		if ingredient.PantryStaple {
+			setPantryStaple(db, ingredient.Name)
+		}
 
 		for unit, size := range ingredient.UnitSizes {
 			if size <= 0 {
@@ -548,6 +551,24 @@ func setIngredientUnitColumn(db execer, column, unitName, ingredientName string)
 		WHERE name = ? AND %s IS NULL AND NOT curated;`, column, column)
 	if _, err := db.Exec(query, unitName, ingredientName); err != nil {
 		log.Printf("could not set %s for %q: %v", column, ingredientName, err)
+	}
+}
+
+// setPantryStaple flags an Ingredient as a store-cupboard basic on Recipe
+// Import's proposal, for the ones migration 032's list didn't cover.
+//
+// One-way, by construction: it is only ever reached for a true proposal, and it
+// only ever writes true. That is what stands in for the `IS NULL` guard the two
+// unit columns use - `pantry_staple` is NOT NULL with a default, so there is no
+// "unset" state to test for, and re-proposing something already flagged has to
+// be harmless rather than merely unlikely.
+//
+// `NOT curated` still applies, so anyone who deliberately un-flags an Ingredient
+// by hand can mark it curated and have that stick.
+func setPantryStaple(db execer, ingredientName string) {
+	query := `UPDATE ingredient SET pantry_staple = TRUE WHERE name = ? AND NOT curated;`
+	if _, err := db.Exec(query, ingredientName); err != nil {
+		log.Printf("could not set pantry_staple for %q: %v", ingredientName, err)
 	}
 }
 

--- a/netlify-functions/recipes/internal/pkg/service/user.go
+++ b/netlify-functions/recipes/internal/pkg/service/user.go
@@ -27,13 +27,35 @@ func AddUser(db *sql.DB, user common.User) error {
 }
 
 func GetUser(db *sql.DB, userID string) (u *common.User, e error) {
-	userQuery := `SELECT id, name, email, onboarded FROM user WHERE id = ?`
+	userQuery := `SELECT id, name, email, onboarded, show_pantry_staples FROM user WHERE id = ?`
 	user := &common.User{}
 
-	if err := db.QueryRow(userQuery, userID).Scan(&user.ID, &user.Name, &user.Email, &user.Onboarded); err != nil {
+	// Scanned into a local and then pointed at, so the field is always non-nil
+	// on the way out - a read of this User always states the preference,
+	// including when it is false. See the field's comment in common/types.go.
+	var showPantryStaples bool
+	if err := db.QueryRow(userQuery, userID).Scan(&user.ID, &user.Name, &user.Email, &user.Onboarded, &showPantryStaples); err != nil {
 		return nil, err
 	}
+	user.ShowPantryStaples = &showPantryStaples
 	return user, nil
+}
+
+// SetShowPantryStaples records whether this user wants the Shopping List's
+// Pantry Staples group opened.
+//
+// Takes the value rather than only ever setting true, unlike SetOnboarded above:
+// onboarding happens once and never un-happens, while this is a preference the
+// same person flips back and forth.
+func SetShowPantryStaples(db *sql.DB, userID string, show bool) error {
+	query := `UPDATE user SET show_pantry_staples = ? WHERE id = ?`
+	_, err := db.Exec(query, show, userID)
+	if err != nil {
+		log.Println("Error setting user show_pantry_staples")
+		log.Println(err)
+		return err
+	}
+	return nil
 }
 
 // SetOnboarded marks a user as having completed the onboarding screen.

--- a/pages/api/parse-recipe-text.test.mts
+++ b/pages/api/parse-recipe-text.test.mts
@@ -70,7 +70,11 @@ describe('parse-recipe-text handler', () => {
     }), res);
 
     expect(extractRecipe).toHaveBeenCalledWith({
-      input: { type: 'text', text: '2 eggs' },
+      // `source` is what tells the extractor this is a list the cook wrote out
+      // rather than a scraped page, which is the difference between a prompt
+      // that keeps every line and one that may drop some as a title or as
+      // pantry noise (lib/recipe-import/extract.test.ts).
+      input: { type: 'text', source: 'ingredient-list', text: '2 eggs' },
       knownIngredients: ['egg'],
       knownUnits: ['gram']
     });

--- a/pages/recipes/new.tsx
+++ b/pages/recipes/new.tsx
@@ -96,6 +96,7 @@ interface ParsedIngredient {
   baseUnit?: string;
   displayUnit?: string;
   unitSizes?: Record<string, number>;
+  pantryStaple?: boolean;
 }
 
 interface ParseUrlResult {
@@ -123,13 +124,14 @@ interface ImageJobStatus {
 // function destructured only name/quantity/unit and silently lost them for two
 // of the three Import Sources.
 function normalizeParsedIngredients(ingredients?: ParsedIngredient[]): RecipeModel['ingredients'] {
-  return (ingredients || []).map(({ name, quantity, unit, baseUnit, displayUnit, unitSizes }) => ({
+  return (ingredients || []).map(({ name, quantity, unit, baseUnit, displayUnit, unitSizes, pantryStaple }) => ({
     name: name || '',
     quantity: quantity || '',
     unit: unit || '',
     ...(baseUnit ? { baseUnit } : {}),
     ...(displayUnit !== undefined && displayUnit !== null ? { displayUnit } : {}),
     ...(unitSizes ? { unitSizes } : {}),
+    ...(pantryStaple ? { pantryStaple } : {}),
   }));
 }
 

--- a/technical-architecture.md
+++ b/technical-architecture.md
@@ -57,12 +57,12 @@ The recipe image extraction uses Netlify Blobs to store async job results; the f
 
 ## Database Schema
 
-Production: TiDB (MySQL-compatible). Migrations in `migrations/` applied manually, in order — there is no consolidated schema file, so `migrations/*.sql` (currently 25 files) is the authoritative source for exact columns/constraints.
+Production: TiDB (MySQL-compatible). Migrations in `migrations/` applied manually, in order — there is no consolidated schema file, so `migrations/*.sql` (currently 32 files) is the authoritative source for exact columns/constraints.
 
 | Table | Purpose |
 |-------|---------|
 | `recipe` | Recipe records (id, name, slug, remote_url, account_id) |
-| `ingredient` | Canonical ingredient names, plus `base_unit_id` (what its Amounts are added up in) and `display_unit_id` (what a Shopping List shows them as) |
+| `ingredient` | Canonical ingredient names, plus `base_unit_id` (what its Amounts are added up in), `display_unit_id` (what a Shopping List shows them as) and `pantry_staple` (grouped away on the Shopping List by default — see CONTEXT.md's Pantry Staple) |
 | `ingredient_unit_size` | How much one `<unit>` of an `<ingredient>` is, in that ingredient's base unit — average weight, pack size and density are all this one relation (see [ADR-0004](./docs/adr/0004-unit-size-as-one-relation.md)) |
 | `unit` | Measurement units (gram, litre, teaspoon, packet, etc.), each with a `kind` (weight/volume/relative), a `factor` for Absolute Units, and an optional `default_size` |
 | `part` | Recipe ↔ ingredient join (recipe_id, ingredient_id, unit_id, quantity) |
@@ -75,7 +75,7 @@ Production: TiDB (MySQL-compatible). Migrations in `migrations/` applied manuall
 | `account` | Shared account aggregate |
 | `account_user` | User ↔ account join (user_id is Auth0 string ID) |
 | `invite` | Email invitations with expiring tokens |
-| `user` | Auth0-backed user identity |
+| `user` | Auth0-backed user identity, plus per-user flags: `onboarded` and `show_pantry_staples` (view preference — see CONTEXT.md's Pantry Staple) |
 
 ## Component Structure
 

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -344,7 +344,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** Get the signed-in user */
+        get: operations["get-user"];
         put?: never;
         /** Add a user */
         post: operations["add-user"];
@@ -369,6 +370,23 @@ export interface paths {
         head?: never;
         /** Mark the current user as onboarded */
         patch: operations["complete-onboarding"];
+        trace?: never;
+    };
+    "/user/preferences": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update the signed-in user's view preferences */
+        patch: operations["set-preferences"];
         trace?: never;
     };
 }
@@ -465,6 +483,7 @@ export interface components {
             department?: string;
             displayUnit?: string;
             name: string;
+            pantryStaple?: boolean;
             quantity: string;
             unit: string;
             unitSizes?: {
@@ -491,6 +510,7 @@ export interface components {
             amounts: components["schemas"]["Amount"][] | null;
             department: string;
             isBought: boolean;
+            pantryStaple?: boolean;
             /** Format: int64 */
             recipe_id: number;
         };
@@ -503,6 +523,15 @@ export interface components {
             readonly $schema?: string;
             IsBought: boolean;
             Name: string;
+        };
+        PreferencesInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /.netlify/functions/recipes/schemas/PreferencesInputBody.json
+             */
+            readonly $schema?: string;
+            showPantryStaples: boolean;
         };
         Recipe: {
             /**
@@ -576,6 +605,7 @@ export interface components {
             id?: string;
             name?: string;
             onboarded?: boolean;
+            showPantryStaples?: boolean;
         };
     };
     responses: never;
@@ -1236,6 +1266,35 @@ export interface operations {
             };
         };
     };
+    "get-user": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["User"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "add-user": {
         parameters: {
             query?: never;
@@ -1277,6 +1336,39 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["User"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "set-preferences": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PreferencesInputBody"];
+            };
+        };
         responses: {
             /** @description OK */
             200: {


### PR DESCRIPTION
## The bug

Pasting six ingredients into the manual **Parse ingredients** box added three of them. Parsing the same text again added a fourth. A third attempt added the rest.

```
Jerk marinade: 120ml                                  ← added on attempt 2
Tomato ketchup: 120ml                                 ← added on attempt 1
Pineapple juice or orange juice (or both): 120ml      ← added on attempt 1
Soy sauce: 80–120ml                                   ← added on attempt 1
Brown sugar: 20g                                      ← added on attempt 3
Oil: 22.5ml                                           ← added on attempt 3
```

Nothing between the model's reply and the form drops anything — the client appends whatever it is given, and there's now a test pinning that down. Both causes were in the extraction prompt, and they're unrelated to each other.

## Cause 1: the first line was read as the recipe's title

The prompt asks for a recipe name, and `textToInput`/`htmlToInput` both produced a bare `{ type: 'text' }` — so the extractor could not tell a list someone typed from a scraped web page, and applied the page rules to both. Line 1 of a `Name: amount` list is a plausible dish name, and the paste route keeps only `ingredients`, so the line vanished with nothing shown to say it had.

`ExtractInput` now carries a **required** `source`, and the prompt splits on it. An ingredient list has no title, no method, and one entry per non-blank line. Required rather than optional so a future Import Source that forgets it is a type error, not a silent fall-through to the page rules.

## Cause 2: two lines were dropped as pantry staples

Brown sugar 20g (~1.5 tbsp) and oil 22.5ml (1.5 tbsp) were both named staples sitting just under the "small amount" threshold the extractor dropped them at. That rule was right in intent and wrong in placement: an omitted ingredient makes the Recipe permanently wrong about its own contents, and looks exactly like a failed extraction. The thresholds were also fuzzy enough to come out differently run to run — which is why attempt three finally kept them.

**No Import Source omits an ingredient any more.** Instead:

- `ingredient.pantry_staple` (migration 032) marks the store-cupboard basics, spelled out by name rather than matched with `LIKE` — over-matching buries a real purchase, under-matching just leaves a line on the list.
- `MarkPantryStaples` flags them when the list is **read**, next to `ApplyDisplayUnits`, so flagging an ingredient improves a list that's already been generated.
- The Shopping List groups them behind a collapsed **Pantry staples (n)**. The count is always visible: hidden is fine, invisible is not.
- Extraction proposes the flag alongside `baseUnit`/`unitSizes` for ingredients migration 032's list doesn't cover.

It marks rather than filters — the API sends every item and the client decides — so the toggle is instant and "grouped" is never indistinguishable from "gone".

## The preference

Per **User**, not per Account: the Shopping List is shared, but two people shopping off one list needn't agree about whether the salt is showing.

This needed a `GET /user`, which didn't exist — the frontend only ever saw a User as the response body of `POST /user` on the landing page. localStorage caches the value and paints from it, so the first render never waits on a request, while the server stays the source of truth (`hooks/use-synced-flag.ts`).

Two things the reconciliation got wrong first time round, both now covered by tests:

- **Adopting the server value whenever it merely *differed* from the cache** reverted the toggle between the click and the save resolving, then flipped it back. Guarded on the server value *changing* instead. Only e2e caught this — whether you see it is a race with the request, so it passed every local click.
- **`showPantryStaples` is a `*bool`.** With `omitempty` on a plain bool, `false` drops out of the JSON and can't be told from "no answer yet", so turning the toggle *off* on one device would never reach another. Same reason `Ingredient.DisplayUnit` is a pointer.

## Notes for review

- **Migrations 032 and 033 need applying to production.** 032 flags existing ingredients by name; on a fresh DB it matches nothing, so the dev seed sets both inline (same pattern as 028).
- **Existing recipes are still missing what was already dropped.** This fixes extraction going forward; anything imported before this has no rows for the salt and oil that were never saved. Backfilling would mean re-extracting and isn't attempted here.
- **`Black Pepper` is deliberately not flagged in the dev seed**, though 032 flags it in production. It's the seed's density exemplar, and burying it in a collapsed group entangles every unit-conversion test with the staples UI.
- The two causes are one commit rather than two. They're interleaved in the same prompt function, and splitting them cleanly would mean reconstructing an intermediate state rather than one that actually existed.

## Verification

- 160 unit tests, 24 e2e (two new, covering the group and that the preference survives a cleared localStorage), Go tests, typecheck, lint
- `docs/openapi.yaml` and `types/api.d.ts` regenerated — no drift
- Ran the stack manually: `pantryStaple: true` comes back on Olive Oil alone, `GET`/`PATCH /user` round-trips, and the group renders and toggles

🤖 Generated with [Claude Code](https://claude.com/claude-code)