### PR TITLE
Fill an empty Method from a link or a photo of the page

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -94,10 +94,16 @@ _Avoid_: Camera (UI label for Photo Import's tab; "Photo Import" is the canonica
 
 The bulk box is an **explicit enumeration**, and the extractor is told so (`source: 'ingredient-list'`, `lib/recipe-import/paste.js`): every non-blank line comes back as an Ingredient Line, and none of it is a title or a method. URL and Photo Import are the opposite — a whole page or photo to find the recipe inside — so they alone get the rules for picking a title and method out of surrounding noise. Applying those to the bulk box loses lines the cook deliberately typed: a first line reading "Jerk marinade: 120ml" gets taken as the dish's name, and the route keeps only `ingredients`, so it vanishes with nothing shown.
 
+**Method Import**:
+Filling in the Method of a Recipe that already exists, on its own, from a link or a photo — the same two sources as Recipe Import, aimed at one field. It exists because an imported Recipe often arrives with ingredients and no method (a photo of the ingredients page, a link the extractor could not find instructions in), and until now the only way out was to type the method by hand. Reached from the pencil beside an empty Method on the Recipe page, which opens the edit form at the Method with the importer already open (`?add=method`).
+
+It is deliberately not Recipe Import with the other fields discarded: the Recipe already has a name, tags and Ingredient Lines, so returning new ones would only raise the question of which to keep. Nothing about the Recipe but its Method can change. An existing Method is never overwritten — an extraction that lands on one is offered for the cook to accept or refuse.
+_Avoid_: Method Extraction (that's the server-side step, `extractMethod`); Re-import (nothing is re-read — the rest of the Recipe is untouched)
+
 **No Import Source omits an Ingredient.** Extraction proposes `pantryStaple` alongside the other catalog metadata; grouping is the Shopping List's job (see Pantry Staple).
 
 **Processing Job**:
-The async unit of work behind Photo Import specifically (not used by URL Import or Manual Entry, which respond synchronously). The client polls for completion rather than waiting on one request, because Netlify Functions' Lambda-based execution can't hold a request open long enough for a Vision call to finish.
+The async unit of work behind a photo specifically — Photo Import and Method Import's photo source, which share one route and one job store (not used by URL Import, Manual Entry or Method Import from a link, which respond synchronously). The client polls for completion rather than waiting on one request, because Netlify Functions' Lambda-based execution can't hold a request open long enough for a Vision call to finish.
 
 ### Meal planning intelligence (experimental, not fully productionized)
 

--- a/components/method-import/index.module.css
+++ b/components/method-import/index.module.css
@@ -1,0 +1,140 @@
+/* Sits directly above the Method textarea, styled like the "add ingredients"
+   box on the other side of the form so the two read as the same kind of
+   offer - a way to fill the field in, not another field. */
+.panel {
+  background-color: var(--color-primary-soft);
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-3);
+}
+
+.header {
+  margin-bottom: var(--space-3);
+}
+
+.title {
+  display: block;
+  font-weight: bold;
+  font-size: var(--text-base);
+  margin-bottom: var(--space-1);
+}
+
+.hint {
+  display: block;
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+
+.sources {
+  display: flex;
+  gap: 8px;
+}
+
+/* Same pill treatment as Add New Recipe's Import Source tabs, which is what
+   these are - the same two sources, narrowed to one field. */
+.sourceTab {
+  border: none;
+  background-color: var(--card);
+  padding: 8px 16px;
+  border-radius: var(--radius-lg);
+  font-size: var(--text-sm);
+  font-weight: bold;
+  color: var(--color-primary);
+  cursor: pointer;
+}
+
+.sourceTabActive {
+  background-color: var(--color-primary);
+  color: #fff;
+}
+
+.sourceSection {
+  margin-top: var(--space-4);
+}
+
+.inputLabel {
+  display: block;
+  margin-bottom: var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: bold;
+}
+
+.inputGroup {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-3);
+}
+
+/* Not inherited from form.module.css: that stylesheet's `.form input` rule
+   only reaches inputs it renders itself, and this one wants a white field on
+   the panel's tint rather than the form's underline. */
+.input {
+  flex-grow: 1;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--color-primary-border);
+  border-radius: var(--radius-sm);
+  background-color: var(--card);
+  font-size: var(--text-base);
+  font-family: inherit;
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.fileInput {
+  display: none;
+}
+
+.photoIcon {
+  width: 20px;
+  height: 20px;
+  margin-right: 8px;
+}
+
+.photoIcon path {
+  fill: currentColor;
+}
+
+/* Shown only when the Method box already has something in it, so the
+   extraction is offered rather than dropped on top of it. */
+.offer {
+  margin-top: var(--space-4);
+  padding: var(--space-3);
+  background-color: var(--card);
+  border: 1px solid var(--color-primary-border);
+  border-radius: var(--radius-md);
+}
+
+.offerHint {
+  margin: 0 0 var(--space-2);
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+
+.offerPreview {
+  max-height: 200px;
+  overflow-y: auto;
+  margin: 0 0 var(--space-3);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.offerActions {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.applied {
+  margin: var(--space-3) 0 0;
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+
+.error {
+  margin-top: var(--space-3);
+}

--- a/components/method-import/index.test.tsx
+++ b/components/method-import/index.test.tsx
@@ -1,0 +1,181 @@
+import { createElement, type ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@hooks/use-auth', () => ({ default: vi.fn() }));
+
+// Mocked at the transport boundary, like Form.test.tsx does, so the real
+// useMutation/useQuery/useAuth machinery still runs.
+vi.mock('../../lib/api-client', () => ({
+  nextApiPost: vi.fn(),
+  nextApiGet: vi.fn(),
+  nextApiPostFormData: vi.fn()
+}));
+
+// Canvas has no implementation in jsdom, and resizing is not what any of this
+// is about - the photo tests only care what gets uploaded and what comes back.
+vi.mock('../../lib/resize-image', () => ({
+  resizeImage: vi.fn(async () => new Blob(['x'], { type: 'image/jpeg' }))
+}));
+
+import useAuth from '@hooks/use-auth';
+import { nextApiPost, nextApiGet, nextApiPostFormData } from '../../lib/api-client';
+import MethodImport from './index';
+
+const mockedUseAuth = useAuth as unknown as Mock;
+const mockedNextApiPost = nextApiPost as unknown as Mock;
+const mockedNextApiGet = nextApiGet as unknown as Mock;
+const mockedNextApiPostFormData = nextApiPostFormData as unknown as Mock;
+
+beforeEach(() => {
+  vi.stubEnv('NEXT_PUBLIC_HOST', 'http://app.test');
+  mockedUseAuth.mockReturnValue({ getAccessTokenSilently: vi.fn(async () => 'test-token') });
+  mockedNextApiPost.mockReset();
+  mockedNextApiGet.mockReset();
+  mockedNextApiPostFormData.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function renderImport(props: Partial<React.ComponentProps<typeof MethodImport>> = {}) {
+  const onMethod = vi.fn();
+  const queryClient = new QueryClient();
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+  const { container } = render(<MethodImport currentMethod="" onMethod={onMethod} {...props} />, { wrapper: Wrapper });
+  // The file input is hidden behind the button that clicks it, so there is no
+  // accessible name to find it by - and a data-testid would be the only one in
+  // the codebase.
+  const fileInput = () => container.querySelector('input[type="file"]') as HTMLInputElement;
+  return { onMethod, fileInput };
+}
+
+const photoFile = () => new File(['photo-bytes'], 'page.jpg', { type: 'image/jpeg' });
+
+describe('MethodImport', () => {
+  it('opens straight onto the link field when the cook came here to add a method', () => {
+    renderImport({ defaultOpen: true });
+    expect(screen.getByLabelText('Recipe link')).toBeInTheDocument();
+  });
+
+  it('starts closed otherwise, so an ordinary edit is not interrupted', () => {
+    renderImport();
+    expect(screen.queryByLabelText('Recipe link')).not.toBeInTheDocument();
+  });
+
+  it('fills in an empty method from a link', async () => {
+    mockedNextApiPost.mockResolvedValue({ method: '1. Beat the eggs\n2. Fry them' });
+    const { onMethod } = renderImport({ defaultOpen: true });
+
+    await userEvent.type(screen.getByLabelText('Recipe link'), 'https://example.com/recipe');
+    await userEvent.click(screen.getByText('Fetch'));
+
+    await waitFor(() => expect(onMethod).toHaveBeenCalledWith('1. Beat the eggs\n2. Fry them'));
+    expect(mockedNextApiPost).toHaveBeenCalledWith(
+      'http://app.test/api/parse-method-url',
+      { url: 'https://example.com/recipe' },
+      'test-token'
+    );
+  });
+
+  // The pencil only appears while the Method is empty, but nothing stops
+  // someone opening this on a Recipe that has one - and the method they already
+  // wrote is not something to overwrite because a fetch happened to land.
+  it('offers rather than applies when there is already a method to lose', async () => {
+    mockedNextApiPost.mockResolvedValue({ method: '1. Imported step' });
+    const { onMethod } = renderImport({ defaultOpen: true, currentMethod: '1. Something I typed' });
+
+    await userEvent.type(screen.getByLabelText('Recipe link'), 'https://example.com/recipe');
+    await userEvent.click(screen.getByText('Fetch'));
+
+    await waitFor(() => expect(screen.getByText('1. Imported step')).toBeInTheDocument());
+    expect(onMethod).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByText('Replace the method'));
+    expect(onMethod).toHaveBeenCalledWith('1. Imported step');
+  });
+
+  it('throws the offered method away when the cook keeps their own', async () => {
+    mockedNextApiPost.mockResolvedValue({ method: '1. Imported step' });
+    const { onMethod } = renderImport({ defaultOpen: true, currentMethod: '1. Something I typed' });
+
+    await userEvent.type(screen.getByLabelText('Recipe link'), 'https://example.com/recipe');
+    await userEvent.click(screen.getByText('Fetch'));
+
+    await waitFor(() => expect(screen.getByText('1. Imported step')).toBeInTheDocument());
+    await userEvent.click(screen.getByText('Keep what I have'));
+
+    expect(screen.queryByText('1. Imported step')).not.toBeInTheDocument();
+    expect(onMethod).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the route error rather than failing silently', async () => {
+    mockedNextApiPost.mockRejectedValue(new Error('No method could be read from that page.'));
+    const { onMethod } = renderImport({ defaultOpen: true });
+
+    await userEvent.type(screen.getByLabelText('Recipe link'), 'https://example.com/recipe');
+    await userEvent.click(screen.getByText('Fetch'));
+
+    await waitFor(() => expect(screen.getByText('No method could be read from that page.')).toBeInTheDocument());
+    expect(onMethod).not.toHaveBeenCalled();
+  });
+
+  it('does not call the route for something that is not a link', async () => {
+    const { onMethod } = renderImport({ defaultOpen: true });
+
+    await userEvent.type(screen.getByLabelText('Recipe link'), 'my cookbook');
+    await userEvent.click(screen.getByText('Fetch'));
+
+    await waitFor(() => expect(screen.getByText(/does not look like a link/)).toBeInTheDocument());
+    expect(mockedNextApiPost).not.toHaveBeenCalled();
+    expect(onMethod).not.toHaveBeenCalled();
+  });
+
+  // mode=method is the only thing separating this from a whole-recipe photo
+  // import on the shared /api/recipe-image route.
+  it('uploads a photo as a method-only import and applies what the job returns', async () => {
+    mockedNextApiPostFormData.mockResolvedValue({ jobId: 'job-1' });
+    mockedNextApiGet.mockResolvedValue({ status: 'completed', result: { method: '1. From the book' } });
+    const { onMethod, fileInput } = renderImport();
+
+    await userEvent.click(screen.getByText('From a photo'));
+    await userEvent.upload(fileInput(), photoFile());
+
+    await waitFor(() => expect(onMethod).toHaveBeenCalledWith('1. From the book'));
+
+    const [, formData] = mockedNextApiPostFormData.mock.calls[0];
+    expect(formData.get('mode')).toBe('method');
+    expect(formData.get('image')).toBeTruthy();
+  });
+
+  it('reports a photo job that fails', async () => {
+    mockedNextApiPostFormData.mockResolvedValue({ jobId: 'job-1' });
+    mockedNextApiGet.mockResolvedValue({ status: 'failed', error: 'The photo was too blurry to read.' });
+    const { onMethod, fileInput } = renderImport();
+
+    await userEvent.click(screen.getByText('From a photo'));
+    await userEvent.upload(fileInput(), photoFile());
+
+    await waitFor(() => expect(screen.getByText('The photo was too blurry to read.')).toBeInTheDocument());
+    expect(onMethod).not.toHaveBeenCalled();
+  });
+
+  // A page with an ingredient list and no instructions extracts to an empty
+  // string. Handing that to the form would clear the field and look like the
+  // import worked.
+  it('says so rather than applying an empty method', async () => {
+    mockedNextApiPost.mockResolvedValue({ method: '   ' });
+    const { onMethod } = renderImport({ defaultOpen: true });
+
+    await userEvent.type(screen.getByLabelText('Recipe link'), 'https://example.com/recipe');
+    await userEvent.click(screen.getByText('Fetch'));
+
+    await waitFor(() => expect(screen.getByText(/did not contain a method/)).toBeInTheDocument());
+    expect(onMethod).not.toHaveBeenCalled();
+  });
+});

--- a/components/method-import/index.tsx
+++ b/components/method-import/index.tsx
@@ -1,0 +1,276 @@
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import Button from '@components/button';
+import Message from '@components/message';
+import Spinner from '@components/recipe-form/spinner';
+import PhotoIcon from '@components/svg/photo';
+import useAuth from '@hooks/use-auth';
+import { nextApiGet, nextApiPost, nextApiPostFormData } from '../../lib/api-client';
+import { queryKeys } from '../../lib/query-keys';
+import { resizeImage } from '../../lib/resize-image';
+import styles from './index.module.css';
+
+interface MethodImportProps {
+  // What is in the Method box right now. Only used to decide whether an
+  // extraction can be dropped straight in or has to be offered first.
+  currentMethod: string;
+  onMethod: (method: string) => void;
+  // The cook arrived by clicking the pencil beside an empty Method, so they are
+  // already here to fill it in - opening straight onto the link field saves them
+  // saying so twice.
+  defaultOpen?: boolean;
+}
+
+interface MethodJobStatus {
+  status: 'completed' | 'failed' | 'processing';
+  result?: { method?: string };
+  error?: string;
+}
+
+type Source = 'url' | 'photo';
+
+// Fills in a Recipe's Method on its own, from the page it came from or from a
+// photograph of the cookbook it came out of.
+//
+// The gap this closes: a Recipe imported from a photo or a link often arrives
+// with ingredients and no method, and until now the only way to fix that was to
+// type the method out - even though the method was right there on the same page
+// the ingredients were read from. The Method section on the Recipe page shows a
+// pencil while it is empty; that pencil lands here.
+//
+// Whole-recipe import is not reused for this. It would return a name, a tag set
+// and an ingredient list for a Recipe that already has all three, and the cook
+// would have to be asked which of them to keep.
+const MethodImport = ({ currentMethod, onMethod, defaultOpen = false }: MethodImportProps) => {
+  const [source, setSource] = useState<Source | null>(defaultOpen ? 'url' : null);
+  const [urlValue, setUrlValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  // An extraction that arrived while there was already a method to lose. Held
+  // here for the cook to accept or throw away rather than applied.
+  const [offered, setOffered] = useState<string | null>(null);
+  const [applied, setApplied] = useState(false);
+  const [job, setJob] = useState<{ jobId: string } | null>(null);
+  const imageInput = useRef<HTMLInputElement>(null);
+  const { getAccessTokenSilently } = useAuth();
+
+  // Read at the moment an extraction lands rather than closed over when it was
+  // started. An import takes seconds, and the cook may have typed a method
+  // themselves in the meantime - which is precisely when overwriting it without
+  // asking would be worst.
+  const currentMethodRef = useRef(currentMethod);
+  useEffect(() => {
+    currentMethodRef.current = currentMethod;
+  }, [currentMethod]);
+
+  const parseUrlMutation = useMutation({
+    mutationFn: async (payload: { url: string }) => {
+      const token = await getAccessTokenSilently();
+      return nextApiPost<{ method: string }>(`${process.env.NEXT_PUBLIC_HOST}/api/parse-method-url`, payload, token);
+    }
+  });
+
+  const uploadImageMutation = useMutation({
+    mutationFn: async (formData: FormData) => {
+      const token = await getAccessTokenSilently();
+      return nextApiPostFormData<{ jobId: string }>(`${process.env.NEXT_PUBLIC_HOST}/api/recipe-image`, formData, token);
+    }
+  });
+
+  // Same shape as Add New Recipe's photo import: the upload hands back a job id
+  // and the job is polled until it settles. refetchInterval stops itself on a
+  // terminal status, and `enabled` stops it the moment the job is cleared.
+  const jobStatusQuery = useQuery<MethodJobStatus>({
+    queryKey: queryKeys.recipeImageJob(job?.jobId),
+    enabled: !!job,
+    queryFn: async () => {
+      const token = await getAccessTokenSilently();
+      return nextApiGet<MethodJobStatus>(`${process.env.NEXT_PUBLIC_HOST}/api/recipe-image?jobId=${job!.jobId}`, token);
+    },
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status === 'completed' || status === 'failed' ? false : 2000;
+    }
+  });
+
+  // A method the cook has not asked to lose is never overwritten: it is offered
+  // instead. An empty Method box - which is how nearly everyone gets here - is
+  // filled in directly, because there is nothing to weigh it against.
+  const deliver = (method: string) => {
+    if (!method.trim()) {
+      setError('That did not contain a method. Try another link or photo, or type it in below.');
+      return;
+    }
+    if (currentMethodRef.current.trim()) {
+      setOffered(method);
+      return;
+    }
+    onMethod(method);
+    setApplied(true);
+    setSource(null);
+  };
+
+  // Drives the photo job to a terminal state. TanStack Query v5 has no
+  // onSuccess/onError on useQuery, so mirroring polled data into state in an
+  // effect is the supported shape - it runs at most once per import.
+  // (follow-ups.md #32)
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    const settled = jobStatusQuery.data;
+    if (!settled) return;
+
+    if (settled.status === 'completed') {
+      setJob(null);
+      deliver(settled.result?.method || '');
+    } else if (settled.status === 'failed') {
+      setJob(null);
+      setError(settled.error || 'Could not read a method from that photo. Try again, or type it in below.');
+    }
+  }, [jobStatusQuery.data]); // eslint-disable-line react-hooks/exhaustive-deps
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const fetchFromUrl = async (rawUrl: string) => {
+    const trimmed = (rawUrl || '').trim();
+    if (!trimmed) return;
+
+    let parsedUrl;
+    try {
+      parsedUrl = new URL(trimmed);
+    } catch {
+      setError('That does not look like a link. Paste the full address, starting with https://');
+      return;
+    }
+
+    setError(null);
+    setApplied(false);
+    setOffered(null);
+
+    try {
+      const { method } = await parseUrlMutation.mutateAsync({ url: parsedUrl.href });
+      deliver(method || '');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not read a method from that link.');
+    }
+  };
+
+  const handleImageChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setError(null);
+    setApplied(false);
+    setOffered(null);
+
+    if (!file.type.startsWith('image/')) {
+      setError('Please choose an image file (JPEG, PNG, etc).');
+      return;
+    }
+
+    try {
+      const resized = await resizeImage(file);
+      const formData = new FormData();
+      formData.append('image', resized, file.name);
+      // What makes this a Method Import rather than a whole-recipe one - the
+      // route reads only the instructions off the page and the job's result
+      // carries nothing else.
+      formData.append('mode', 'method');
+
+      const { jobId } = await uploadImageMutation.mutateAsync(formData);
+      setJob({ jobId });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not upload that photo. Please try again.');
+    }
+  };
+
+  const working = parseUrlMutation.isPending || uploadImageMutation.isPending || !!job;
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.header}>
+        <span className={styles.title}>No method yet?</span>
+        <span className={styles.hint}>Read it off the original page, or photograph the page of the book.</span>
+      </div>
+
+      <div className={styles.sources}>
+        <button
+          type="button"
+          className={`${styles.sourceTab} ${source === 'url' ? styles.sourceTabActive : ''}`}
+          onClick={() => { setSource('url'); setError(null); }}
+        >
+          From a link
+        </button>
+        <button
+          type="button"
+          className={`${styles.sourceTab} ${source === 'photo' ? styles.sourceTabActive : ''}`}
+          onClick={() => { setSource('photo'); setError(null); }}
+        >
+          From a photo
+        </button>
+      </div>
+
+      { source === 'url' && (
+        <div className={styles.sourceSection}>
+          <label htmlFor="method-import-url" className={styles.inputLabel}>Recipe link</label>
+          <div className={styles.inputGroup}>
+            <input
+              id="method-import-url"
+              className={styles.input}
+              placeholder="https://"
+              autoComplete="off"
+              type="text"
+              value={urlValue}
+              onChange={(e) => setUrlValue(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); fetchFromUrl(urlValue); } }}
+            />
+            <Button
+              style="primary"
+              disabled={working}
+              onClick={(e) => { e.preventDefault(); fetchFromUrl(urlValue); }}
+            >
+              Fetch
+              { parseUrlMutation.isPending && <Spinner /> }
+            </Button>
+          </div>
+        </div>
+      )}
+
+      { source === 'photo' && (
+        <div className={styles.sourceSection}>
+          <input
+            type="file"
+            id="method-image-input"
+            accept="image/*"
+            capture="environment"
+            ref={imageInput}
+            className={styles.fileInput}
+            onChange={handleImageChange}
+          />
+          <Button style="primary" disabled={working} onClick={(e) => { e.preventDefault(); imageInput.current?.click(); }}>
+            <PhotoIcon className={styles.photoIcon} />
+            Photograph the method
+            { (uploadImageMutation.isPending || job) && <Spinner /> }
+          </Button>
+          <p className={styles.hint}>Fit the whole set of instructions in the frame - the ingredient list can be left out.</p>
+        </div>
+      )}
+
+      { offered && (
+        <div className={styles.offer}>
+          <p className={styles.offerHint}>There is already a method here. This is what came back:</p>
+          <pre className={styles.offerPreview}>{offered}</pre>
+          <div className={styles.offerActions}>
+            <Button style="primary" onClick={(e) => { e.preventDefault(); onMethod(offered); setOffered(null); setApplied(true); setSource(null); }}>
+              Replace the method
+            </Button>
+            <Button onClick={(e) => { e.preventDefault(); setOffered(null); }}>Keep what I have</Button>
+          </div>
+        </div>
+      )}
+
+      { applied && <p className={styles.applied}>Method filled in below - read it over, then save the recipe.</p> }
+
+      { error && <div className={styles.error}><Message message={error} status="error" /></div> }
+    </div>
+  );
+};
+
+export default MethodImport;

