### PR TITLE
Move every workflow action onto the node24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -74,9 +74,9 @@ jobs:
       run:
         working-directory: netlify-functions/recipes
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           # Matches go.mod's `go 1.23.0` and the Dockerfile's build stage.
           go-version: '1.23'
@@ -116,7 +116,7 @@ jobs:
       # Needs Node, but belongs to this job: it checks the artefact generated
       # from the one immediately above, and running it here keeps the whole
       # generated-file chain failing in one place.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -44,14 +44,19 @@ jobs:
       # not github.ref: dispatching from a feature branch would otherwise push
       # that branch straight onto the production machine, and per-branch API
       # deploys are explicitly out of scope for this migration.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha || 'master' }}
 
-      # Pinned, like every other action here. This is the only job that holds
-      # FLY_API_TOKEN, so a mutable @master ref would let an upstream change
-      # reach the credential without any change on our side.
-      - uses: superfly/flyctl-actions/setup-flyctl@v1.4
+      # Pinned to an exact tag rather than the moving `v1`, unlike the actions/*
+      # majors elsewhere. This is the only job that holds FLY_API_TOKEN, so a
+      # ref that moves on its own would let an upstream change reach the
+      # credential with no change on our side.
+      #
+      # The cost of that choice is this: an exact pin does not pick up runtime
+      # bumps either. `v1.4` sat on node16 until GitHub's node20 deprecation
+      # surfaced it. Re-check this tag whenever a runner deprecation lands.
+      - uses: superfly/flyctl-actions/setup-flyctl@1.6
 
       # --remote-only builds on Fly's builder rather than this runner. It is
       # already flyctl's default (--local-only is the opt-out), so this is

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload traces
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-traces
           path: test-results/
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload docker compose logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docker-compose-logs
           path: docker-compose.log


### PR DESCRIPTION
GitHub is deprecating Node 20 on Actions runners and is already force-running our actions on Node 24 — a warning today, a failure later. Surfaced by the `Deploy API` run after #76 merged.

| Action | Was | Now | First major on `node24` |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | v5 |
| `actions/setup-node` | v4 | **v7** | v5 |
| `actions/setup-go` | v5 | **v7** | v6 |
| `actions/upload-artifact` | v4 | **v7** | v7 |
| `superfly/…/setup-flyctl` | v1.4 | **1.6** | 1.6 |

Bumped to the latest major of each rather than the minimum that clears the warning — one bump now against two later.

## Two things the warning doesn't tell you

**`upload-artifact@v5` is still `node20`.** A one-major bump there looks like a fix and silently leaves the deprecation in place. v7 is the first that actually moves.

**`setup-flyctl@v1.4` was on `node16`, not `node20`** — GitHub had already force-migrated it once, so it was two runtimes behind while appearing in the warning as one. The exact pin is deliberate and stays: that job is the only holder of `FLY_API_TOKEN`, so a self-moving ref could reach the credential with no change on our side. The cost of that choice is exactly what happened here — an exact pin doesn't pick up runtime bumps either — so its comment now says to re-check on the next deprecation.

## Verification

The workflows are the change, so CI running green on this PR *is* the verification — `build-lint-test`, `go` and `e2e` all exercise `checkout`, `setup-node`, `setup-go` and `upload-artifact` on the new majors. Worth a specific look at the e2e run's uploaded `playwright-report` artifact, since `upload-artifact` crossed three majors and has a history of behaviour changes between them.

`deploy-api.yml` can't be exercised by a PR — it only fires on `workflow_run` against `master`. It'll be proven by the first deploy after this merges, which is also the next `setup-flyctl` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)