### PR TITLE
Restore the cutover spec under specs/completed

### DIFF
--- a/specs/completed/api-hosting-migration.md
+++ b/specs/completed/api-hosting-migration.md
@@ -1,0 +1,228 @@
+# Move the Go API off Netlify Functions onto Fly.io in Frankfurt
+
+Decisions and rationale: [ADR-0006](../docs/adr/0006-go-api-leaves-netlify-functions.md).
+This spec covers the *how*. Do this before [`observability.md`](./observability.md) —
+that spec's design assumes the API is a long-lived process.
+
+## Current state (why this isn't greenfield)
+
+The Go API is one AWS Lambda behind Netlify Functions. `main.go`'s `init()` builds a
+negroni router via `app.GetRouter("/.netlify/functions/recipes")` and `main()` branches
+three ways: `openapi` (print spec, exit), `dev` (plain `http.Server` on `:8080`), and
+default (`lambda.Start`).
+
+Three facts make this migration small:
+
+- **The server already exists.** The `dev` branch runs the *same* router as an ordinary
+  HTTP server. Production and local currently differ only in how the router is invoked.
+- **It's already containerized.** `netlify-functions/recipes/Dockerfile.dev` plus the
+  `api` service in `docker-compose.yml` build and run it, and the e2e suite depends on
+  that working.
+- **Everything reaches the API through `NEXT_PUBLIC_API_HOST`.** Nothing constructs a
+  Lambda URL of its own. There are four consumers, and **three of them run server-side**:
+  `lib/api-client.ts` (browser), `lib/dave/tools.ts`, `lib/authenticate.ts` and
+  `lib/recipe-import/known-names.ts`. See Phase 4 — that split is the migration's main
+  correctness trap.
+
+And three make it necessary:
+
+- Netlify's functions region defaults to `cmh` (us-east-2) and region selection is
+  Pro/Enterprise. TiDB is `eu-central-1`. Every query is transatlantic, several
+  sequentially per request.
+- Netlify's Lambda compatibility mode — which is what `lambda.Start` +
+  `events.APIGatewayProxyRequest` is — stops being accepted for deploys on 1 July 2027.
+- No Netlify tier exposes Lambda layers or extensions, so there is no collector sidecar
+  and no post-response flush at any price.
+
+Two pre-existing defects surface here and are fixed as part of the work:
+
+- `app.go:211` sets `AllowedOrigins: {"*"}` with `AllowCredentials: true`. The CORS spec
+  forbids that pairing, so it does not do what it appears to.
+- `.github/workflows/ci.yml` triggers on `pull_request` and `workflow_dispatch` only.
+  `go fmt`, `go test` and both drift checks live in `build.sh`, i.e. they run **only** in
+  Netlify's deploy build. Remove Go from Netlify without addressing this and they stop
+  running entirely.
+
+## Proposed approach
+
+### Phase 0 — DONE. The unknown is settled: `Authorization` is forwarded
+
+**Answered empirically on 2026-08-05**, via a throwaway branch deploy (PR #74, since
+closed) carrying the exact rewrite this migration proposes — `/api/bigshop/*`,
+`status = 200`, `force = true` — pointed at an echoing origin. Netlify's docs do not
+answer this, and the one support-forum thread asking it was closed without a staff reply,
+so measurement was the only route.
+
+| Question | Result |
+| --- | --- |
+| `Authorization` forwarded to an external origin? | **Yes**, intact |
+| Arbitrary custom headers (`traceparent`, `X-Probe-Custom`)? | **Yes**, verbatim |
+| `PUT` / `PATCH` / `DELETE` proxied? | **Yes**, all 200 |
+| Method, body and `Content-Type` preserved on POST? | **Yes**, body round-tripped exactly |
+| Genuine rewrite rather than a 302? | **Yes**, 0 redirects, URL unchanged |
+
+**The `api.bigshop.life` subdomain fallback is therefore not needed**, and same-origin is
+confirmed rather than assumed. Every route family the API actually uses — `apiGet` plus
+`apiMutate`'s four verbs in `lib/api-client.ts` — is covered by the methods tested.
+
+Netlify adds several headers on the way through, visible at the origin:
+
+- `x-nf-client-connection-ip` — the real client IP survives the proxy, so rate limiting or
+  abuse handling at the origin remains possible.
+- `x-nf-request-id` — correlates a request with Netlify's own logs. Worth putting on spans;
+  noted in [`observability.md`](./observability.md).
+- `x-nf-netlify-proxy` — a **signed JWT** (`iss: netlify`, `sub: proxy`, carrying
+  `request_id` and `client_ip`). This means the Fly origin could verify that traffic
+  arrived via Netlify with no shared secret to manage — a cheaper mechanism than the JWS
+  signing ADR-0006 considered and rejected. It does **not** change that decision: Dave's
+  server-side calls address Fly directly and would not carry it, so the origin must accept
+  unsigned traffic anyway. Recorded because it is the obvious thing to reach for later.
+- `x-country`, `x-nf-account-tier`.
+- Netlify **rewrites `Accept` to `*/*,image/webp`**. See "Things to get right" — Huma
+  negotiates on `Accept`.
+
+### Phase 1 — Make it deployable
+
+- Production `Dockerfile` (multi-stage, static build, no `air`, non-root) alongside the
+  existing `Dockerfile.dev`.
+- `fly.toml`: one `shared-cpu-1x` machine, **512MB** (Go plus the collector sidecar that
+  `observability.md` adds later), region `fra`, `auto_stop_machines = false`.
+- `DSN` as a Fly secret. `main.go:37`'s TiDB TLS config is unchanged — it pins
+  `gateway01.eu-central-1` and Fly reaches it identically, over the public endpoint.
+  Note Fly runs its own hardware, so `fra` is the same *metro* as TiDB's AWS
+  `eu-central-1`, not the same provider network — the hop is Frankfurt peering at
+  ~1–5ms rather than intra-AWS at ~0.5–1ms. Accepted in ADR-0006; no private
+  networking or PrivateLink is available or attempted.
+- Change the router base path from `/.netlify/functions/recipes` to **`/api/bigshop`**,
+  then regenerate both derived artefacts:
+  `go run . openapi > ../../docs/openapi.yaml` and `npm run generate:api-types`.
+- Fly health check on `/health`.
+
+### Phase 2 — Move the checks before removing them
+
+- Add a `go` job to `ci.yml`: `go fmt ./...`, `go test ./... -v`, the `openapi.yaml` drift
+  check, and the existing `api.d.ts` drift check.
+- **Add `push: branches: [master]` to `ci.yml`'s triggers.** Without this, the checks
+  currently guaranteed by Netlify's deploy build would only run on PRs.
+- `build.sh` reduces to `npm run package`. Remove `GO_VERSION` from `netlify.toml`.
+- New `deploy-api.yml`: on push to master, gated on CI, builds the image and runs
+  `fly deploy`.
+
+Phase 2 lands *before* Phase 3 so there is never a window where the Go checks run nowhere.
+
+### Phase 3 — Dual run
+
+Deploy to Fly and add the rewrite while the frontend still points at the Lambda:
+
+```toml
+[[redirects]]
+  from = "/api/bigshop/*"
+  to = "https://<app>.fly.dev/api/bigshop/:splat"
+  status = 200
+  force = true
+```
+
+Nothing is live — no client requests that path yet. Both APIs serve the same production
+TiDB, so there is no data migration and no divergence.
+
+Verify against real production data: an authenticated `GET /api/bigshop/recipes` through
+`www.bigshop.life`, a write, and `/health`. Compare a shopping-list generate's latency
+against the Lambda's for the same account.
+
+### Phase 4 — Cut over
+
+One frontend deploy changes two values:
+
+- `NEXT_PUBLIC_API_HOST` → `/api/bigshop` (relative — same origin via the rewrite)
+- `API_HOST_INTERNAL` → `https://<app>.fly.dev/api/bigshop`, a new **server-side-only**
+  variable (no `NEXT_PUBLIC_` prefix, and it must never acquire one).
+
+**All three server-side consumers must switch to `API_HOST_INTERNAL`**, not just Dave.
+A relative `NEXT_PUBLIC_API_HOST` is meaningless in a Node process, so any that is missed
+breaks outright rather than merely running slowly:
+
+| Consumer | Runs | Why it matters |
+| --- | --- | --- |
+| `lib/api-client.ts` | Browser | Stays on the relative path — this is the one that should |
+| `lib/dave/tools.ts` | Netlify fn | Several calls per turn; avoids us-east-2 → edge → Frankfurt |
+| `lib/authenticate.ts` | Netlify fn | **On the critical path of every authenticated Next.js route** — it authenticates by calling `GET /account` on the Go API |
+| `lib/recipe-import/known-names.ts` | Netlify fn | Forwards the caller's header to read canonical Ingredient/Unit names |
+
+`lib/authenticate.ts` deserves particular attention: it was added by #71 and means every
+authenticated Next.js API route now makes a *synchronous* call to the Go API before doing
+its own work. Post-migration that is a transatlantic hop from us-east-2 to Frankfurt on
+every such request. Going direct rather than via the proxy removes one leg of it; removing
+the other would mean moving those routes, which is out of scope.
+
+`e2e/env.ts`'s `API_HOST` changes to the new base path in the same PR.
+
+Rollback is reverting those values and redeploying. The Lambda is still there, still
+serving its old path, untouched.
+
+### Phase 5 — Tidy up, after a cooling-off period
+
+Deliberately a separate PR, days later:
+
+- Delete the `lambda.Start` branch from `main()`, plus `aws-lambda-go` and
+  `aws-lambda-go-api-proxy` from `go.mod`. The `dev` branch becomes the only server path,
+  so production and local run identical code.
+- Rename `netlify-functions/recipes/` → `api/`. Update `docker-compose.yml`, `build.sh`,
+  `scripts/build-local.sh`, `CLAUDE.md`, `technical-architecture.md`.
+- Fix the CORS config to a real origin allowlist.
+
+## Decisions made (grilled — do not re-litigate without a load-bearing reason)
+
+- **Fly.io, `fra`, one always-on machine.** Not Netlify Pro (costs ~4× and fixes less —
+  no sidecar at any tier, flush remains, deadline remains). Not a Hetzner/EC2 VPS (cheaper
+  but OS, TLS, patching and deploy tooling all become ours). Not auto-stop — cold starts
+  are what we are migrating away from.
+- **Netlify keeps everything else**: the Next.js site, SSR, the four LLM API routes,
+  branch deploys.
+- **Same origin via a 200 rewrite**, not a subdomain — preserves the no-CORS property.
+  Subdomain is the documented fallback if Phase 0 fails.
+- **Base path `/api/bigshop`.** `/api/*` alone would swallow the five Next.js routes.
+  No version segment; `/api/bigshop/v1` remains available later at the cost of one
+  regeneration.
+- **The Fly origin stays publicly reachable**, guarded by the Auth0 JWT validation that
+  already guards every route bar `/health`. No JWS signing — it is defence in depth over
+  an already-authenticated API, and buying it would mean either slowing Dave down or
+  maintaining a second auth path.
+- **Dual-run cutover**, flipped by env var, with the Lambda left deployed for a
+  cooling-off period. Not big-bang.
+- **Go checks move to `ci.yml` wholesale**, with a push trigger added.
+
+## Explicitly out of scope
+
+- Per-branch API deploys. Branch deploys will proxy to the single production API instance.
+  This is a real, accepted degradation — see ADR-0006's consequences.
+- Moving the Next.js LLM routes anywhere. They stay Netlify Functions in us-east-2; their
+  latency is dominated by OpenAI calls measured in seconds.
+- Multi-instance or multi-region Fly deployment. One machine; revisit if deploy blips
+  become annoying.
+- Any observability work. That is [`observability.md`](./observability.md), and it depends
+  on this landing first.
+
+## Things to get right when building this
+
+- **Phase 0 is done** — see above. Nothing is blocked on it.
+- **Netlify rewrites the `Accept` header to `*/*,image/webp` through the proxy.** Huma
+  does content negotiation on `Accept`, so confirm during Phase 3's verification that
+  responses still come back as JSON rather than something else. It should be fine — `*/*`
+  is present and Huma resolves that to JSON — but it is a header the API's framework
+  actually reads, mutated by an intermediary, which is exactly the shape of bug
+  `follow-ups.md` #12 records being caught only by e2e.
+- **Phase 2 before Phase 3.** There must be no window in which the Go checks run nowhere.
+- `docs/openapi.yaml` and `types/api.d.ts` are generated and drift-checked. A base path
+  change means regenerating both; the drift check will catch it if you forget, but only
+  once the check is running in its new home.
+- **A relative `NEXT_PUBLIC_API_HOST` (`/api/bigshop`) works in the browser and nowhere
+  else.** Three server-side consumers must move to `API_HOST_INTERNAL` — see the table in
+  Phase 4. This list was wrong in the first draft of this spec (it named two consumers;
+  there are four) and grew again when #71 added `lib/authenticate.ts`, so re-grep for
+  `NEXT_PUBLIC_API_HOST` at implementation time rather than trusting the table.
+- The Netlify proxy has a **26 second ceiling**. Comfortable for CRUD; worth remembering
+  if any endpoint ever grows slow.
+- `docker-compose.yml`, `dev-full.sh` and the e2e stack already run the API as a plain
+  server and need no structural change — only the base path in `e2e/env.ts`.
+- Keep `/health`'s no-auth carve-out (`app.go:219`). It now backs a Fly health check as
+  well as the uptime monitoring in `observability.md`.