--- a/components/recipe-form/Form.test.tsx
+++ b/components/recipe-form/Form.test.tsx
@@ -25,7 +25,11 @@ vi.mock('../../lib/api-client', () => ({
   apiPost: vi.fn(),
   apiPut: vi.fn(),
   apiDelete: vi.fn(),
-  nextApiPost: vi.fn()
+  nextApiPost: vi.fn(),
+  // Method Import's two, which this form renders in edit mode. Nothing here
+  // exercises them - components/method-import/index.test.tsx does.
+  nextApiGet: vi.fn(),
+  nextApiPostFormData: vi.fn()
 }));
 
 import useAuth from '@hooks/use-auth';
@@ -205,6 +209,57 @@ describe('Form', () => {
 
     await waitFor(() => expect(screen.getByText('Could not parse that')).toBeInTheDocument());
     expect(screen.getByLabelText('Ingredients')).toHaveValue('2 eggs');
+  });
+
+  // Method Import (components/method-import). The form is where it lives; what
+  // it does is tested next to it.
+  describe('method import', () => {
+    it('offers to fill the method in from a link or a photo when editing', async () => {
+      await renderForm({ initialRecipe: editableRecipe, mode: 'edit' });
+
+      expect(screen.getByText('From a link')).toBeInTheDocument();
+      expect(screen.getByText('From a photo')).toBeInTheDocument();
+    });
+
+    // Add New Recipe already offers both sources for the whole recipe, method
+    // included, so a method-only importer there would be two controls doing
+    // the same job.
+    it('leaves it out when creating a recipe', async () => {
+      await renderForm();
+
+      expect(screen.queryByText('From a link')).not.toBeInTheDocument();
+    });
+
+    it('opens onto the link field when the cook arrived from the Method pencil', async () => {
+      await renderForm({ initialRecipe: editableRecipe, mode: 'edit', focusSection: 'method' });
+
+      expect(screen.getByLabelText('Recipe link')).toBeInTheDocument();
+    });
+
+    it('stays closed on an ordinary edit', async () => {
+      await renderForm({ initialRecipe: editableRecipe, mode: 'edit' });
+
+      expect(screen.queryByLabelText('Recipe link')).not.toBeInTheDocument();
+    });
+
+    // The whole point of the feature: what the import returns has to reach the
+    // Method field, and from there the save payload.
+    it('writes an imported method into the field it is going to save', async () => {
+      mockedNextApiPost.mockResolvedValue({ method: '1. Beat the eggs' });
+      await renderForm({ initialRecipe: editableRecipe, mode: 'edit', focusSection: 'method' });
+
+      await userEvent.type(screen.getByLabelText('Recipe link'), 'https://example.com/recipe');
+      await userEvent.click(screen.getByText('Fetch'));
+
+      await waitFor(() => expect(screen.getByLabelText('Method')).toHaveValue('1. Beat the eggs'));
+
+      await userEvent.click(screen.getByText('Update Recipe'));
+      await waitFor(() => expect(mockedApiPut).toHaveBeenCalledWith(
+        '/recipe',
+        'test-token',
+        expect.objectContaining({ method: '1. Beat the eggs' })
+      ));
+    });
   });
 
   it('redirects to the new recipe after a successful submit', async () => {

--- a/components/recipe-form/Form.tsx
+++ b/components/recipe-form/Form.tsx
@@ -1,9 +1,10 @@
 import styles from './form.module.css';
-import { MouseEvent, useState, useEffect, useMemo } from 'react';
+import { MouseEvent, useState, useEffect, useMemo, useRef } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router'
 import Button from '@components/button';
 import Message from '@components/message';
+import MethodImport from '@components/method-import';
 import Spinner from './spinner';
 import useUnits from '@hooks/use-units';
 import useTags from '@hooks/use-tags';
@@ -41,6 +42,11 @@ interface FormUnit {
 interface FormProps {
   initialRecipe?: Partial<RecipeModel>;
   mode?: 'new' | 'edit';
+  // Which part of the form the cook came here to fill in, from the pencil beside
+  // an empty section on the Recipe page (?add=method). The form is two columns
+  // of fields on a desktop and a long scroll on a phone, so "we opened the edit
+  // page for you" is not on its own an answer to "add a method".
+  focusSection?: 'method';
 }
 
 interface ParseTextResult {
@@ -59,7 +65,7 @@ function normalizeInitialRecipe(initialRecipe: Partial<RecipeModel>, bareRecipe:
   };
 }
 
-export default function Form({initialRecipe = {}, mode = 'new'}: FormProps) {
+export default function Form({initialRecipe = {}, mode = 'new', focusSection}: FormProps) {
   const bareRecipe: FormRecipe = { name: '', remoteUrl: '', notes: '', method: '', ingredients: [], tags: []};
 
   let useInitialRecipe = Object.keys(initialRecipe).length > 0;
@@ -73,6 +79,8 @@ export default function Form({initialRecipe = {}, mode = 'new'}: FormProps) {
   const router = useRouter();
   const { getAccessTokenSilently } = useAuth();
   const queryClient = useQueryClient();
+  const methodSection = useRef<HTMLDivElement>(null);
+  const scrolledToFocus = useRef(false);
 
   const saveMutation = useMutation({
     mutationFn: async (recipeToSave: FormRecipe): Promise<CreatedResponse | undefined> => {
@@ -156,6 +164,22 @@ export default function Form({initialRecipe = {}, mode = 'new'}: FormProps) {
       setRecipe(normalizeInitialRecipe(initialRecipe, bareRecipe));
     }
   }, [initialRecipe]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Takes the cook to the section they clicked the pencil for. Deliberately not
+  // an autoFocus on the textarea: the point of arriving here from the Method
+  // pencil is usually to import the method rather than to start typing, and
+  // focusing the box would put a caret in the one thing the import is about to
+  // fill in. Runs once - `recipe.id` is in the deps because in edit mode this
+  // component renders nothing at all until the Recipe has loaded, so on a cold
+  // page load there is no section to scroll to on the first pass.
+  useEffect(() => {
+    if (focusSection !== 'method' || scrolledToFocus.current) return;
+    const node = methodSection.current;
+    if (!node) return;
+    scrolledToFocus.current = true;
+    // Guarded: jsdom has no layout, so it does not implement scrollIntoView.
+    node.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
+  }, [focusSection, recipe.id]);
 
   // The fetched Unit list, plus synthetic entries for any unit the extractor
   // introduced that isn't in the catalog yet (e.g. "bunch") - whether those
@@ -371,8 +395,19 @@ export default function Form({initialRecipe = {}, mode = 'new'}: FormProps) {
         </div>
 
         <div className={styles.gridCell}>
-          <div className={styles.group}>
+          <div className={styles.group} ref={methodSection}>
             <label htmlFor="recipe-method">Method</label>
+            {/* Edit only. On a new Recipe the page above this form already
+                offers the same two sources for the whole recipe, method
+                included, so a second method-only importer would be a choice
+                between two things that do the same job. */}
+            { mode === 'edit' && (
+              <MethodImport
+                currentMethod={recipe.method}
+                onMethod={(method) => setRecipe(prev => ({ ...prev, method }))}
+                defaultOpen={focusSection === 'method'}
+              />
+            )}
             <textarea placeholder="1. Cook until done" value={recipe.method} autoComplete="off" id="recipe-method" rows={5} onChange={(e) => updateRecipe('method', e.target.value)}/>
           </div>
           <div className={styles.group}>

--- a/components/recipe/index.tsx
+++ b/components/recipe/index.tsx
@@ -56,6 +56,10 @@ const Method = ({ method }: { method?: string | null }) => {
 // than merely not shown. The pencil beside it turns that dead end into the way
 // to fill it, and appears only while the section is empty so a complete recipe
 // isn't littered with edit affordances (the masthead's Edit covers that).
+//
+// The Method pencil carries ?add=method, which scrolls the edit form to the
+// Method and opens Method Import - so the answer to "this has no method" can be
+// the original link or a photo of the cookbook page, not only typing it out.
 const SectionHeading = ({ children, addLabel, editHref }: { children: ReactNode; addLabel: string; editHref?: string }) => (
   <div className={styles.sectionHeading}>
     <h3 className={styles.heading}>{children}</h3>
@@ -102,7 +106,7 @@ const Recipe = ({ recipe }: { recipe: Partial<RecipeModel> }) => {
         </ul>
       </div>
       <div className={styles.section}>
-        <SectionHeading addLabel="Add a method" editHref={hasMethod ? undefined : editHref}>
+        <SectionHeading addLabel="Add a method" editHref={hasMethod || !editHref ? undefined : `${editHref}?add=method`}>
           Method
         </SectionHeading>
         <Method method={recipe.method} />

--- a/e2e/recipe-import.spec.ts
+++ b/e2e/recipe-import.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test';
 import { test, expect } from './fixtures';
-import { deleteRecipeByName } from './api';
+import { createRecipe, deleteRecipeById, deleteRecipeByName } from './api';
 
 // Recipe Import, with the LLM stubbed out at the Next.js API route.
 //
@@ -179,5 +179,106 @@ test.describe('recipe import', () => {
 
     expectClassificationInPayload(payloads, ingredientName);
     await deleteRecipeByName(request, recipeName);
+  });
+});
+
+// Method Import: the same two sources, aimed at one field of a Recipe that
+// already exists. Stubbed at the route for the same reason as above - the model
+// is not what can break here, the journey from the pencil to a saved method is.
+//
+// Worth covering end to end rather than in Vitest alone because the feature is
+// mostly plumbing between four places (the pencil's ?add=method, the edit page
+// reading it, the form opening the panel, and the extracted text reaching the
+// save payload), and each piece is individually correct in a way that says
+// nothing about whether they are joined up.
+test.describe('method import', () => {
+  const importedMethod = '1. Mix everything together.\n2. Bake for 30 minutes.';
+
+  // A Recipe with ingredients and no method - which is how nearly every
+  // imported Recipe arrives, and the only state that shows the pencil.
+  const methodlessRecipe = (name: string) => ({
+    name,
+    method: '',
+    ingredients: [{ name: 'flour', quantity: '200', unit: 'gram' }],
+  });
+
+  test('the Method pencil leads to an import that fills the field in from a link', async ({ page, request }) => {
+    const recipeName = `E2E Method Link ${runId}`;
+    const id = await createRecipe(request, methodlessRecipe(recipeName));
+
+    await page.route('**/api/parse-method-url', (route) => route.fulfill({ json: { method: importedMethod } }));
+
+    await page.goto(`/recipes/${id}`);
+    await page.getByRole('link', { name: 'Add a method' }).click();
+
+    // The pencil is only worth anything if it lands on the Method with the
+    // import already open - the edit form is long, and Method is at the bottom
+    // of it on a phone.
+    await expect(page).toHaveURL(new RegExp(`/recipes/${id}/edit\\?add=method$`));
+    await expect(page.getByLabel('Recipe link')).toBeVisible();
+
+    await page.getByLabel('Recipe link').fill('https://example.com/a-recipe');
+    await page.getByRole('button', { name: 'Fetch' }).click();
+
+    await expect(page.getByLabel('Method', { exact: true })).toHaveValue(importedMethod);
+
+    await page.getByRole('button', { name: 'Update Recipe' }).click();
+    await expect(page).toHaveURL(new RegExp(`/recipes/${id}`));
+    // Rendered as steps on the Recipe page, so the pencil is gone and the
+    // section it pointed at is filled in.
+    await expect(page.getByText('Bake for 30 minutes.')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Add a method' })).toHaveCount(0);
+
+    await deleteRecipeById(request, id);
+  });
+
+  test('a photographed page fills the method in the same way', async ({ page, request }) => {
+    const recipeName = `E2E Method Photo ${runId}`;
+    const id = await createRecipe(request, methodlessRecipe(recipeName));
+
+    // Asynchronous like whole-recipe Photo Import, and on the same route -
+    // matched on pathname so the polling request's ?jobId= is caught too.
+    await page.route((url) => url.pathname === '/api/recipe-image', (route) =>
+      route.request().method() === 'POST'
+        ? route.fulfill({ json: { jobId: `e2e-method-job-${runId}` } })
+        : route.fulfill({ json: { status: 'completed', result: { method: importedMethod } } })
+    );
+
+    await page.goto(`/recipes/${id}/edit?add=method`);
+    await page.getByRole('button', { name: 'From a photo' }).click();
+    await page.setInputFiles('input[type="file"]', 'specs/evidence/sidebar-alignment/after.png');
+
+    await expect(page.getByLabel('Method', { exact: true })).toHaveValue(importedMethod, { timeout: 15_000 });
+
+    await page.getByRole('button', { name: 'Update Recipe' }).click();
+    await expect(page).toHaveURL(new RegExp(`/recipes/${id}`));
+    await expect(page.getByText('Bake for 30 minutes.')).toBeVisible();
+
+    await deleteRecipeById(request, id);
+  });
+
+  // The pencil only appears on an empty Method, but the panel is on the edit
+  // form regardless - and a method the cook wrote is not something to lose to a
+  // fetch they may have started before remembering they had one.
+  test('offers rather than overwrites a method that is already there', async ({ page, request }) => {
+    const recipeName = `E2E Method Kept ${runId}`;
+    const id = await createRecipe(request, {
+      ...methodlessRecipe(recipeName),
+      method: 'My own method.',
+    });
+
+    await page.route('**/api/parse-method-url', (route) => route.fulfill({ json: { method: importedMethod } }));
+
+    await page.goto(`/recipes/${id}/edit?add=method`);
+    await page.getByLabel('Recipe link').fill('https://example.com/a-recipe');
+    await page.getByRole('button', { name: 'Fetch' }).click();
+
+    await expect(page.getByText('There is already a method here.')).toBeVisible();
+    await expect(page.getByLabel('Method', { exact: true })).toHaveValue('My own method.');
+
+    await page.getByRole('button', { name: 'Replace the method' }).click();
+    await expect(page.getByLabel('Method', { exact: true })).toHaveValue(importedMethod);
+
+    await deleteRecipeById(request, id);
   });
 });

--- a/lib/recipe-import/extract.d.ts
+++ b/lib/recipe-import/extract.d.ts
@@ -30,8 +30,16 @@ export interface ExtractedRecipe {
   tags: string[];
 }
 
+export interface ExtractedMethod {
+  method: string;
+}
+
 export function extractRecipe(args: {
   input: ExtractInput;
   knownIngredients?: string[];
   knownUnits?: string[];
 }): Promise<ExtractedRecipe>;
+
+// Method Import (see extract.js). No knownIngredients/knownUnits: it returns
+// prose, so there is no name or unit for a canonical list to reconcile.
+export function extractMethod(args: { input: ExtractInput }): Promise<ExtractedMethod>;

--- a/lib/recipe-import/extract.js
+++ b/lib/recipe-import/extract.js
@@ -53,7 +53,31 @@ const SCHEMA = {
   additionalProperties: false,
 };
 
+// Just the method, for a Recipe that already exists and is only missing its
+// instructions (see extractMethod below). Nothing else is asked for: the cook is
+// filling one field on a Recipe they have already named and whose ingredients
+// they have already got, and a name or an ingredient list extracted here would
+// have nowhere to go.
+const METHOD_SCHEMA = {
+  type: 'object',
+  properties: {
+    method: { type: 'string' },
+  },
+  required: ['method'],
+  additionalProperties: false,
+};
+
 const DEFAULT_UNITS = 'bottle,clove,gram,kilogram,litre,millilitre,packet,pinch,slice,tablespoon,teaspoon,tin';
+
+// How a method should come back, wherever it is extracted from. Shared by the
+// whole-recipe prompt and the method-only one so the two can't drift into
+// formatting the same field differently - components/recipe/index.tsx parses
+// "1. ", "2. " back out of this text to render numbered steps.
+const METHOD_FORMAT_RULES = `formatted in markdown as clearly as possible. Each
+      instruction should be its own numbered line, e.g. "1. Preheat the oven.\\n2. Mix the
+      ingredients.\\n3. Bake for 30 minutes." If a step is itself a list of items, format it as a
+      nested markdown list. The method must NOT use double quotes (") at any point - replace them
+      with a single quote if needed, or omit them.`;
 
 // A hand-written ingredient list and a scraped page are read very differently,
 // and conflating them cost the cook one of six ingredients on a single paste
@@ -90,12 +114,8 @@ function buildFieldRules(source) {
     - isVegetarian: true only if none of the ingredients are meat, poultry, fish, or a
       meat/fish-derived product (e.g. gelatine, fish sauce, chicken stock).
     - ingredients: an array of {name, quantity, unit}.
-    - method: the cooking method/instructions, formatted in markdown as clearly as possible. Each
-      instruction should be its own numbered line, e.g. "1. Preheat the oven.\\n2. Mix the
-      ingredients.\\n3. Bake for 30 minutes." If a step is itself a list of items, format it as a
-      nested markdown list. The method must NOT use double quotes (") at any point - replace them
-      with a single quote if needed, or omit them. If no method/instructions can be found (e.g. a
-      bare ingredient list), return an empty string.
+    - method: the cooking method/instructions, ${METHOD_FORMAT_RULES} If no method/instructions
+      can be found (e.g. a bare ingredient list), return an empty string.
 `;
 }
 
@@ -279,4 +299,45 @@ export async function extractRecipe({ input, knownIngredients = [], knownUnits =
     }),
     tags: isVegetarian ? ['Vegetarian'] : [],
   };
+}
+
+// Method Import: a Recipe that already exists, with an empty Method, being
+// filled in from a link or a photograph of the cookbook page it came from.
+//
+// Deliberately not extractRecipe with the other fields thrown away. Nothing here
+// needs the canonical Ingredient and Unit lists, which are the expensive part of
+// the whole-recipe prompt in both tokens and a round trip to the database, and
+// asking for ingredients we would then discard invites the model to spend its
+// attention on them. It also cannot go wrong in the way the full import can: no
+// ingredient can be renamed, dropped, or given a wrong unit size by an
+// extraction that only ever returns prose.
+export async function extractMethod({ input }) {
+  const instructions = `
+    Read the following recipe content - it is text/HTML scraped from a recipe web page, or an
+    attached photo of a recipe (e.g. from a cookbook) - and extract ONLY the cooking method.
+
+    - method: the cooking method/instructions, ${METHOD_FORMAT_RULES}
+    - Ignore everything that is not part of the instructions: the recipe's title, its ingredient
+      list, serving sizes, and - if this looks like a full scraped page rather than a plain recipe -
+      navigation, ads, comments and related recipes.
+    - Do not invent steps. If the content carries no method/instructions at all, return an empty
+      string; the caller tells the cook the page had none, which is far better than a plausible
+      method nobody wrote.
+  `;
+
+  const response = await openai.responses.create({
+    model: EXTRACTION_MODEL,
+    input: buildRequestInput(input, instructions),
+    text: {
+      format: {
+        type: 'json_schema',
+        name: 'method',
+        schema: METHOD_SCHEMA,
+        strict: true,
+      },
+    },
+  });
+
+  const { method } = JSON.parse(response.output_text);
+  return { method: method || '' };
 }

--- a/lib/resize-image.ts
+++ b/lib/resize-image.ts
@@ -1,0 +1,76 @@
+// Shrinks a photo before it is uploaded to /api/recipe-image, which rejects
+// anything over 5MB (and would spend an OpenAI call on the pixels above that
+// size for nothing). Browser-only - it goes through <canvas>.
+//
+// Lives here rather than in pages/recipes/new.tsx, where it used to, because
+// Method Import photographs a page the same way and a second copy would be one
+// more place for the size limits to drift out of step with the route's.
+export function resizeImage(file: File): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => {
+      const img = new Image();
+      img.src = reader.result as string;
+      img.onload = () => {
+        const canvas = document.createElement('canvas');
+        let width = img.width;
+        let height = img.height;
+
+        // Calculate new dimensions while maintaining aspect ratio
+        const MAX_WIDTH = 2000; // Maximum width
+        const MAX_HEIGHT = 2000; // Maximum height
+        const MAX_SIZE = 5 * 1024 * 1024; // 5MB in bytes
+
+        if (width > MAX_WIDTH) {
+          height = Math.round((height * MAX_WIDTH) / width);
+          width = MAX_WIDTH;
+        }
+
+        if (height > MAX_HEIGHT) {
+          width = Math.round((width * MAX_HEIGHT) / height);
+          height = MAX_HEIGHT;
+        }
+
+        canvas.width = width;
+        canvas.height = height;
+
+        // A freshly created canvas's 2d context is never null in practice.
+        const ctx = canvas.getContext('2d')!;
+        ctx.drawImage(img, 0, 0, width, height);
+
+        // Recursive function to create blob with quality adjustment
+        const createBlob = (quality: number): Promise<Blob | null> => {
+          return new Promise((resolveBlob) => {
+            canvas.toBlob((blob) => {
+              if (!blob) {
+                resolveBlob(null);
+                return;
+              }
+
+              if (blob.size <= MAX_SIZE || quality <= 0.1) {
+                resolveBlob(blob);
+              } else {
+                // Reduce quality and try again
+                createBlob(quality - 0.1).then(resolveBlob);
+              }
+            }, 'image/jpeg', quality);
+          });
+        };
+
+        // Start with 90% quality
+        createBlob(0.9)
+          .then((blob) => {
+            if (!blob) {
+              reject(new Error('Failed to create image blob'));
+              return;
+            }
+            resolve(blob);
+          })
+          .catch(reject);
+      };
+      img.onerror = reject;
+    };
+    reader.onerror = reject;
+  });
+}

--- a/pages/api/parse-method-url.test.mts
+++ b/pages/api/parse-method-url.test.mts
@@ -1,0 +1,148 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+
+vi.mock('../../lib/recipe-import/extract', () => ({
+  extractMethod: vi.fn()
+}));
+
+vi.mock('../../lib/authenticate', () => ({
+  authenticateAccount: vi.fn()
+}));
+
+import { extractMethod } from '../../lib/recipe-import/extract';
+import { authenticateAccount } from '../../lib/authenticate';
+import handler from './parse-method-url';
+
+const mockedExtractMethod = extractMethod as unknown as Mock;
+const mockedAuthenticate = authenticateAccount as unknown as Mock;
+
+function mockReq(overrides: Partial<NextApiRequest>): NextApiRequest {
+  return { headers: {}, ...overrides } as NextApiRequest;
+}
+
+function mockRes(): NextApiResponse {
+  const res: Partial<NextApiResponse> = {};
+  res.status = vi.fn(() => res) as unknown as NextApiResponse['status'];
+  res.json = vi.fn(() => res) as unknown as NextApiResponse['json'];
+  return res as NextApiResponse;
+}
+
+beforeEach(() => {
+  mockedExtractMethod.mockReset();
+  mockedAuthenticate.mockReset();
+  mockedAuthenticate.mockResolvedValue({ ok: true, account: { id: 7 } });
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('parse-method-url handler', () => {
+  it('rejects non-POST methods', async () => {
+    const res = mockRes();
+    await handler(mockReq({ method: 'GET', body: {} }), res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  // Unlike /api/parse-recipe-url, which is still open. Nothing else stands
+  // between an anonymous caller and an OpenAI call on this app's quota.
+  it('rejects an unauthenticated caller without fetching or extracting anything', async () => {
+    mockedAuthenticate.mockResolvedValue({ ok: false, status: 401, error: 'Authentication required' });
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'POST', body: { url: 'https://example.com/recipe' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mockedExtractMethod).not.toHaveBeenCalled();
+  });
+
+  it('requires a url', async () => {
+    const res = mockRes();
+    await handler(mockReq({ method: 'POST', body: {} }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'url is required' });
+  });
+
+  it('rejects a malformed url', async () => {
+    const res = mockRes();
+    await handler(mockReq({ method: 'POST', body: { url: 'not a url' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'url is not a valid URL' });
+  });
+
+  it('fetches the page and returns just the method', async () => {
+    const html = '<html><head><script>bad()</script></head><body><p>1. Beat the eggs</p></body></html>';
+    (fetch as unknown as Mock).mockResolvedValue({ text: async () => html });
+    mockedExtractMethod.mockResolvedValue({ method: '1. Beat the eggs\n2. Fry them' });
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'POST', body: { url: 'https://example.com/recipe' } }), res);
+
+    expect(fetch).toHaveBeenCalledWith('https://example.com/recipe');
+    const [{ input }] = mockedExtractMethod.mock.calls[0];
+    expect(input.type).toBe('text');
+    expect(input.text).not.toContain('<script>');
+    expect(input.text).toContain('1. Beat the eggs');
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ method: '1. Beat the eggs\n2. Fry them' });
+  });
+
+  // The whole-recipe route hands back a name and tags too. This one must not:
+  // the Recipe being filled in already has both, and the cook did not ask for
+  // them to be reconsidered.
+  it('returns nothing but the method, whatever else the extraction carries', async () => {
+    (fetch as unknown as Mock).mockResolvedValue({ text: async () => '<html><body>x</body></html>' });
+    mockedExtractMethod.mockResolvedValue({ method: '1. Cook', name: 'Something else', tags: ['Vegetarian'] });
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'POST', body: { url: 'https://example.com/recipe' } }), res);
+
+    expect(res.json).toHaveBeenCalledWith({ method: '1. Cook' });
+  });
+
+  // Same reasoning as follow-ups.md #40: an empty string reaching the form looks
+  // like the page had no method rather than like the extraction failed.
+  it('fails visibly rather than returning an empty method', async () => {
+    (fetch as unknown as Mock).mockResolvedValue({ text: async () => '<html><body>hello</body></html>' });
+    mockedExtractMethod.mockResolvedValue({ method: '   ' });
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'POST', body: { url: 'https://example.com/recipe' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'No method could be read from that page. Try another link, a photo, or type it in below.'
+    });
+  });
+
+  // A page with a method and no ingredient list is a perfectly good source
+  // here, where /api/parse-recipe-url treats exactly that as a hard failure.
+  it('accepts a page carrying a method and no ingredients at all', async () => {
+    (fetch as unknown as Mock).mockResolvedValue({ text: async () => '<html><body>1. Simmer</body></html>' });
+    mockedExtractMethod.mockResolvedValue({ method: '1. Simmer for an hour' });
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'POST', body: { url: 'https://example.com/recipe' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ method: '1. Simmer for an hour' });
+  });
+
+  it('returns a 500 with the error message when fetching/extraction fails', async () => {
+    (fetch as unknown as Mock).mockRejectedValue(new Error('network down'));
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'POST', body: { url: 'https://example.com/recipe' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'network down' });
+  });
+});

--- a/pages/api/parse-method-url.ts
+++ b/pages/api/parse-method-url.ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { extractMethod } from '../../lib/recipe-import/extract';
+import { htmlToInput } from '../../lib/recipe-import/url';
+import { authenticateAccount } from '../../lib/authenticate';
+
+// Method Import from a link: an existing Recipe with an empty Method, filled in
+// from the page it came from.
+//
+// Separate from /api/parse-recipe-url rather than a mode on it, because the two
+// disagree about nearly everything that route does: this one wants no canonical
+// Ingredient/Unit names (it returns prose), keeps a page with no ingredients at
+// all - a method-only page is a perfectly good source here and a hard failure
+// there - and fails on an empty *method* instead.
+//
+// It does authenticate, which /api/parse-recipe-url still does not. Nothing but
+// a token stands between an anonymous request and an OpenAI call on this app's
+// quota, and there is no reason for a new route to inherit that.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const auth = await authenticateAccount(req);
+  if (!auth.ok) {
+    return res.status(auth.status).json({ error: auth.error });
+  }
+
+  const { url } = req.body;
+
+  if (!url) {
+    return res.status(400).json({ error: 'url is required' });
+  }
+
+  try {
+    new URL(url);
+  } catch {
+    return res.status(400).json({ error: 'url is not a valid URL' });
+  }
+
+  try {
+    const html = await (await fetch(url)).text();
+    const { method } = await extractMethod({ input: htmlToInput(html) });
+
+    // Same reasoning as follow-ups.md #40: silently handing back an empty
+    // string looks like the page had no method, rather than like this app
+    // failed to read one. The cook is one keystroke from typing it themselves,
+    // so say which it was.
+    if (!method?.trim()) {
+      return res.status(422).json({
+        error: 'No method could be read from that page. Try another link, a photo, or type it in below.',
+      });
+    }
+
+    res.status(200).json({ method });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+  }
+}

--- a/pages/api/recipe-image.test.mts
+++ b/pages/api/recipe-image.test.mts
@@ -6,16 +6,38 @@ vi.mock('@netlify/blobs', () => ({
 }));
 
 // Imported transitively by the route, and constructs an OpenAI client at module
-// load - which needs a key that no test should have. Nothing here gets as far
-// as an extraction anyway.
+// load - which needs a key that no test should have. Both extractors are
+// stubbed; the upload tests below assert on which of the two a request picked.
 vi.mock('../../lib/recipe-import/extract', () => ({
-  extractRecipe: vi.fn()
+  extractRecipe: vi.fn(),
+  extractMethod: vi.fn()
+}));
+
+// The route reads the upload with formidable and the file off disk. Neither is
+// what these tests are about, so both are stood in for - `parseFields` below is
+// what a given test wants the form to have carried.
+let parseFields: Record<string, string[]> = {};
+
+vi.mock('formidable', () => ({
+  default: () => ({
+    parse: (_req: unknown, cb: (err: unknown, fields: unknown, files: unknown) => void) =>
+      cb(null, parseFields, {
+        image: [{ filepath: '/tmp/upload.jpg', mimetype: 'image/jpeg', size: 1024 }]
+      })
+  })
+}));
+
+vi.mock('fs/promises', () => ({
+  default: { readFile: vi.fn(async () => Buffer.from('image-bytes')), unlink: vi.fn(async () => {}) }
 }));
 
 import { getStore } from '@netlify/blobs';
+import { extractRecipe, extractMethod } from '../../lib/recipe-import/extract';
 import handler from './recipe-image';
 
 const mockedGetStore = getStore as unknown as Mock;
+const mockedExtractRecipe = extractRecipe as unknown as Mock;
+const mockedExtractMethod = extractMethod as unknown as Mock;
 
 // One job, owned by account 7.
 const job = { id: 'job-1', accountId: 7, status: 'completed', result: { name: 'Omelette' }, error: null };
@@ -48,6 +70,11 @@ beforeEach(() => {
   storeGet.mockReset();
   storeGet.mockResolvedValue(JSON.stringify(job));
   mockedGetStore.mockReturnValue({ get: storeGet, set: vi.fn() });
+  parseFields = {};
+  mockedExtractRecipe.mockReset();
+  mockedExtractRecipe.mockResolvedValue({ name: 'Omelette', ingredients: [], method: '', tags: [] });
+  mockedExtractMethod.mockReset();
+  mockedExtractMethod.mockResolvedValue({ method: '1. Beat the eggs' });
 });
 
 afterEach(() => {
@@ -140,5 +167,48 @@ describe('recipe-image upload (POST)', () => {
     await handler(mockReq({ method: 'POST', headers: { authorization: 'Bearer forged' } }), res);
 
     expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  // Method Import shares this route with whole-recipe Photo Import, and `mode`
+  // is the only thing that tells them apart. Get that wrong in either direction
+  // and the failure is quiet: a method-only upload that runs the full
+  // extraction returns a name, tags and an ingredient list for a Recipe that
+  // already has all three, and a whole-recipe upload that runs the method-only
+  // one returns a Recipe with no ingredients in it.
+  it('runs the whole-recipe extraction when no mode is given', async () => {
+    stubAccountApi({ id: 7 });
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'POST', headers: { authorization: 'Bearer good' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(mockedExtractRecipe).toHaveBeenCalled();
+    expect(mockedExtractMethod).not.toHaveBeenCalled();
+  });
+
+  it('runs the method-only extraction for a mode=method upload', async () => {
+    stubAccountApi({ id: 7 });
+    parseFields = { mode: ['method'] };
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'POST', headers: { authorization: 'Bearer good' } }), res);
+
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(mockedExtractMethod).toHaveBeenCalled();
+    expect(mockedExtractRecipe).not.toHaveBeenCalled();
+  });
+
+  // The canonical Ingredient/Unit lists cost two calls to the Go API and a good
+  // chunk of the prompt, and a method-only extraction has no name or unit for
+  // them to reconcile. Only the account check should reach the API.
+  it('does not look up canonical names for a method-only upload', async () => {
+    stubAccountApi({ id: 7 });
+    parseFields = { mode: ['method'] };
+    const res = mockRes();
+
+    await handler(mockReq({ method: 'POST', headers: { authorization: 'Bearer good' } }), res);
+
+    const paths = (fetch as unknown as Mock).mock.calls.map(([url]) => String(url));
+    expect(paths).toEqual(['http://api.test/account']);
   });
 });

--- a/pages/api/recipe-image.ts
+++ b/pages/api/recipe-image.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { getStore } from '@netlify/blobs';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { PageConfig } from 'next';
-import { extractRecipe } from '../../lib/recipe-import/extract';
+import { extractRecipe, extractMethod } from '../../lib/recipe-import/extract';
 import { imageToInput } from '../../lib/recipe-import/photo';
 import { requireEnv } from '../../lib/env';
 import { fetchKnownNames } from '../../lib/recipe-import/known-names';
@@ -61,6 +61,15 @@ const processImage = async (base64Image: string, knownIngredients: string[], kno
     knownIngredients,
     knownUnits,
   });
+};
+
+// Method Import from a photo (a `mode=method` upload): the same photograph of a
+// cookbook page, read for its instructions alone. It shares this route rather
+// than getting one of its own because everything around the extraction - the
+// 5MB upload, the account check, the job in Netlify Blobs and the polling that
+// reads it back - is identical, and it is the part with the teeth in it.
+const processMethodImage = async (base64Image: string) => {
+  return extractMethod({ input: imageToInput(base64Image) });
 };
 
 // Fails fast with a clear error if either var is unset (e.g. a preview
@@ -167,11 +176,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Validate the image
     validateImage(imageFile);
 
+    // formidable returns every field as an array. Anything other than 'method'
+    // - including the field being absent, which is every existing caller - is a
+    // whole-recipe import.
+    const [mode] = fields.mode || [];
+    const methodOnly = mode === 'method';
+
     // Read from the database rather than taken from the form fields - see
     // lib/recipe-import/known-names.ts for why the client is no longer asked.
     // Awaited before the job is created so a lookup failure is logged against
-    // the request that caused it, not against the background job.
-    const { knownIngredients, knownUnits } = await fetchKnownNames(req);
+    // the request that caused it, not against the background job. Skipped
+    // entirely for a method-only import, which has no name to canonicalise.
+    const { knownIngredients, knownUnits } = methodOnly
+      ? { knownIngredients: [], knownUnits: [] }
+      : await fetchKnownNames(req);
 
     // Read the file and convert to base64
     const imageBuffer = await fs.readFile(imageFile.filepath);
@@ -185,7 +203,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const initialJob = await updateJobStatus(jobId, auth.account.id, 'processing');
 
     // Start processing in the background
-    processImage(base64Image, knownIngredients, knownUnits)
+    const processing = methodOnly
+      ? processMethodImage(base64Image)
+      : processImage(base64Image, knownIngredients, knownUnits);
+
+    processing
       .then(async (result) => {
         await updateJobStatus(jobId, auth.account.id, 'completed', result);
       })

--- a/pages/recipes/[id]/edit.tsx
+++ b/pages/recipes/[id]/edit.tsx
@@ -5,6 +5,7 @@ import useRecipe from '@hooks/use-recipe';
 import useRecipeIdParam from '@hooks/use-recipe-id-param';
 import Form from '@components/recipe-form/Form';
 import PageHeading from '@components/page-heading';
+import { useRouter } from 'next/router';
 
 
 const Recipes = () => {
@@ -13,6 +14,14 @@ const Recipes = () => {
   // here was dead.
   const id = useRecipeIdParam();
   const [recipe] = useRecipe(id);
+  const router = useRouter();
+
+  // ?add=method is how the pencil beside an empty Method section on the Recipe
+  // page arrives here (components/recipe/index.tsx). It scrolls the form to the
+  // Method and opens Method Import, so the click lands on the thing it was
+  // about rather than at the top of a form. Anything else is ignored - it is a
+  // hint about where to look, not something to fail on.
+  const focusSection = router.query.add === 'method' ? 'method' as const : undefined;
 
   return (
     <Layout pageTitle={"Recipes"}>
@@ -23,7 +32,7 @@ const Recipes = () => {
           >
             {recipe.name}
           </PageHeading>
-          <Form initialRecipe={recipe} mode="edit" />
+          <Form initialRecipe={recipe} mode="edit" focusSection={focusSection} />
         </MainContent>
         <Sidebar>
           <RecipeList />

--- a/pages/recipes/new.tsx
+++ b/pages/recipes/new.tsx
@@ -9,79 +9,9 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import PhotoIcon from '@components/svg/photo';
 import { nextApiPost, nextApiPostFormData, nextApiGet } from '../../lib/api-client';
 import { queryKeys } from '../../lib/query-keys';
+import { resizeImage } from '../../lib/resize-image';
 import useAuth from '@hooks/use-auth';
 import type { Recipe as RecipeModel } from '../../types/models';
-
-// Helper function to resize image
-const resizeImage = (file: File): Promise<Blob> => {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.readAsDataURL(file);
-    reader.onload = () => {
-      const img = new Image();
-      img.src = reader.result as string;
-      img.onload = () => {
-        const canvas = document.createElement('canvas');
-        let width = img.width;
-        let height = img.height;
-
-        // Calculate new dimensions while maintaining aspect ratio
-        const MAX_WIDTH = 2000; // Maximum width
-        const MAX_HEIGHT = 2000; // Maximum height
-        const MAX_SIZE = 5 * 1024 * 1024; // 5MB in bytes
-
-        if (width > MAX_WIDTH) {
-          height = Math.round((height * MAX_WIDTH) / width);
-          width = MAX_WIDTH;
-        }
-
-        if (height > MAX_HEIGHT) {
-          width = Math.round((width * MAX_HEIGHT) / height);
-          height = MAX_HEIGHT;
-        }
-
-        canvas.width = width;
-        canvas.height = height;
-
-        // A freshly created canvas's 2d context is never null in practice.
-        const ctx = canvas.getContext('2d')!;
-        ctx.drawImage(img, 0, 0, width, height);
-
-        // Recursive function to create blob with quality adjustment
-        const createBlob = (quality: number): Promise<Blob | null> => {
-          return new Promise((resolveBlob) => {
-            canvas.toBlob((blob) => {
-              if (!blob) {
-                resolveBlob(null);
-                return;
-              }
-
-              if (blob.size <= MAX_SIZE || quality <= 0.1) {
-                resolveBlob(blob);
-              } else {
-                // Reduce quality and try again
-                createBlob(quality - 0.1).then(resolveBlob);
-              }
-            }, 'image/jpeg', quality);
-          });
-        };
-
-        // Start with 90% quality
-        createBlob(0.9)
-          .then((blob) => {
-            if (!blob) {
-              reject(new Error('Failed to create image blob'));
-              return;
-            }
-            resolve(blob);
-          })
-          .catch(reject);
-      };
-      img.onerror = reject;
-    };
-    reader.onerror = reject;
-  });
-};
 
 const SOURCE_TABS: { id: 'url' | 'camera' | 'manual'; label: string }[] = [
   { id: 'url', label: 'Recipe Link' },

--- a/technical-architecture.md
+++ b/technical-architecture.md
@@ -48,9 +48,10 @@ For authenticated endpoints, copy the `Authorization` header from browser dev to
 
 | Route | File | Purpose |
 |-------|------|---------|
-| `/api/recipe-image` | `recipe-image.mjs` | GPT-4 Vision: photo → structured recipe JSON (async, polled) |
+| `/api/recipe-image` | `recipe-image.mjs` | GPT-4 Vision: photo → structured recipe JSON (async, polled). A `mode=method` form field switches it to Method Import — same upload, auth, job and polling, but only the method is read out of the photo, and the canonical Ingredient/Unit lookup is skipped |
 | `/api/parse-recipe-url` | `parse-recipe-url.js` | Fetches a recipe URL, reduces the page to the recipe (`lib/recipe-import/url.js`: schema.org JSON-LD where present, else the page's visible text) and makes one LLM call to extract name/ingredients/method/vegetarian-ness — works against any recipe site, replacing the older per-site DOM-selector-plus-regex scrapers (formerly `pages/api/third-parties/*`, now deleted). 422s rather than returning a recipe with no ingredients |
 | `/api/parse-recipe-text` | `parse-recipe-text.js` | LLM-parses freeform multiline ingredient text (Manual Entry's bulk paste box) into structured ingredient lines |
+| `/api/parse-method-url` | `parse-method-url.ts` | Method Import from a link: same page reduction as `/api/parse-recipe-url`, but one LLM call for the method alone (`extractMethod`), no canonical-name lookup, and it accepts a page with no ingredient list. 422s rather than returning an empty method. Unlike the routes above it requires a valid token |
 | `/api/dave/chat` | `dave/chat.js` | GPT-3.5-turbo chat with tool calling (search/get/create shopping list) |
 
 The recipe image extraction uses Netlify Blobs to store async job results; the frontend polls every 2 seconds until complete.
@@ -83,6 +84,7 @@ Components are organized by feature with index files:
 - `components/layout/`: Page layout, header, Grid/Sidebar/MainContent wrappers
 - `components/recipe/`: Individual recipe display and editing
 - `components/recipe-form/`: Full recipe editor (ingredients, tags, image upload)
+- `components/method-import/`: Fills an existing Recipe's Method from a link or a photo, rendered inside the recipe editor in edit mode only (see CONTEXT.md's Method Import)
 - `components/recipe-list/`: Browsable/searchable list of user recipes
 - `components/shopping-list/`: ShoppingList display + Recipes selector sub-components
 - `components/identity/`: Auth0 login/logout/create account buttons


### PR DESCRIPTION
## What

The pencil beside an empty **Method** on a Recipe page now leads somewhere useful. It carries `?add=method`; the edit page scrolls the form to the Method and opens a **Method Import** panel above the textarea, offering the same two sources Recipe Import does, aimed at one field:

- **From a link** — paste the recipe's URL, hit Fetch, the method drops into the field.
- **From a photo** — photograph the page of the cookbook.

Then you save the Recipe as normal. Nothing about it but the Method can change.

## Why

A Recipe imported from a photo or a URL often arrives with ingredients and no method. The Method section already said so — it renders empty rather than hiding itself — but the only thing the pencil could offer was a blank textarea, even though the method was usually right there on the page the ingredients had just been read from.

## How

**A method-only extractor, not whole-recipe import with the rest thrown away.** `extractMethod` asks for the method alone against its own small schema. That skips the canonical Ingredient/Unit lookup (a round trip to the Go API and a good chunk of the prompt, neither of which has anything to reconcile in prose), and it accepts a page carrying instructions and no ingredient list — a hard failure for `/api/parse-recipe-url`, a perfectly good source here. It also cannot rename an Ingredient, invent a Unit or propose a Unit Size, because it only ever returns prose. The Recipe already has a name, tags and Ingredient Lines; returning new ones would only raise the question of which to keep.

**The two sources split by how long they take, as Recipe Import's do.** A link is synchronous (`/api/parse-method-url`, new). A photo goes through the existing Processing Job: `/api/recipe-image` takes a `mode=method` field and swaps the extractor, reusing the 5MB upload, the account check, the Netlify Blobs job and the polling around it unchanged — that machinery is the part with the teeth in it.

**An existing Method is never overwritten.** An extraction that lands on one is offered for the cook to accept or refuse, read through a ref rather than a closure so a method typed *during* the fetch is still safe. An empty extraction says so rather than clearing the field, for the same reason `/api/parse-recipe-url` 422s rather than opening an empty form (follow-ups.md #40): a blank result looks like the page had no method rather than like this app failed to read one.

The panel renders in **edit mode only** — Add New Recipe already offers both sources for the whole Recipe, method included. The method formatting rules are now one shared constant, since two prompts writing the same field into text that `components/recipe/index.tsx` parses `1. `, `2. ` back out of is exactly the kind of thing that drifts. `resizeImage` moved to `lib/` now that two photo paths use it.

## Testing

- **e2e (3 new):** pencil → import → saved method for both sources, plus the overwrite guard. Routes stubbed the way the other import specs stub theirs — no LLM call.
- **Component:** the panel's own tests (apply, offer, discard, empty result, bad link, `mode=method` on the upload), plus Form tests that an imported method reaches the save payload.
- **Route:** `/api/parse-method-url` (auth, 422 on an empty method, returns nothing but the method), and which extractor a `mode=method` upload picks — get that wrong in either direction and the failure is quiet rather than loud.
- Full suite green: 187 Vitest, 27 Playwright, lint, typecheck, production build. Also driven by hand in Chrome against a local stack.

## Not covered

The extraction call itself is stubbed everywhere (as with every existing import test), and this checkout has no `OPENAI_API_KEY`, so **the new prompt has not been run against a real page** — worth one manual try before this is relied on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