--- a/specs/completed/api-hosting-migration.state.md
+++ b/specs/completed/api-hosting-migration.state.md
@@ -1,0 +1,256 @@
+---
+spec: specs/api-hosting-migration.md
+status: in-progress
+branch: fly-migration
+pr: https://github.com/Ianfeather/big-shop/pull/76
+---
+
+**The code for Phases 1–4 is written and green; the migration is not done.** This file and
+the spec briefly moved into `specs/completed/` when the PR opened, which was wrong — the
+cutover had not happened and Phase 5 had not started. Moved back on 2026-08-08.
+
+## Where this actually is
+
+| | State |
+| --- | --- |
+| PR [#76](https://github.com/Ianfeather/big-shop/pull/76) | Open, all checks green, **not merged** |
+| Fly app `big-shop-api` | **Live**, verified 2026-08-08 — `/api/bigshop/health` 200, `/api/bigshop/recipes` 401 |
+| `FLY_API_TOKEN` repo secret | Not set — `deploy-api.yml` fails at its last step until it is |
+| `go` in the `required checks` ruleset | Not added |
+| Cutover (runbook step 5) | Not done. **Merging the PR is the cutover** — `.env.production` carries the post-cutover values |
+| Phase 5 | Not started, by design |
+
+## Measured: the migration's premise, confirmed
+
+Runbook step 5's latency check, run 2026-08-08 before cutover. `GET /shopping-list`, same
+production Account, same production TiDB, five samples each after a discarded warm-up,
+TTFB minus TLS-established. Both through Netlify's edge, so this is the production shape:
+
+```
+LAMBDA (us-east-2)  server≈1624ms  total≈1678ms  n=5
+FLY (fra)           server≈ 165ms  total≈ 212ms  n=5
+```
+
+**1,459ms removed, ~90% of the request.** ADR-0006 justified the move on 300–500ms, so the
+result is 3–5x the case that was argued. Recorded in the ADR's new "Measured outcome"
+section.
+
+Why the estimate was low is *not* settled. Counted from the code, `GET /shopping-list`
+makes nine sequential queries, not the "several" assumed — but nine at ~90ms predicts
+~810ms against ~1,624ms observed, so query count does not explain it either. The leading
+hypothesis is TLS connection establishment (TiDB Serverless requires it; `main.go` sets no
+pool limits), which would make ADR-0006's last listed consequence the dominant effect
+rather than a footnote. `follow-ups.md` #49 carries the investigation.
+
+Also verified pre-cutover, against `deploy-preview-76`:
+- The rewrite is genuine — 200, `redirects=0`, URL unchanged, not a 302.
+- Auth is enforced through the proxy (401 without a token).
+- **The `Accept` risk is retired**: an authenticated response comes back
+  `content-type: application/json` despite Netlify rewriting `Accept` to `*/*,image/webp`.
+- A write through the proxy works.
+
+Not verifiable on a preview: anything needing a browser login — see `follow-ups.md` #48,
+opened for it. Those checks move to production after merge.
+
+## Still to do
+
+1. `fly tokens create deploy` → add as repo secret `FLY_API_TOKEN`.
+2. Add `go` to the `required checks` ruleset (it matches on job name; until then the job
+   gates nothing, and a red `go` silently stops the API deploying while Netlify keeps
+   shipping the site).
+3. Runbook step 5: check Netlify's own env vars are not still overriding
+   `NEXT_PUBLIC_API_HOST` with the Lambda URL, verify the proxy, compare a shopping-list
+   generate's latency against the Lambda, then merge.
+4. **Phase 5, days later, as a separate PR**: delete the `lambda.Start` branch and
+   `lambdaBasePath` from `main.go`, drop `aws-lambda-go`/`aws-lambda-go-api-proxy`, remove
+   `GO_VERSION` from `netlify.toml`, rename `netlify-functions/recipes/` → `api/`, fix the
+   CORS allowlist. **Merging it is what makes rollback stop working**, so not the same day.
+
+Known ergonomics wrinkle found on first contact with the deployed app: a bare `/health`
+returns 401, because the carve-out is `basePath + "/health"` and everything is registered
+under `/api/bigshop`. `fly.toml`'s check uses the right path, so this is cosmetic — but it
+is the first thing anyone tries, and `observability.md`'s uptime monitor will meet it too.
+A root alias in `app.go`'s carve-out would cost two lines and no OpenAPI regeneration.
+
+Fly app name: `big-shop-api` (→ `big-shop-api.fly.dev`), chosen by the user at planning
+time and baked into `fly.toml` and the `netlify.toml` rewrite.
+
+This run covers **Phases 1–4 as code**. `flyctl` is not installed on this machine and no
+Fly account is configured, so `fly launch`, secrets, `fly deploy` and the Phase 3
+production verification are the user's to run, from `docs/fly-migration-runbook.md`
+(written in Session 3). **Phase 5 is deliberately excluded** — the spec calls for it as a
+separate PR after a cooling-off period.
+
+## Branch-deploy verification (post-PR)
+
+All CI green on the first run, including the new `go` job (46s) and Netlify's own
+**Redirect rules** check, which validates the `[[redirects]]` block. Netlify's build also
+succeeded, independently confirming that keeping `GO_VERSION` was right — it still compiled
+the Lambda.
+
+Against `deploy-preview-76--big-shop.netlify.app`, which is the only place the two things
+that cannot be tested locally could be checked:
+
+```
+GET /.netlify/functions/recipes/health   -> 200 "ok"   # lambdaBasePath works; rollback target is real
+GET /.netlify/functions/recipes/recipes  -> 401        # ...with auth still running
+GET /api/bigshop/health                  -> 502        # rewrite fires; no Fly app exists yet
+```
+
+The 502 is the correct result at this stage: it proves the rewrite is wired and aimed at
+`big-shop-api.fly.dev`, which runbook step 1 creates.
+
+## Session 1: Phase 1 — make it deployable
+Status: done
+Scope: Production `Dockerfile` + `.dockerignore`, `fly.toml`, raised HTTP timeouts on the
+  `dev` server branch (it becomes the production server), router base path
+  `/.netlify/functions/recipes` → `/api/bigshop`, regenerated `docs/openapi.yaml` and
+  `types/api.d.ts`, and every local reference to the old path (`scripts/dev-full.sh`,
+  `.env.development`, `e2e/env.ts`, `CLAUDE.md`, `technical-architecture.md`).
+Depends on: none
+Commit: f925c12
+Notes: Gates green — vitest 134, e2e 21, `go test`/`go vet`/`gofmt` clean, both drift
+  checks clean, and the production image verified serving real reads *and* writes against
+  a local MySQL (including with `Accept: */*,image/webp`, which still returns
+  `application/json` — the spec's Huma-negotiation worry, cleared at the origin).
+
+  Deviations from the spec's Phase 1, all deliberate:
+  - `e2e/env.ts` is filed under Phase 4 in the spec but has to move with the base path or
+    e2e goes red immediately — same PR either way.
+  - The `dev` server branch is renamed `serve` (`dev` still accepted as an alias, so
+    CLAUDE.md's documented invocation keeps working). It is the production server now, so
+    a container started by an argument called "dev" read as a mistake.
+  - Its timeouts go from 3s read/write to 10s/30s/120s and `ListenAndServe` now
+    `log.Fatal`s. Those timeouts had never applied to production traffic — the Lambda path
+    ignores them — and 3s would have truncated shopping-list generation.
+
+  Two review findings fixed, both raised independently by the Standards and Spec agents:
+  - **`lambdaBasePath` added.** A single `basePath` const would have made the redeployed
+    Lambda 404 on its own path, silently voiding the spec's rollback story ("The Lambda is
+    still there, still serving its old path, untouched"). The Lambda now keeps its old
+    prefix; the server uses the new one; Phase 5 deletes the former with `lambda.Start`.
+  - **`AUTH0_DOMAIN`/`AUTH0_AUDIENCE` pinned in `fly.toml`'s `[env]`.** The spec names only
+    `DSN`. With `AUTH0_DOMAIN` unset the JWKS fetch resolves to `https:///...` and every
+    authenticated route rejects while `/health` stays green — a machine that looks
+    deployed and serves nothing. `SENDGRID_API_KEY` is the other var the API reads; it is
+    a secret, so it goes in the runbook alongside `DSN`.
+
+  Not verified locally: Lambda-mode route registration (it needs a Lambda runtime). The
+  Netlify branch deploy this PR triggers is the real check — the old path must still work
+  there.
+
+## Session 2: Phase 2 — move the checks before removing them
+Status: done
+Scope: `ci.yml` gains `push: branches: [master]` and a `go` job (gofmt gate, `go test`,
+  both drift checks). `build.sh` reduces to `npm run package`; `GO_VERSION` leaves
+  `netlify.toml`. New `.github/workflows/deploy-api.yml` gated on CI.
+Depends on: Session 1
+Commit: a1fa73d
+Notes: Gates green — vitest 134, typecheck, lint, all three workflow YAMLs and both TOMLs
+  parse, all shell scripts pass `bash -n`.
+
+  Deviations from the spec's Phase 2:
+  - **`GO_VERSION` stays in `netlify.toml`**, contrary to "Remove `GO_VERSION` from
+    `netlify.toml`". Netlify still *compiles* the Lambda on every deploy through the
+    cooling-off period — the functions directory is configured in the Netlify UI, not in
+    `netlify.toml`, which is exactly why removing the pin looks safe from the repo alone.
+    A failed Netlify build takes the whole site down, not just the API. Phase 5 deletes
+    the function and the pin together.
+  - **`gofmt -l`, not `go fmt ./...`** as the spec words it. `go fmt` rewrites files and
+    exits 0 regardless, so the check as specified would have shipped as a gate that can
+    never fail — it has been one in `build.sh` all along.
+  - **`go vet` added** (spec lists four checks, not five) and `scripts/build-local.sh`
+    updated to match, so the local script and CI don't drift.
+
+  Review findings fixed: stale docs in `CLAUDE.md` and `technical-architecture.md` (three
+  statements about `build.sh` running Go tests, now false); `deploy-api.yml`'s concurrency
+  comment contradicted its config; manual dispatch would have deployed whatever branch it
+  was dispatched from; `setup-flyctl@master` pinned to `@v1.4` (it is the only job holding
+  `FLY_API_TOKEN`); `npm ci` added before the `api.d.ts` drift check so the pinned
+  generator runs rather than whatever `npx` fetches.
+
+  **ACTION REQUIRED (repo setting, not code): add `go` to the `required checks` ruleset.**
+  Worse than a missing gate — `deploy-api.yml` keys off the whole CI workflow's
+  conclusion, so a red `go` job merged through the un-updated ruleset silently stops the
+  API deploying while Netlify goes on shipping the site from that same commit.
+
+  Known limitation, accepted and tracked as `follow-ups.md` #43: the deploy is gated on CI
+  only, as the spec says, and `e2e.yml` is a separate workflow a `workflow_run` cannot see.
+  Narrower than it sounds — every commit on `master` came through a PR where both suites
+  were green — but the ruleset is not "strict", so the merge commit itself is CI-verified
+  and not e2e-verified, and it is the merge commit that deploys.
+
+  `push: branches: [master]` on `ci.yml` turns out to matter for a different reason than
+  first written. It is not extra check coverage: a direct push to `master` is *rejected*,
+  not merely ungated (master's own `d81c9d6` established this after the branch was cut).
+  It is required because `deploy-api.yml`'s `workflow_run` filters on the triggering run's
+  head branch, which for a `pull_request` run is the PR's branch and never `master` —
+  without the push trigger the API would never deploy at all. Comment corrected on rebase.
+
+## Session 3: Phase 3 — dual run
+Status: done
+Scope: `netlify.toml` rewrite `/api/bigshop/*` → `https://big-shop-api.fly.dev/api/bigshop/:splat`
+  (`status = 200`, `force = true`), plus `docs/fly-migration-runbook.md` for the deploy and
+  production-verification steps only the user can execute.
+Depends on: Session 2
+Commit: 19ca47a
+Notes: Gates green — vitest 134, e2e 21, typecheck, lint, `netlify.toml` parses and the
+  redirect resolves as intended. Confirmed no `pages/api` route is shadowed: the five are
+  `parse-recipe-text`, `parse-recipe-url`, `recipe-image`, `dave/chat`, `dev/openapi-spec`,
+  all siblings of `/api/bigshop` rather than under it.
+
+  The rewrite cannot be verified locally — e2e talks to the container directly, and there
+  is no Netlify proxy in front of `next dev`. Its real verification is the runbook's step 5.
+
+  Review caught four runbook commands that would not have worked as written:
+  - `fly tokens deploy` is not a command (`fly tokens create deploy` is).
+  - Every `fly` command must run from `netlify-functions/recipes`. `--config` relocates
+    only the config *file*; the app root and Docker build context still come from the
+    working directory, so running from the repo root would have used the whole repo as
+    build context with no Dockerfile in it.
+  - The rewrite-vs-redirect check used `curl -I`. The `/health` carve-out in `app.go` is
+    `r.Method == http.MethodGet`, so a HEAD falls through to the JWT middleware and returns
+    401 on a *healthy* deploy — the check would have failed precisely when all was well.
+  - `/health` returns the bare string `ok`, not JSON.
+
+  Also swapped `fly launch` for `fly apps create`: `fly.toml` and `Dockerfile` are already
+  committed, so there is nothing to scaffold, and launch's framework detection would have
+  found the Next.js app at the repo root.
+
+## Session 4: Phase 4 — cut over
+Status: done
+Scope: New `lib/api-host.ts` (`serverApiHost()`, prefers `API_HOST_INTERNAL`, falls back to
+  `NEXT_PUBLIC_API_HOST`); `lib/dave/tools.ts`, `lib/authenticate.ts` and
+  `lib/recipe-import/known-names.ts` move onto it; `API_HOST_INTERNAL` set in
+  `.env.development` and `scripts/dev-full.sh`; tests extended; env docs updated.
+Depends on: Session 3
+Commit: fa21ebd
+Notes: Gates green — vitest 143 (31 files), e2e 21, typecheck, lint.
+
+  Consumer set re-grepped at implementation time as the spec insists: four, three of them
+  server-side, matching the table. `lib/api-client.ts` correctly stays on
+  `NEXT_PUBLIC_API_HOST`. Nothing outside `.ts` constructs a Go API URL.
+
+  Two additions beyond the spec's letter, both from review:
+  - **`serverApiHost()` rejects a relative value** instead of returning it. A relative path
+    is truthy, so the exact misconfiguration the spec warns about (`API_HOST_INTERNAL`
+    forgotten, `NEXT_PUBLIC_API_HOST` relative) sailed past every caller's `if (!host)`
+    guard and surfaced as an opaque `fetch` throw. Now it logs the missing variable and
+    takes the existing not-configured path.
+  - **`.env.production` updated** — it is tracked, and both reviewers caught that leaving
+    it naming the Lambda created a silent fallback: forget the Netlify variable and auth,
+    import and Dave quietly keep using a Lambda that Phase 5 deletes. It now carries the
+    post-cutover values, which makes **merging the PR the cutover**. Netlify's own env vars
+    still override the file, so they remain the rollback lever. Runbook step 5 reordered
+    accordingly: Fly must be verified *before* merge.
+
+  Test quality was the real finding. Under mutation (`serverApiHost()` →
+  `process.env.NEXT_PUBLIC_API_HOST`) the suite now fails in 5 places across three files.
+  Before this session `known-names.test.ts` passed that mutation — it asserted a URL
+  *suffix*, which a relative path satisfies — and `lib/dave/tools.ts` had no coverage of
+  the non-mock path at all (all 12 existing cases pass `useMockApi = true`).
+  `pages/api/recipe-image.test.mts` had its stub corrected to the production shape, but it
+  stubs `fetch` without inspecting the URL, so it does not catch the regression;
+  `authenticate.test.ts` is what does.
+
+  Also extracted `toolApiHost()` from four identical lines in `tools.ts`.


### PR DESCRIPTION
Finishes a file move that only ever did its delete half. Documentation only — no code, no user-visible surface, so no screenshots.

## What happened

`5080d98` ("move cutover spec to completed") removed `specs/api-hosting-migration.md` and `specs/api-hosting-migration.state.md` from `specs/`, but the copies under `specs/completed/` were never staged — they existed only in the working tree. That deletion reached `master` via #84, so as of `c809737` both files are in **no commit at all** and survive only on one machine.

## What this does

Adds them back at their intended destination. Both are byte-identical to the versions deleted in `5080d98^`, verified with `git show 5080d98^:specs/<f> | diff -`, and the line counts match the original deletion exactly (228 and 256).

## Testing

Docs only; nothing under test asserts on these files. CI (`build-lint-test`, `e2e`) runs as the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)