### PR TITLE
Settle #49, and spec the work it found

### DIFF
--- a/docs/adr/0006-go-api-leaves-netlify-functions.md
+++ b/docs/adr/0006-go-api-leaves-netlify-functions.md
@@ -84,26 +84,38 @@ best case.
 **1,459ms removed — about 90% of the request, a 10x improvement.** Three to five times
 the 300–500ms this decision was justified on.
 
-**Why the estimate was low is not yet settled, and the obvious answer is wrong.** Counted
-from the code, `GET /shopping-list` issues **nine** sequential DB round trips — three of
-them re-resolving `GetAccountID` from the same `userID` — with no N+1 loop anywhere. At the
-~90ms round trip assumed above, nine predicts ~810ms, but the Lambda spent ~1,624ms. So
-roughly 800ms is unaccounted for by query *count*.
+**Why the estimate was low is now settled, and neither the count nor the hypothesis below
+was right.** Follow-up #49 measured it (see `follow-ups-resolved.md` for the method and the
+numbers). The short version: **`GET /shopping-list` costs fifteen blocking round trips, not
+nine.** Nine is the number of *queries*, and a query is not a round trip. Six of the nine
+carry parameters, and `database/sql` over `go-sql-driver` serves a parameterised query as a
+server-side prepared statement — `COM_STMT_PREPARE`, wait, `COM_STMT_EXECUTE`, wait — so
+each costs **two**. The three catalog queries take no parameters and go as a single
+`COM_QUERY`. Six twos and three ones is fifteen, and fifteen at the ~90ms assumed above is
+~1,350ms rather than ~810ms. The rest of the 1,624ms is the Netlify-edge-to-`us-east-2` hop
+and one more transatlantic round trip nobody had counted at all: **every authenticated
+request re-fetched the Auth0 JWKS**, uncached, before touching the database.
 
-The leading hypothesis is connection establishment rather than queries: TiDB Serverless
-requires TLS, so a new connection costs a TCP plus a TLS handshake — three to four round
-trips, ~270–360ms transatlantic — before any query runs, and `main.go` sets no pool limits
-at all. That would make the last consequence listed below ("connection pooling starts
-working properly") the dominant effect rather than a footnote. It is a hypothesis, not a
-finding; follow-up #49 carries the investigation, and
-[ADR-0007](./0007-observability-otel-grafana-cloud.md)'s per-query spans will settle it for
-free once they land.
+*This paragraph's original text is preserved below because being wrong in a specific,
+recorded way is the useful part.* The leading hypothesis was connection establishment
+rather than queries: TiDB Serverless requires TLS, so a new connection costs a TCP plus a
+TLS handshake — three to four round trips — before any query runs, and `main.go` sets no
+pool limits at all. That turned out to be real but not dominant: measured, a TLS MySQL
+connection costs ~5 round trips (~450ms transatlantic), but it is paid **once per
+connection**, and these samples were warm. It was the right suspicion about the wrong
+term — the request was indeed paying for something other than queries, just not that.
 
 The honest caveats: one endpoint, one Account, one moment. It is the endpoint this ADR
 singled out as worst, so it is the right one to quote, but it is a headline rather than a
-distribution — real percentiles arrive with the observability work. And the mechanism
-credited above is the one that was *predicted*; the measurement suggests the biggest single
-win may have come from somewhere else.
+distribution — real percentiles arrive with the observability work.
+
+The decision itself survives the correction intact, and for a better reason than it was
+made on. Moving to the same metro as the database was justified on "several sequential
+queries at ~90ms"; it turned out to be paying that ~90ms **fifteen** times per request
+rather than nine, plus once more to Auth0. Every one of those is a transatlantic hop that
+Frankfurt makes local, which is why the move recovered three times what was claimed for it.
+The reason it over-delivered is that the round trips were undercounted, not that the
+mechanism was wrong.
 
 ## Consequences
 
@@ -130,4 +142,6 @@ win may have come from somewhere else.
   address Fly directly and carry no such header, so unsigned traffic must be accepted
   regardless. Recorded because it is the obvious thing to reach for if that changes.
 - Connection pooling to TiDB starts working properly. Every cold Lambda container
-  previously built a fresh pool and `Ping`ed across the Atlantic during `init()`.
+  previously built a fresh pool and `Ping`ed across the Atlantic during `init()` — since
+  measured at ~5 round trips for a TLS MySQL connection, so ~450ms transatlantic, once per
+  connection.

--- a/follow-ups-resolved.md
+++ b/follow-ups-resolved.md
@@ -297,17 +297,19 @@ cross-references between entries (e.g. #9 references #16).
       against the real tenant, a request with a well-formed token costs ~15–18ms where one
       with no token at all costs ~2ms, on every request rather than the first. On the Lambda
       that was a transatlantic hop to an EU Auth0 tenant on every single request. Filed as
-      #52.
+      #54.
 
     **What was already true and stays true: none of this is urgent.** At 165ms the endpoint
     is fine and the migration took ~90% of the cost out. The point of the item was to
     understand the reason before anyone optimised on a guess, and the reason turned out to
     contradict both the guess *and* the number in the title.
 
-    One consequence for other queued work: **#44 reasons about a query profile that is now
-    known to be wrong** — it is a headers/caching item and nothing in it depends on the
-    count, but its framing of the API as "22 routes, nineteen of them account-scoped and
-    mutable" should be read alongside the fact that the mutable ones are the expensive ones.
+    One note for #44, which landed alongside this and reasoned about a query profile that
+    had never been measured. Nothing in its conclusions depended on the count, and none of
+    them change: the three cacheable routes are the three cheapest here (1 round trip each),
+    and the expensive routes are all account-scoped and correctly `private, no-store`. What
+    the measurement adds is why that split is so lopsided — the mutable routes are not
+    merely uncacheable, they are where every round trip actually is.
 
     Fixed here rather than filed, being a real defect found directly on the measured path:
     **a token whose `kid` names no key in the tenant's JWKS panicked the handler** instead

--- a/follow-ups-resolved.md
+++ b/follow-ups-resolved.md
@@ -227,3 +227,95 @@ cross-references between entries (e.g. #9 references #16).
     [ADR-0006](./docs/adr/0006-go-api-leaves-netlify-functions.md), a preview still proxies
     to the single production Fly API, so it exercises production data. Previews are for
     frontend changes; API changes are verified against the local stack and the e2e suite.
+
+49. ~~Investigate why a request costs ~160ms per query, not ~90ms — and why `GET /shopping-list`
+    issues nine of them.~~ **Resolved** — measured 2026-08-09. The premise in the title is
+    wrong in a way that turns out to be the whole answer: the request does not issue nine
+    round trips at ~160ms each. It issues **fifteen**, at roughly the ~90ms
+    [ADR-0006](./docs/adr/0006-go-api-leaves-netlify-functions.md) assumed all along. Nine
+    was a count of *queries*, and a query is not a round trip.
+
+    **A parameterised query costs two round trips, not one.** `database/sql` hands a query
+    carrying arguments to `go-sql-driver` as a server-side prepared statement, because
+    `mysqlConn.query` returns `driver.ErrSkip` for anything with arguments unless
+    `interpolateParams` is set, and it is not set. So each one goes `COM_STMT_PREPARE`,
+    wait, `COM_STMT_EXECUTE`, wait. (`COM_STMT_CLOSE` follows but the MySQL protocol sends
+    no reply to it, so it costs nothing to wait for.) A query with *no* parameters is sent
+    as a single `COM_QUERY` and costs one. `GET /shopping-list` runs six of the former and
+    three of the latter:
+
+    | Call | Statements | Blocking round trips |
+    | --- | --- | --- |
+    | `GetRecipesFromList` | `GetAccountID` + 1, both parameterised | 4 |
+    | `GetIngredientListItems` | `GetAccountID` + 1, both parameterised | 4 |
+    | `GetExtraListItems` | `GetAccountID` + 1, both parameterised | 4 |
+    | `GetUnitCatalog` | 1, no parameters | 1 |
+    | `GetIngredientCatalog` | 2, no parameters | 2 |
+    | | | **15** |
+
+    **How it was measured, because counting is exactly what went wrong the first time.**
+    A `toxiproxy` was inserted between the API container and MySQL, injecting a known delay
+    on each server response, and the endpoint timed at several delays. Total request time is
+    linear in injected latency and **the slope is the round-trip count** — no interpretation
+    required, and immune to how the driver chooses to log itself:
+
+    | Injected latency | `GET /shopping-list` |
+    | --- | --- |
+    | 0ms | 6.3ms |
+    | 10ms | 185.2ms |
+    | 25ms | 415.5ms |
+    | 50ms | 788.2ms |
+
+    Slope **15.2 round trips**, against 15 counted from MySQL's general log. Re-run with
+    `interpolateParams=true` in the DSN, the slope falls to **9.2** — which is the nine the
+    ADR counted, and confirms the mechanism precisely: that flag is exactly the difference
+    between a query and a round trip here.
+
+    **The arithmetic closes.** 15 × ~90ms is ~1,350ms of the Lambda's 1,624ms. The rest is
+    the Netlify-edge-to-`us-east-2` hop, plus one transatlantic round trip nobody had
+    counted at all — see the JWKS finding below.
+
+    **The connection-establishment hypothesis was real but not the answer.** Measured the
+    same way, a TLS MySQL connection costs **~5.0 round trips** to establish (plain TCP:
+    ~3.0), so ~450ms transatlantic against TiDB. But that is paid once per connection, not
+    per request, and the ADR's samples were warm. It was the right instinct — the request
+    *was* paying for something other than queries — applied to the wrong term. Where it did
+    bite is exactly where ADR-0006 already says it did: every cold Lambda container built a
+    fresh pool during `init()`.
+
+    **Two things found on the way that are worth more than the original question.**
+
+    - **`POST /shopping-list` is far worse than the endpoint that was measured**, and it is
+      the one that does the actual work. Measured at **~57 blocking round trips** for a
+      two-recipe list (census: ~50), resolving `GetAccountID` **nine** times. It loops
+      `GetRecipeByID` per Recipe, so it grows with the size of the list — ADR-0006's "no
+      N+1 loops" is true of `GET`, not of `POST`. On the Lambda that was ~5 seconds. Filed
+      as #53.
+    - **Every authenticated request re-fetched the Auth0 JWKS**, uncached, before touching
+      the database — `getPemCert` in `internal/pkg/app/app.go` does a bare `http.Get` and
+      `go-jwt-middleware` v1 calls it per request. Confirmed by measurement, not by reading:
+      against the real tenant, a request with a well-formed token costs ~15–18ms where one
+      with no token at all costs ~2ms, on every request rather than the first. On the Lambda
+      that was a transatlantic hop to an EU Auth0 tenant on every single request. Filed as
+      #52.
+
+    **What was already true and stays true: none of this is urgent.** At 165ms the endpoint
+    is fine and the migration took ~90% of the cost out. The point of the item was to
+    understand the reason before anyone optimised on a guess, and the reason turned out to
+    contradict both the guess *and* the number in the title.
+
+    One consequence for other queued work: **#44 reasons about a query profile that is now
+    known to be wrong** — it is a headers/caching item and nothing in it depends on the
+    count, but its framing of the API as "22 routes, nineteen of them account-scoped and
+    mutable" should be read alongside the fact that the mutable ones are the expensive ones.
+
+    Fixed here rather than filed, being a real defect found directly on the measured path:
+    **a token whose `kid` names no key in the tenant's JWKS panicked the handler** instead
+    of returning 401. Anyone could send one — the audience and issuer checks pass on public
+    values, and the key lookup is the next step. `net/http` recovers per-connection so the
+    process survived, but the caller got an empty reply and a torn-down connection rather
+    than a refusal. The same defect `normalizeAudience`'s comment describes, one branch
+    further down. Now returned as an error, with a regression test
+    (`TestKeyLookupFailureIsRefusedNotPanicked`) that unwinds on the panic; the discarded
+    error from `jwt.ParseRSAPublicKeyFromPEM` next to it, which returned a nil key with a
+    nil error, is returned too.

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -445,6 +445,10 @@ Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are r
     round trips and `POST /shopping-list` around **57** for a two-recipe list. Everything
     here was measurable before and is now measured; nothing below is designed.
 
+    **The full prioritised list, extended across every route and with the measured baseline
+    for each, is [`specs/request-model-optimisations.md`](./specs/request-model-optimisations.md).**
+    What follows is the summary; that document is what to work from.
+
     Three changes, in descending order of ratio-of-win-to-risk:
 
     - **`interpolateParams=true` in the DSN.** One parameter, and #49 measured the endpoint

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -442,48 +442,16 @@ Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are r
 
 53. **Cut the round trips per request, now that there is a measurement to cut against.**
     Filed out of #49, which established that `GET /shopping-list` costs **15** blocking DB
-    round trips and `POST /shopping-list` around **57** for a two-recipe list. Everything
-    here was measurable before and is now measured; nothing below is designed.
+    round trips (not the nine everyone had counted), `POST /shopping-list` around **50** for
+    a two-Recipe list and growing by 8 per Recipe, and that one request re-resolves the same
+    Account up to nine times.
 
-    **The full prioritised list, extended across every route and with the measured baseline
-    for each, is [`specs/request-model-optimisations.md`](./specs/request-model-optimisations.md).**
-    What follows is the summary; that document is what to work from.
-
-    Three changes, in descending order of ratio-of-win-to-risk:
-
-    - **`interpolateParams=true` in the DSN.** One parameter, and #49 measured the endpoint
-      going from 15.2 round trips to 9.2 — it eliminates the `COM_STMT_PREPARE` before every
-      parameterised query by having the driver interpolate arguments client-side instead.
-      **This is the one that needs a real decision rather than a diff**: it moves parameter
-      escaping from the database to `go-sql-driver`. The driver's interpolation is
-      deliberate and refuses rather than guesses (it bails on non-UTF-8 and will not
-      interpolate at all under `multiStatements`), and TiDB is unaffected either way, but
-      "the database is what escapes our parameters" is a property worth losing knowingly or
-      not at all. Note it also stops the statement cache being useful, which matters less
-      here than it sounds since nothing reuses a prepared statement across requests anyway.
-    - **Resolve `GetAccountID` once per request.** Unchanged from #49's original framing,
-      but the numbers are bigger than it thought: three times on `GET`, **nine** times on
-      `POST`. Resolving it in middleware (`userMiddleware` already has the hook, and carries
-      a `TODO` proposing exactly this) and passing it down touches every service function's
-      signature, which is the actual cost and the reason it wants deciding.
-    - **`POST /shopping-list`'s per-Recipe loop.** `GenerateShoppingList` calls
-      `GetRecipeByID` per Recipe, at 6 round trips each plus its own `GetAccountID`, so the
-      cost grows with the size of the list — a real N+1, and on the endpoint that does the
-      work rather than the one that reads it. Fetching every Recipe's lines in one query is
-      the obvious shape.
-
-    Still worth having regardless, and unchanged from #49: explicit `SetMaxOpenConns` /
-    `SetMaxIdleConns` / `SetConnMaxLifetime`, which are currently unset. #49 measured a TLS
-    MySQL connection at ~5 round trips to establish, so the pool's behaviour is worth
-    choosing rather than defaulting — and TiDB Serverless has its own connection ceiling, so
-    it is a real choice. `db.Stats()` as a metric is the cheap way to know whether any of it
-    is working; ADR-0007's per-query spans are the permanent way.
-
-    **Sequencing note.** The measurement rig is reusable and cost about an hour: a
-    `toxiproxy` between the API container and MySQL, injecting a known per-response delay,
-    then timing an endpoint at several delays — the slope is the round-trip count. Any of
-    these changes can be verified the same way before it goes near production, which is what
-    makes them safe to do without waiting for ADR-0007.
+    **Designed: [`specs/request-model-optimisations.md`](./specs/request-model-optimisations.md).**
+    Six phases, each independently shippable, with the measured baseline for every route and
+    the rig to verify each change against. Phase 1 is #52. Phase 2 —
+    `interpolateParams=true`, worth ~40% of every route — is the one that needs a decision
+    from Ian rather than a diff, because it moves parameter escaping from TiDB into the
+    driver.
 
 54. **The Auth0 JWKS is re-fetched on every authenticated request.** Found while measuring
     #49 and arguably more important than what it went looking for. `getPemCert`
@@ -515,3 +483,9 @@ Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are r
     returning 401 — was fixed alongside #49 rather than left here, since it was a defect
     rather than a design question. Fixing the caching should not reintroduce it: an unknown
     `kid` is exactly the case a cache must handle by refreshing and then *failing cleanly*.
+
+    **Designed as Phase 1 of
+    [`specs/request-model-optimisations.md`](./specs/request-model-optimisations.md)**,
+    which is where the implementation detail lives — including the one constraint that
+    decides the approach: `go-jwt-middleware` **v2.3.0** is the last release declaring
+    `go 1.23.0`, and this repo pins Go 1.23 in four places.

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -2,7 +2,7 @@
 
 Small defects and doc-drift found while building `CONTEXT.md` from the codebase (2026-07-13). Not designed here — just flagged for later action.
 
-Items 1–30, 32, 33, 36, 39, 40, 44 and 48 have all been resolved — see [`follow-ups-resolved.md`](./follow-ups-resolved.md) for the full history (numbering preserved for cross-references between entries).
+Items 1–30, 32, 33, 36, 39, 40, 44, 48 and 49 have all been resolved — see [`follow-ups-resolved.md`](./follow-ups-resolved.md) for the full history (numbering preserved for cross-references between entries).
 
 Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are real but deliberately not being fixed, so they are not queued work.
 
@@ -289,61 +289,6 @@ Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are r
     No code change is implied. If a rewrite does happen, `pages/index.tsx` is the only file
     involved, and nothing under test asserts on this copy.
 
-49. **Investigate why a request costs ~160ms per query, not ~90ms — and why `GET /shopping-list`
-    issues nine of them.** Opened off the back of the Fly migration's latency measurement
-    (see [ADR-0006](./docs/adr/0006-go-api-leaves-netlify-functions.md)'s Measured outcome).
-    An investigation, not a fix: the numbers do not add up yet, and guessing which way they
-    are wrong is how the wrong thing gets optimised.
-
-    **What is known.** `GET /shopping-list` on the Lambda took ~1,624ms of server time and
-    ~165ms on Fly. Counted from the code, that request makes **nine sequential DB round
-    trips**:
-
-    | Call | Queries |
-    | --- | --- |
-    | `GetRecipesFromList` | `GetAccountID` + 1 |
-    | `GetIngredientListItems` | `GetAccountID` + 1 |
-    | `GetExtraListItems` | `GetAccountID` + 1 |
-    | `GetUnitCatalog` | 1 |
-    | `GetIngredientCatalog` | 2 |
-
-    No N+1 loops — every one is a flat query. Two things fall out:
-
-    - **`GetAccountID` is resolved three times per request**, from the same `userID`, to get
-      the same answer. Transatlantic that was ~270ms of pure waste; from Frankfurt it is
-      small but still free to remove. Resolving it once in the handler and passing it down
-      is the obvious change, and it touches every service function's signature, which is why
-      it wants deciding rather than doing on impulse.
-    - **The arithmetic does not close.** ADR-0006 assumed ~90ms a round trip, so nine
-      queries predicts ~810ms — but the Lambda spent ~1,624ms. Something accounts for the
-      other ~800ms, and it is not query count.
-
-    **The leading hypothesis is connection establishment, not queries.** TiDB Serverless
-    requires TLS, so a new connection costs a TCP handshake plus a TLS handshake — three to
-    four round trips, ~270–360ms transatlantic, before a single query runs. `main.go` sets
-    no pool limits at all, so `database/sql` defaults apply (`MaxIdleConns` 2), and every
-    cold Lambda container built a fresh pool and `Ping`ed during `init()` — a consequence
-    ADR-0006 already names. Whether a *warm* container was still paying handshakes, and how
-    often Netlify recycled them, is exactly what nobody knows.
-
-    **What would settle it**, cheapest first:
-
-    - `observability.md`'s tracing, once it lands. A span per query against a span for the
-      request answers this directly and permanently, with no bespoke work — which is the
-      argument for simply waiting rather than investigating now.
-    - `db.Stats()` on the Fly process (`OpenConnections`, `Idle`, `WaitCount`) exposed on a
-      debug route or as a metric. Cheap, and tells you whether the pool is actually being
-      reused now that the process is long-lived.
-    - Explicit `SetMaxOpenConns` / `SetMaxIdleConns` / `SetConnMaxLifetime`. Currently
-      unset, which was defensible when every container was short-lived and is now just
-      undecided. Note TiDB Serverless has its own connection ceiling, so this is a real
-      choice, not a formality.
-
-    **Deliberately not urgent.** At 165ms the endpoint is fine, and the migration already
-    took ~90% of the cost out. This is filed so the *reason* is understood before anyone
-    reaches for caching (#44 reasons about a query profile that had never been measured) or
-    concludes that query count was the problem. The interesting finding is that the biggest
-    win came from something other than the mechanism the ADR predicted.
 
 50. **Email: Big Shop sends exactly one, and it doesn't work.** A placeholder so this isn't
     forgotten — **it wants a full spec of its own before any of it is built**, and nothing
@@ -494,3 +439,75 @@ Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are r
     time someone wants to assert Go-level behaviour and cannot — the first time was #44.
     If it does get built, `addRecipe`/`editRecipe` purging the `units` tag is a good first
     test: it is the case that motivated it, and it has no coverage anywhere else.
+
+53. **Cut the round trips per request, now that there is a measurement to cut against.**
+    Filed out of #49, which established that `GET /shopping-list` costs **15** blocking DB
+    round trips and `POST /shopping-list` around **57** for a two-recipe list. Everything
+    here was measurable before and is now measured; nothing below is designed.
+
+    Three changes, in descending order of ratio-of-win-to-risk:
+
+    - **`interpolateParams=true` in the DSN.** One parameter, and #49 measured the endpoint
+      going from 15.2 round trips to 9.2 — it eliminates the `COM_STMT_PREPARE` before every
+      parameterised query by having the driver interpolate arguments client-side instead.
+      **This is the one that needs a real decision rather than a diff**: it moves parameter
+      escaping from the database to `go-sql-driver`. The driver's interpolation is
+      deliberate and refuses rather than guesses (it bails on non-UTF-8 and will not
+      interpolate at all under `multiStatements`), and TiDB is unaffected either way, but
+      "the database is what escapes our parameters" is a property worth losing knowingly or
+      not at all. Note it also stops the statement cache being useful, which matters less
+      here than it sounds since nothing reuses a prepared statement across requests anyway.
+    - **Resolve `GetAccountID` once per request.** Unchanged from #49's original framing,
+      but the numbers are bigger than it thought: three times on `GET`, **nine** times on
+      `POST`. Resolving it in middleware (`userMiddleware` already has the hook, and carries
+      a `TODO` proposing exactly this) and passing it down touches every service function's
+      signature, which is the actual cost and the reason it wants deciding.
+    - **`POST /shopping-list`'s per-Recipe loop.** `GenerateShoppingList` calls
+      `GetRecipeByID` per Recipe, at 6 round trips each plus its own `GetAccountID`, so the
+      cost grows with the size of the list — a real N+1, and on the endpoint that does the
+      work rather than the one that reads it. Fetching every Recipe's lines in one query is
+      the obvious shape.
+
+    Still worth having regardless, and unchanged from #49: explicit `SetMaxOpenConns` /
+    `SetMaxIdleConns` / `SetConnMaxLifetime`, which are currently unset. #49 measured a TLS
+    MySQL connection at ~5 round trips to establish, so the pool's behaviour is worth
+    choosing rather than defaulting — and TiDB Serverless has its own connection ceiling, so
+    it is a real choice. `db.Stats()` as a metric is the cheap way to know whether any of it
+    is working; ADR-0007's per-query spans are the permanent way.
+
+    **Sequencing note.** The measurement rig is reusable and cost about an hour: a
+    `toxiproxy` between the API container and MySQL, injecting a known per-response delay,
+    then timing an endpoint at several delays — the slope is the round-trip count. Any of
+    these changes can be verified the same way before it goes near production, which is what
+    makes them safe to do without waiting for ADR-0007.
+
+54. **The Auth0 JWKS is re-fetched on every authenticated request.** Found while measuring
+    #49 and arguably more important than what it went looking for. `getPemCert`
+    (`netlify-functions/recipes/internal/pkg/app/app.go`) does a bare
+    `http.Get(".../.well-known/jwks.json")` with no cache, and `go-jwt-middleware` v1 calls
+    the `ValidationKeyGetter` once per request. Auth0's own guidance is to cache the key set
+    and refresh on an unknown `kid`; v2 of the library ships a caching provider that does
+    this, which is the likely fix.
+
+    Measured against the real tenant: a request carrying a well-formed token costs ~15–18ms
+    where one carrying no token costs ~2ms, on every request rather than the first. Go's
+    default transport keeps the connection alive, so it is normally one round trip — but the
+    idle timeout is 90s, and a quiet period costs the full TCP+TLS reconnect (~140ms
+    measured, and it was a transatlantic ~350ms on the Lambda).
+
+    Three reasons it is worth fixing beyond the milliseconds:
+
+    - **It is an availability coupling nobody chose.** Big Shop's request rate is its JWKS
+      request rate. If Auth0 rate-limits, slows, or has an incident on that endpoint, every
+      authenticated request fails — not just logins.
+    - **It is unauthenticated work.** Anyone who can send a syntactically valid token with
+      the right (public) `aud` and `iss` makes the API perform an outbound HTTPS request.
+      That is a cheap amplification primitive, and the audience/issuer values are in
+      `fly.toml` and `.env.development` by design.
+    - **It is on the critical path of every request**, ahead of the database, so it is pure
+      serial latency on the endpoint #49 was measuring and on every other one.
+
+    The related panic — a token whose `kid` matched nothing killed the request rather than
+    returning 401 — was fixed alongside #49 rather than left here, since it was a defect
+    rather than a design question. Fixing the caching should not reintroduce it: an unknown
+    `kid` is exactly the case a cache must handle by refreshing and then *failing cleanly*.

--- a/netlify-functions/recipes/internal/pkg/app/app.go
+++ b/netlify-functions/recipes/internal/pkg/app/app.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"recipes/internal/pkg/common"
@@ -230,15 +229,24 @@ func (a *App) GetRouter(base string) (*negroni.Negroni, huma.API, error) {
 				return nil, errors.New("invalid issuer")
 			}
 
+			// Returned, never panicked. Both of these are reachable by an
+			// unauthenticated caller: getPemCert fails whenever the token's
+			// `kid` names no key in the tenant's JWKS, which anyone can send.
+			// The panic this replaces was recovered per-connection by
+			// net/http, so the process survived - but the request got no
+			// response at all (curl reports an empty reply) instead of the
+			// 401 it should. Same defect normalizeAudience's comment above
+			// describes, one branch further down, and the reason it matters
+			// is the same: there is no Recovery middleware in the negroni
+			// stack to turn a panic into a response.
 			cert, err := getPemCert(token)
 			if err != nil {
-
-				panic(err.Error())
+				return nil, err
 			}
-			result, _ := jwt.ParseRSAPublicKeyFromPEM([]byte(cert))
-			fmt.Println("valid token:")
-			fmt.Println(result)
-			return result, nil
+			// The error here used to be discarded, which returned a nil key
+			// with a nil error and left the jwt library to fail on it later,
+			// somewhere less obvious.
+			return jwt.ParseRSAPublicKeyFromPEM([]byte(cert))
 		},
 		SigningMethod: jwt.SigningMethodRS256,
 	})

--- a/netlify-functions/recipes/internal/pkg/app/app_test.go
+++ b/netlify-functions/recipes/internal/pkg/app/app_test.go
@@ -1,11 +1,14 @@
 package app
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"recipes/internal/pkg/common"
 
@@ -406,4 +409,60 @@ func TestHealthCarveOut(t *testing.T) {
 			t.Error("HEAD /health = 200; the carve-out is meant to be GET-only")
 		}
 	})
+}
+
+// TestKeyLookupFailureIsRefusedNotPanicked covers the last panic on the auth
+// path. A token whose `kid` names no key in the tenant's JWKS is something any
+// unauthenticated caller can send, and the key lookup used to panic on it: the
+// process survived (net/http recovers per-connection) but the caller got an
+// empty reply rather than a 401, and the connection was torn down.
+//
+// AUTH0_DOMAIN is pointed at a name that cannot resolve, which fails the same
+// lookup one step earlier - no JWKS fixture, and no network. The claims below
+// have to match the environment exactly, because the audience and issuer
+// checks run *before* the key lookup and would otherwise be what rejects the
+// token, proving nothing.
+func TestKeyLookupFailureIsRefusedNotPanicked(t *testing.T) {
+	t.Setenv("DISABLE_AUTH", "")
+	t.Setenv("AUTH0_AUDIENCE", testAudience)
+	t.Setenv("AUTH0_DOMAIN", "tenant.invalid")
+
+	application, err := NewApp(&common.Env{})
+	if err != nil {
+		t.Fatalf("NewApp() error = %v", err)
+	}
+	router, _, err := application.GetRouter("/api/bigshop")
+	if err != nil {
+		t.Fatalf("GetRouter() error = %v", err)
+	}
+
+	// Signed with a throwaway key, so the signature is valid RS256 and parsing
+	// gets as far as the key lookup. Which key signed it is irrelevant - the
+	// lookup fails before anything is verified against it.
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"iss": "https://tenant.invalid/",
+		"aud": []string{testAudience},
+		"sub": "auth0|unknown-kid",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	token.Header["kid"] = "no-such-key"
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("SignedString() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/bigshop/shopping-list", nil)
+	req.Header.Set("Authorization", "Bearer "+signed)
+	rec := httptest.NewRecorder()
+
+	// A panic here fails the test by unwinding it, which is the regression.
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("GET /shopping-list with an unknown kid = %d, want 401", rec.Code)
+	}
 }

--- a/specs/request-model-optimisations.md
+++ b/specs/request-model-optimisations.md
@@ -1,0 +1,197 @@
+# Request model optimisations
+
+Prioritised from the measurements in follow-up #49 (see
+[`follow-ups-resolved.md`](../follow-ups-resolved.md) for the method). Nothing here is
+designed yet; this is the ordered list of what to change and what each is worth, so the
+expensive items are picked knowingly and the cheap ones are not skipped.
+
+**None of it is urgent.** Post-Fly, `GET /shopping-list` is ~165ms and the endpoint is
+fine. The reason to write it down now is that #49 found the cost model everyone was
+reasoning from was wrong by a factor of ~1.7, and #44 is already reasoning about caching
+on top of it.
+
+## The unit of cost is a round trip, not a query
+
+The single most useful correction from #49. A query carrying parameters costs **two**
+blocking round trips, because `database/sql` over `go-sql-driver` serves it as a
+server-side prepared statement (`COM_STMT_PREPARE`, wait, `COM_STMT_EXECUTE`, wait). A
+query with no parameters costs **one**. So `round trips = 2 × parameterised + 1 × plain`,
+and every count in this document is in round trips.
+
+## Measured baseline
+
+Every route, censused against the local stack via MySQL's general log, 2026-08-09. The
+`account` column is how many times that one request re-resolved `GetAccountID` from the
+same `userID` to get the same answer.
+
+| Route | round trips | account lookups |
+| --- | --- | --- |
+| `POST /shopping-list` (2 Recipes) | **50** | 9 |
+| `PATCH /shopping-list/buy` | **19** | 4 |
+| `GET /shopping-list` | **15** | 3 |
+| `GET /shopping-list/history` | 8 | 2 |
+| `DELETE /shopping-list/clear` | 8 | 2 |
+| `GET /recipe/{id}` | 6 | 1 |
+| `GET /recipes` | 4 | 1 |
+| `GET /account` | 4 | 1 |
+| `GET /invites` | 4 | 0 |
+| `POST /shopping-list/extra` | 4 | 1 |
+| `GET /user` | 2 | 0 |
+| `GET /tags`, `/units`, `/ingredients` | 1 | 0 |
+
+Plus, on **every authenticated request regardless of route**, one uncached HTTPS round trip
+to Auth0's JWKS endpoint (#52).
+
+`POST /shopping-list` measured 42 round trips for one Recipe and 50 for two: **+8 per
+Recipe**, so a ten-Recipe list is ~114. That slope is two independent per-Recipe loops —
+`GetRecipeByID` (6) and `LogShoppingListEvent`'s one `INSERT` per Recipe (2).
+
+## The list
+
+Ordered by leverage. The first three change every route at once; the rest are per-route.
+
+### 1. Stop preparing every parameterised query
+
+`interpolateParams=true` in the DSN. **Measured: `GET /shopping-list` 15.2 → 9.2 round
+trips**; the same ~40% comes off every route in the table. One parameter, no code.
+
+The catch, and it is a real one: it moves parameter escaping from the database into the
+driver. `go-sql-driver`'s interpolation is careful rather than clever — it refuses on
+non-UTF-8 input and will not interpolate at all under `multiStatements` — but "the
+database escapes our parameters" is a property to give up deliberately or not at all.
+
+The alternative that keeps server-side prepares is to **hold `*sql.Stmt` values on the
+`App` and reuse them**, so the `PREPARE` is paid once per connection at startup rather
+than per query. That is the more conservative fix and costs more code: `database/sql`
+re-prepares a cached `Stmt` on each new connection, so it interacts with item 8.
+
+### 2. Resolve the Account once per request
+
+Every service function calls `GetAccountID` for itself. The excess is 2 round trips each
+today, 1 after item 1: **8 redundant lookups on `POST /shopping-list`**, 3 on `PATCH buy`,
+2 on `GET /shopping-list`.
+
+The mechanical fix is to resolve it in `userMiddleware` — which already carries a `TODO`
+proposing exactly this — and read it from the request context. The better fix, and barely
+more work, is to stop passing `userID string` down at all and pass a **`Caller` (or
+`Session`) value carrying both the user and the resolved Account**. That kills the pattern
+rather than the symptom: right now every service function is independently responsible for
+answering "who is this", which is why it happens nine times and why nobody noticed.
+
+This touches every service function's signature. That is the entire cost, and it is the
+reason #49 flagged it as wanting a decision rather than an impulse.
+
+### 3. Cache the JWKS (#52)
+
+Removes one outbound HTTPS round trip from every authenticated request, ahead of the
+database. More importantly it removes an availability coupling nobody chose: Big Shop's
+request rate is currently its Auth0 JWKS request rate, so an incident or a rate limit on
+that endpoint fails every request, not just logins.
+
+`go-jwt-middleware` v2 ships a caching provider; the v1 in use here has none. Whatever is
+used must refresh on an unknown `kid` and then **fail cleanly** — that path is where the
+panic fixed in #49 lived.
+
+### 4. `POST /shopping-list`'s two per-Recipe loops
+
+The worst endpoint, and the one that does the actual work. At +8 round trips per Recipe:
+
+- **`GetRecipeByID` per Recipe.** `CombineIngredients` needs only `recipe.ID` and
+  `recipe.Ingredients`, so the loop also fetches name, notes, method and tags per Recipe
+  and discards them. One query over the whole Recipe set (`WHERE recipe_id IN (...)`)
+  replaces the loop.
+- **`LogShoppingListEvent`'s `INSERT` per Recipe.** A single multi-row `INSERT` — the shape
+  `AddIngredientListItems` already uses a few lines away.
+
+### 5. `PATCH /shopping-list/buy` re-reads the entire list to tick one box
+
+19 round trips, of which the write is 4 and the other 15 are re-running the whole of
+`GetShoppingList` — including both catalogs and the display-unit/pantry/rounding passes —
+so the response can carry the full list back.
+
+This is a **request-model** change rather than a query optimisation, which is why it is on
+this list rather than in #51: the client already knows which item it ticked. Returning 204,
+or just the changed Item, makes this the cheapest write in the API instead of the second
+most expensive read. Worth checking what `hooks/` actually does with the response before
+changing the contract.
+
+### 6. Read the `list` table once, not three times
+
+`GetRecipesFromList`, `GetIngredientListItems` and `GetExtraListItems` are three queries
+against the same table for the same Account, differing only in a `type` filter and which
+columns they project. One `SELECT ... WHERE account_id = ?` returns all of it, partitioned
+in Go — where the Extras/Ingredients split already happens anyway.
+
+### 7. Stop re-reading the catalogs on every request
+
+`GetUnitCatalog` + `GetIngredientCatalog` are 3 round trips on both shopping-list routes,
+and they load the **entire global catalog** — so they grow with the catalog rather than
+with the user's list.
+
+`unit` and `ingredient` change only when a Recipe is saved. An in-process cache invalidated
+on write is straightforward now and was impossible before: this is a **single long-lived
+process** since ADR-0006, where on Lambda every container would have held its own stale
+copy. Note the overlap with #44, which proposes edge-caching `/units` and `/ingredients` for
+*clients* — this is the complement for the API's own use, and #44 already concludes an
+in-process cache is the real win for `known-names.ts`.
+
+`GET /tags` is the extreme case: a fixed list seeded by migration that no code path writes
+to (`hooks/use-tags.ts` documents this), re-read on every call.
+
+### 8. Choose the connection pool deliberately
+
+`main.go` sets no limits, so `database/sql` defaults apply — notably `MaxIdleConns` of 2.
+That was defensible when every container was short-lived and is now just undecided.
+
+It matters more once item 9 lands: #49 measured a TLS MySQL connection at **~5 round trips**
+to establish, so any concurrency that pushes past two idle connections pays a full handshake
+to get one back. Set `SetMaxOpenConns` / `SetMaxIdleConns` / `SetConnMaxLifetime` against
+TiDB Serverless's own ceiling, and expose `db.Stats()` as a metric so the choice can be
+checked rather than assumed.
+
+### 9. Run independent reads concurrently
+
+The item that changes the *shape* rather than the count. Once the Account is resolved once
+(item 2), `GET /shopping-list`'s remaining reads — the list, the unit catalog, the
+ingredient catalog — are mutually independent and run strictly sequentially today. An
+`errgroup` makes the request's depth the slowest single query rather than the sum of all of
+them.
+
+Deliberately last. It needs pool headroom (item 8) to help rather than hurt, and it is
+worth much less once items 1, 2, 6 and 7 have taken the count down — parallelising four
+round trips saves less than not making eleven of them.
+
+## Where that lands
+
+`GET /shopping-list`, measured today at 15:
+
+| After | round trips |
+| --- | --- |
+| today | 15 |
+| \+ item 1 (`interpolateParams`) | 9 *(measured)* |
+| \+ item 2 (Account once) | 7 |
+| \+ item 6 (one `list` read) | 5 |
+| \+ item 7 (catalogs cached) | **2** |
+
+Only the first of those is measured end to end; the rest are counted, and counting is
+exactly what #49 caught being wrong. **Every one of them should be checked on the rig
+before it is believed** — a `toxiproxy` between the API container and MySQL injecting a
+known per-response delay, timing the endpoint at several delays, where the slope is the
+round-trip count. It cost about an hour to build and it is the reason this list has numbers
+at all.
+
+`POST /shopping-list` (2 Recipes) goes 50 → ~21 on items 1 and 2 alone, and items 4 and 7
+should roughly halve it again — but that one is an estimate on an estimate, and it is the
+route whose cost also grows with list size, so it is the one to measure first.
+
+## What not to do
+
+- **Do not reach for a cache to fix a latency number** without checking the round-trip
+  count first. That is how #44 came to reason about a query profile that had never been
+  measured, and how "nine queries at ~160ms" survived long enough to reach an ADR.
+- **Do not optimise `GET /shopping-list` and stop.** It is the endpoint that got measured
+  because ADR-0006 singled it out, but `POST` costs three times as much and is the one that
+  does the work.
+- **Do not wait for ADR-0007's tracing to start.** Per-query spans will make all of this
+  visible permanently and for free, and are strictly better than the rig above for
+  production. They are not a prerequisite for any item here, and the rig already exists.

--- a/specs/request-model-optimisations.md
+++ b/specs/request-model-optimisations.md
@@ -7,9 +7,10 @@ spec covers the *how*.
 
 **Not urgent, and worth saying so at the top.** Post-Fly, `GET /shopping-list` is ~165ms
 and nothing here is a fire. The reason to do it is that #49 found the cost model everyone
-was reasoning from was wrong by a factor of ~1.7, and #44 is already reasoning about
-caching on top of it. Phases are ordered so each is independently shippable and each one
-leaves the API in a working state.
+was reasoning from was wrong by a factor of ~1.7, and work has already started landing on
+top of it — #44 shipped `Cache-Control` across the API against a query profile nobody had
+measured. Phases are ordered so each is independently shippable and each one leaves the API
+in a working state.
 
 ## The unit of cost is a round trip, not a query
 
@@ -115,6 +116,13 @@ The upgrade also retires two unmaintained dependencies: `go-jwt-middleware` v1.0
 5. Keep `TestKeyLookupFailureIsRefusedNotPanicked` **unchanged**. It is the cross-version
    regression guard: an unknown `kid` must still produce a 401 and not a panic or an empty
    reply. If it needs editing to pass, that is a finding, not a chore.
+6. **Do not disturb the middleware order.** `cacheControlMiddleware` sits at `app.go:288`,
+   ahead of the health carve-out, CORS and auth, precisely so it stamps the JWT
+   middleware's own 401s — which is what `TestDefaultCacheControl`'s first case asserts.
+   Phase 1 replaces what `n.Use` is *given* at `app.go:314`, not where it sits.
+   `TestDefaultCacheControl`, `TestOnlyTheGlobalCatalogsOverrideTheDefault` and
+   `TestEachRouteStampsItsOwnPolicy` (all #44) must stay green; a 401 from v2's middleware
+   still has to carry `private, no-store`.
 
 ### Verify
 
@@ -291,10 +299,20 @@ process** since ADR-0006, where on Lambda every container would have held its ow
 copy. Invalidate from `AddRecipe`/`EditRecipe` — the same write path that already coins new
 Units (`components/recipe-form/Form.tsx:101` refetches `/units` for exactly this reason).
 
-Note the overlap with **#44**, which proposes edge-caching `/units` and `/ingredients` for
-*clients*. This is the complement for the API's own use, and #44 already concludes an
-in-process cache is the real win for `lib/recipe-import/known-names.ts`. Do not let the two
-invalidation mechanisms drift; a Recipe save has to clear both.
+**This is a different cache from the one #44 shipped, and they have to be invalidated
+together.** #44 (resolved, [ADR-0009](../docs/adr/0009-edge-caching-the-global-catalogs.md))
+put `GET /units` behind Netlify's edge with a `units` cache tag, purged on Recipe
+create/edit through the new `internal/pkg/purge` package. That cache serves *clients*; this
+one serves the API's own combining logic. A Recipe save must clear both, so hang the
+in-process invalidation off the same call site in `AddRecipe`/`EditRecipe` that already
+purges the tag — one place that knows the catalog changed, not two that have to stay in
+step.
+
+Not to be confused with **#51** either, which is a third path: `/ingredients` fetched from a
+Netlify function by `lib/recipe-import/known-names.ts` on every import. Same table, but that
+round trip is Ohio → Frankfurt and an in-process cache in a Netlify function is exactly what
+#51 argues is the weakest of its three options. Nothing here depends on how #51 resolves; if
+it resolves by moving extraction into the Go API, this cache serves that too.
 
 `GET /tags` is the extreme case — a fixed list seeded by migration that no code path writes
 to (`hooks/use-tags.ts` documents this), re-read on every call.

--- a/specs/request-model-optimisations.md
+++ b/specs/request-model-optimisations.md
@@ -1,28 +1,28 @@
-# Request model optimisations
+# Cut the per-request round trips
 
-Prioritised from the measurements in follow-up #49 (see
-[`follow-ups-resolved.md`](../follow-ups-resolved.md) for the method). Nothing here is
-designed yet; this is the ordered list of what to change and what each is worth, so the
-expensive items are picked knowingly and the cheap ones are not skipped.
+Measurements and rationale: follow-up #49 (see
+[`follow-ups-resolved.md`](../follow-ups-resolved.md)) and
+[ADR-0006](../docs/adr/0006-go-api-leaves-netlify-functions.md)'s Measured outcome. This
+spec covers the *how*.
 
-**None of it is urgent.** Post-Fly, `GET /shopping-list` is ~165ms and the endpoint is
-fine. The reason to write it down now is that #49 found the cost model everyone was
-reasoning from was wrong by a factor of ~1.7, and #44 is already reasoning about caching
-on top of it.
+**Not urgent, and worth saying so at the top.** Post-Fly, `GET /shopping-list` is ~165ms
+and nothing here is a fire. The reason to do it is that #49 found the cost model everyone
+was reasoning from was wrong by a factor of ~1.7, and #44 is already reasoning about
+caching on top of it. Phases are ordered so each is independently shippable and each one
+leaves the API in a working state.
 
 ## The unit of cost is a round trip, not a query
 
-The single most useful correction from #49. A query carrying parameters costs **two**
-blocking round trips, because `database/sql` over `go-sql-driver` serves it as a
-server-side prepared statement (`COM_STMT_PREPARE`, wait, `COM_STMT_EXECUTE`, wait). A
-query with no parameters costs **one**. So `round trips = 2 × parameterised + 1 × plain`,
-and every count in this document is in round trips.
+A query carrying parameters costs **two** blocking round trips, because `database/sql`
+over `go-sql-driver` serves it as a server-side prepared statement (`COM_STMT_PREPARE`,
+wait, `COM_STMT_EXECUTE`, wait — `COM_STMT_CLOSE` follows but the protocol sends no reply,
+so it costs no waiting). A query with no parameters costs **one**. So
+`round trips = 2 × parameterised + 1 × plain`, and every number below is in round trips.
 
 ## Measured baseline
 
-Every route, censused against the local stack via MySQL's general log, 2026-08-09. The
-`account` column is how many times that one request re-resolved `GetAccountID` from the
-same `userID` to get the same answer.
+Censused against the local stack via MySQL's general log, 2026-08-09. `account` is how many
+times one request re-resolved `GetAccountID` from the same `userID` for the same answer.
 
 | Route | round trips | account lookups |
 | --- | --- | --- |
@@ -32,134 +32,300 @@ same `userID` to get the same answer.
 | `GET /shopping-list/history` | 8 | 2 |
 | `DELETE /shopping-list/clear` | 8 | 2 |
 | `GET /recipe/{id}` | 6 | 1 |
-| `GET /recipes` | 4 | 1 |
-| `GET /account` | 4 | 1 |
+| `GET /recipes`, `/account`, `POST /shopping-list/extra` | 4 | 1 |
 | `GET /invites` | 4 | 0 |
-| `POST /shopping-list/extra` | 4 | 1 |
 | `GET /user` | 2 | 0 |
 | `GET /tags`, `/units`, `/ingredients` | 1 | 0 |
 
-Plus, on **every authenticated request regardless of route**, one uncached HTTPS round trip
-to Auth0's JWKS endpoint (#52).
+Plus, on **every authenticated request whatever the route**, one uncached HTTPS round trip
+to Auth0's JWKS endpoint, before the first query.
 
-`POST /shopping-list` measured 42 round trips for one Recipe and 50 for two: **+8 per
-Recipe**, so a ten-Recipe list is ~114. That slope is two independent per-Recipe loops —
-`GetRecipeByID` (6) and `LogShoppingListEvent`'s one `INSERT` per Recipe (2).
+`POST /shopping-list` measured 42 for one Recipe and 50 for two — **+8 per Recipe**, so a
+ten-Recipe list is ~114. That slope is two independent per-Recipe loops: `GetRecipeByID`
+(6) and `LogShoppingListEvent`'s one `INSERT` per Recipe (2).
 
-## The list
+---
 
-Ordered by leverage. The first three change every route at once; the rest are per-route.
+## Phase 1 — Cache the JWKS
 
-### 1. Stop preparing every parameterised query
+**First because it is independent of every other phase, touches no SQL, and the latency is
+the least of what it fixes.** Big Shop's request rate is currently its Auth0 JWKS request
+rate: `getPemCert` (`internal/pkg/app/app.go`) does a bare `http.Get` with no cache, and
+`go-jwt-middleware` v1 calls the `ValidationKeyGetter` on every request. A rate limit or an
+incident on that endpoint fails *every* request, not just logins. It is also outbound work
+any unauthenticated caller can trigger, since the audience and issuer it checks first are
+public values.
 
-`interpolateParams=true` in the DSN. **Measured: `GET /shopping-list` 15.2 → 9.2 round
-trips**; the same ~40% comes off every route in the table. One parameter, no code.
+Measured against the real tenant: a request with a well-formed token costs ~15–18ms where
+one with no token costs ~2ms, on every request rather than the first. Go's default
+transport keeps the connection alive so it is normally one round trip, but `IdleConnTimeout`
+is 90s, and a quiet period costs the full reconnect (~140ms measured locally; it was a
+transatlantic ~350ms on the Lambda).
 
-The catch, and it is a real one: it moves parameter escaping from the database into the
-driver. `go-sql-driver`'s interpolation is careful rather than clever — it refuses on
-non-UTF-8 input and will not interpolate at all under `multiStatements` — but "the
-database escapes our parameters" is a property to give up deliberately or not at all.
+### Approach: upgrade to `go-jwt-middleware` v2 rather than hand-roll a cache
 
-The alternative that keeps server-side prepares is to **hold `*sql.Stmt` values on the
-`App` and reuse them**, so the `PREPARE` is paid once per connection at startup rather
-than per query. That is the more conservative fix and costs more code: `database/sql`
-re-prepares a cached `Stmt` on each new connection, so it interacts with item 8.
+A JWKS cache has to get TTL, key rotation and concurrent refresh right, in the one code
+path where a mistake is an auth bypass. v2 ships `jwks.CachingProvider`, which does it.
 
-### 2. Resolve the Account once per request
+**Pin `v2.3.0`.** This is load-bearing: v2.3.1 declares `go 1.24.0` and v3 declares
+`go 1.25.0`, while this repo pins Go **1.23** in four places (`netlify.toml:28`,
+`.github/workflows/ci.yml:82`, `Dockerfile:7`, `Dockerfile.dev:1`). **v2.3.0 declares
+exactly `go 1.23.0`** and is the last release that does. Taking anything newer means
+bumping Go everywhere first — which is a reasonable thing to want (it would also unpin
+Huma from v2.35.0, pinned for the same reason) but it is a different piece of work and
+must not be smuggled in here.
 
-Every service function calls `GetAccountID` for itself. The excess is 2 round trips each
-today, 1 after item 1: **8 redundant lookups on `POST /shopping-list`**, 3 on `PATCH buy`,
-2 on `GET /shopping-list`.
+The upgrade also retires two unmaintained dependencies: `go-jwt-middleware` v1.0.0 and
+`form3tech-oss/jwt-go` (a fork of the abandoned `dgrijalva/jwt-go`).
 
-The mechanical fix is to resolve it in `userMiddleware` — which already carries a `TODO`
-proposing exactly this — and read it from the request context. The better fix, and barely
-more work, is to stop passing `userID string` down at all and pass a **`Caller` (or
-`Session`) value carrying both the user and the resolved Account**. That kills the pattern
-rather than the symptom: right now every service function is independently responsible for
-answering "who is this", which is why it happens nine times and why nobody noticed.
+### Actions
 
-This touches every service function's signature. That is the entire cost, and it is the
-reason #49 flagged it as wanting a decision rather than an impulse.
+1. `go get github.com/auth0/go-jwt-middleware/v2@v2.3.0`; drop
+   `github.com/auth0/go-jwt-middleware v1.0.0` and `github.com/form3tech-oss/jwt-go` from
+   `go.mod`.
+2. In `GetRouter`, replace the `jwtmiddleware.New(jwtmiddleware.Options{...})` block with:
 
-### 3. Cache the JWKS (#52)
+   ```go
+   issuerURL, err := url.Parse("https://" + os.Getenv("AUTH0_DOMAIN") + "/")
+   provider := jwks.NewCachingProvider(issuerURL, 5*time.Minute)
+   jwtValidator, err := validator.New(
+       provider.KeyFunc,
+       validator.RS256,
+       issuerURL.String(),
+       []string{os.Getenv("AUTH0_AUDIENCE")},
+   )
+   middleware := jwtmiddleware.New(jwtValidator.ValidateToken)
+   ```
 
-Removes one outbound HTTPS round trip from every authenticated request, ahead of the
-database. More importantly it removes an availability coupling nobody chose: Big Shop's
-request rate is currently its Auth0 JWKS request rate, so an incident or a rate limit on
-that endpoint fails every request, not just logins.
+   The provider is built **once, here** — building it per request would cache nothing.
+   `GetRouter` is called once from `init()`, so this is already the right place.
+3. Rewrite `userMiddleware` to read v2's claims:
 
-`go-jwt-middleware` v2 ships a caching provider; the v1 in use here has none. Whatever is
-used must refresh on an unknown `kid` and then **fail cleanly** — that path is where the
-panic fixed in #49 lived.
+   ```go
+   claims, ok := r.Context().Value(jwtmiddleware.ContextKey{}).(*validator.ValidatedClaims)
+   ```
 
-### 4. `POST /shopping-list`'s two per-Recipe loops
+   and take `claims.RegisteredClaims.Subject` as the user ID. **Guard the type assertion**
+   — the current line chains three unchecked assertions and is the same class of defect as
+   the panic fixed in #49.
+4. Delete `getPemCert`, the `Jwks` and `JSONWebKeys` types, and `normalizeAudience` — v2
+   validates issuer and audience itself, and `normalizeAudience` exists only to work around
+   `form3tech-oss/jwt-go`'s handling of a JSON array `aud`. Delete `TestNormalizeAudience`
+   and `TestRequiredClaims` with it.
+5. Keep `TestKeyLookupFailureIsRefusedNotPanicked` **unchanged**. It is the cross-version
+   regression guard: an unknown `kid` must still produce a 401 and not a panic or an empty
+   reply. If it needs editing to pass, that is a finding, not a chore.
 
-The worst endpoint, and the one that does the actual work. At +8 round trips per Recipe:
+### Verify
 
-- **`GetRecipeByID` per Recipe.** `CombineIngredients` needs only `recipe.ID` and
-  `recipe.Ingredients`, so the loop also fetches name, notes, method and tags per Recipe
-  and discards them. One query over the whole Recipe set (`WHERE recipe_id IN (...)`)
-  replaces the loop.
-- **`LogShoppingListEvent`'s `INSERT` per Recipe.** A single multi-row `INSERT` — the shape
-  `AddIngredientListItems` already uses a few lines away.
+- `TestKeyLookupFailureIsRefusedNotPanicked` and `TestHealthCarveOut` pass.
+- Black-box, against the real tenant, using the probe from #49: run the API locally with
+  `DISABLE_AUTH=false`, `AUTH0_DOMAIN=dev-x-n37k6b.eu.auth0.com`,
+  `AUTH0_AUDIENCE=https://big-shop-api`, and send repeated requests carrying a token with
+  a valid `aud`/`iss` and a garbage signature. **Before:** ~15–18ms every request.
+  **After:** ~15ms on the first, ~2ms on the rest.
+- The e2e suite runs under `DISABLE_AUTH=true` and so exercises none of this — it is a
+  guard against breaking the *other* branch of `GetRouter`, not evidence this worked.
 
-### 5. `PATCH /shopping-list/buy` re-reads the entire list to tick one box
+### Known limitation, accepted
 
-19 round trips, of which the write is 4 and the other 15 are re-running the whole of
-`GetShoppingList` — including both catalogs and the display-unit/pantry/rounding passes —
-so the response can carry the full list back.
+v2's `CachingProvider` caches the whole key set for the TTL and does **not** refresh on an
+unknown `kid`. During an Auth0 signing-key rotation, tokens signed by a key minted inside
+the current TTL window would fail until it expires. 5 minutes is chosen against that: the
+tenant currently publishes two keys at once, so a new key is visible in the JWKS well
+before Auth0 signs with it, and the exposure is theoretical rather than a live risk.
 
-This is a **request-model** change rather than a query optimisation, which is why it is on
-this list rather than in #51: the client already knows which item it ticked. Returning 204,
-or just the changed Item, makes this the cheapest write in the API instead of the second
-most expensive read. Worth checking what `hooks/` actually does with the response before
-changing the contract.
+---
 
-### 6. Read the `list` table once, not three times
+## Phase 2 — One round trip per query
 
-`GetRecipesFromList`, `GetIngredientListItems` and `GetExtraListItems` are three queries
-against the same table for the same Account, differing only in a `type` filter and which
-columns they project. One `SELECT ... WHERE account_id = ?` returns all of it, partitioned
-in Go — where the Extras/Ingredients split already happens anyway.
+**Decision required from Ian before this is implemented.** Setting `interpolateParams=true`
+on the DSN makes `go-sql-driver` interpolate arguments client-side instead of preparing
+server-side. **Measured: `GET /shopping-list` 15.2 → 9.2 round trips**, and the same ~40%
+comes off every route in the baseline table. One DSN parameter, no code.
 
-### 7. Stop re-reading the catalogs on every request
+The trade-off is that parameter escaping moves from TiDB into the driver. The driver's
+interpolation is conservative — it refuses on invalid UTF-8 and will not interpolate at all
+under `multiStatements` — but "the database escapes our parameters" is a property to give
+up knowingly or not at all.
+
+**If that is not acceptable**, the alternative that keeps server-side prepares is to hold
+`*sql.Stmt` values on the `App` and reuse them, paying the `PREPARE` once per connection
+instead of once per query. Same win, materially more code, and it interacts with Phase 6's
+pool settings because `database/sql` re-prepares a cached `Stmt` on each new connection.
+Ship one or the other, not both.
+
+### Actions
+
+1. Add `&interpolateParams=true` to the DSN in `docker-compose.yml:39` (covers local dev
+   *and* e2e).
+2. Update the production DSN: `fly secrets set DSN='...&interpolateParams=true' -a big-shop-api`.
+   That is the **only** other place it is set — there is no `.env` copy of it by design
+   (`docker/README.md`).
+3. Note it in `technical-architecture.md`'s environment table, with a one-line reason, so
+   the next person to rewrite the DSN does not drop it silently.
+
+### Verify
+
+Run the rig (appendix) before and after. Expect the `GET /shopping-list` slope to fall from
+~15.2 to ~9.2. Run `npm run test:e2e` — a mis-escaped parameter would show up as a wrong or
+empty Shopping List, which those specs assert on.
+
+---
+
+## Phase 3 — Resolve the Account once per request
+
+21 of the 26 service functions taking `userID string` immediately call `GetAccountID` for
+themselves, so one request resolves the same Account up to **nine** times. The excess is 2
+round trips each today, 1 after Phase 2.
+
+### Approach: a lazily-resolved `Caller`, not eager middleware resolution
+
+The obvious fix — resolve in `userMiddleware` and put the ID in the context — **would make
+five routes slower**. `GET /tags`, `/units`, `/ingredients`, `/user` and `/invites` make
+zero account lookups today, and eager resolution adds one to each.
+
+So: a `Caller` value carrying the user ID and resolving the Account **on first use**,
+memoised for the rest of the request. Zero stays zero; nine becomes one.
+
+```go
+type Caller struct {
+    UserID    string
+    db        *sql.DB
+    once      sync.Once
+    accountID int
+    err       error
+}
+
+func (c *Caller) AccountID() (int, error) // GetAccountID once, then cached
+```
+
+This also kills the pattern rather than the symptom: today every service function is
+independently responsible for answering "who is this", which is *why* it happens nine times
+and why nobody noticed.
+
+### Actions
+
+1. Add `Caller` to `internal/pkg/common` (it is shared by `app` and `service`).
+2. `userMiddleware` and `devUserMiddleware` construct one and put it in the request context
+   in place of the bare `userID` string. **Both must become methods on `*App`** — they are
+   free functions today and cannot reach the DB.
+3. Change the 21 service functions from `userID string` to `caller *common.Caller`, calling
+   `caller.AccountID()` where they called `GetAccountID(db, userID)`. `GetAccountID` itself
+   stays — `Caller` is its only caller afterwards.
+4. `GetShoppingList`, `GenerateShoppingList` and the history functions pass the same
+   `Caller` down rather than re-deriving.
+
+### Preserve exactly
+
+**Do not change the error behaviour.** A user with no `account_user` row currently surfaces
+`sql.ErrNoRows` from whichever service function asked, and handlers turn that into a 500.
+Resolving lazily keeps that identical; resolving eagerly in middleware would turn it into a
+blanket rejection and change what `POST /user` does on a genuinely new user. Fix that
+separately if it is worth fixing.
+
+### Verify
+
+Re-census (appendix) and confirm the account-lookup column reads 1 where it read 3, 4 and
+9, and **still reads 0** for `/tags`, `/units`, `/ingredients`, `/user` and `/invites`.
+Full Go suite plus `npm run test:e2e`.
+
+---
+
+## Phase 4 — The two expensive endpoints
+
+### 4a. `PATCH /shopping-list/buy` stops returning the whole list
+
+19 round trips to tick a checkbox: the write is 4 and the other 15 re-run the whole of
+`GetShoppingList` — both catalogs, display units, pantry marking, rounding — to build a
+response body.
+
+**Which nothing reads.** `pages/list.tsx:75` discards `buyMutation`'s result; the page
+already flips the checkbox optimistically in `buyIngredient` and the surrounding comment
+explains that as a deliberate design. So this is dead work end to end.
+
+1. Change `buyListItem` to return `StatusOutput` (or 204) instead of `ShoppingListOutput`.
+2. Regenerate `docs/openapi.yaml` and `types/api.d.ts` — **both are drift-checked in CI and
+   will fail the build otherwise**:
+   `docker compose run --rm api go run . openapi > docs/openapi.yaml` then
+   `npm run generate:api-types`.
+3. Confirm `pages/list.tsx` needs no change; if `apiPatch`'s generic requires one, it is a
+   type-level change only.
+
+Takes the route from 19 round trips to ~4 today, ~2 after Phases 2 and 3.
+
+### 4b. `POST /shopping-list`'s two per-Recipe loops
+
+- **`GetRecipeByID` per Recipe** (6 round trips each). `CombineIngredients` needs only
+  `recipe.ID` and `recipe.Ingredients`, so the loop also fetches name, notes, method and
+  tags per Recipe and throws them away. Replace with one query over the whole set
+  (`WHERE recipe_id IN (...)`), grouped in Go.
+- **`LogShoppingListEvent`'s `INSERT` per Recipe** (`history.go:16`). Replace with a single
+  multi-row `INSERT` — the shape `AddIngredientListItems` uses a few lines away.
+
+Verify with the rig at one and at two Recipes: the **slope** must go flat, not just the
+intercept down. That is the whole point of the change and it is the thing a single-size
+measurement cannot see.
+
+---
+
+## Phase 5 — Read less
+
+### 5a. Read the `list` table once, not three times
+
+`GetRecipesFromList`, `GetIngredientListItems` and `GetExtraListItems` query the same table
+for the same Account, differing only in a `type` filter and projection. One
+`SELECT ... WHERE account_id = ?` returns all of it, partitioned in Go — where the
+Extras/Ingredients split already happens. Keep `ORDER BY list.id`: `GetIngredientListItems`
+documents why an Item's Amounts must come back in insertion order.
+
+### 5b. Cache the catalogs in process
 
 `GetUnitCatalog` + `GetIngredientCatalog` are 3 round trips on both shopping-list routes,
-and they load the **entire global catalog** — so they grow with the catalog rather than
-with the user's list.
+and they load the **entire global catalog** — so they grow with the catalog, not with the
+user's list.
 
 `unit` and `ingredient` change only when a Recipe is saved. An in-process cache invalidated
 on write is straightforward now and was impossible before: this is a **single long-lived
 process** since ADR-0006, where on Lambda every container would have held its own stale
-copy. Note the overlap with #44, which proposes edge-caching `/units` and `/ingredients` for
-*clients* — this is the complement for the API's own use, and #44 already concludes an
-in-process cache is the real win for `known-names.ts`.
+copy. Invalidate from `AddRecipe`/`EditRecipe` — the same write path that already coins new
+Units (`components/recipe-form/Form.tsx:101` refetches `/units` for exactly this reason).
 
-`GET /tags` is the extreme case: a fixed list seeded by migration that no code path writes
+Note the overlap with **#44**, which proposes edge-caching `/units` and `/ingredients` for
+*clients*. This is the complement for the API's own use, and #44 already concludes an
+in-process cache is the real win for `lib/recipe-import/known-names.ts`. Do not let the two
+invalidation mechanisms drift; a Recipe save has to clear both.
+
+`GET /tags` is the extreme case — a fixed list seeded by migration that no code path writes
 to (`hooks/use-tags.ts` documents this), re-read on every call.
 
-### 8. Choose the connection pool deliberately
+---
+
+## Phase 6 — The pool, and then concurrency
+
+### 6a. Choose the pool deliberately
 
 `main.go` sets no limits, so `database/sql` defaults apply — notably `MaxIdleConns` of 2.
-That was defensible when every container was short-lived and is now just undecided.
+Defensible when every container was short-lived; now just undecided. #49 measured a TLS
+MySQL connection at **~5.0 round trips** to establish (plain TCP: ~3.0), so any concurrency
+that pushes past two idle connections pays a full handshake to get one back.
 
-It matters more once item 9 lands: #49 measured a TLS MySQL connection at **~5 round trips**
-to establish, so any concurrency that pushes past two idle connections pays a full handshake
-to get one back. Set `SetMaxOpenConns` / `SetMaxIdleConns` / `SetConnMaxLifetime` against
-TiDB Serverless's own ceiling, and expose `db.Stats()` as a metric so the choice can be
-checked rather than assumed.
+Set `SetMaxOpenConns` / `SetMaxIdleConns` / `SetConnMaxLifetime` against TiDB Serverless's
+own connection ceiling — that ceiling is a real number to look up, not a formality — and
+expose `db.Stats()` (`OpenConnections`, `Idle`, `WaitCount`) so the choice can be checked
+rather than assumed.
 
-### 9. Run independent reads concurrently
+### 6b. Run independent reads concurrently
 
-The item that changes the *shape* rather than the count. Once the Account is resolved once
-(item 2), `GET /shopping-list`'s remaining reads — the list, the unit catalog, the
-ingredient catalog — are mutually independent and run strictly sequentially today. An
-`errgroup` makes the request's depth the slowest single query rather than the sum of all of
-them.
+Once the Account resolves once, `GET /shopping-list`'s remaining reads are mutually
+independent and run strictly sequentially today. An `errgroup` makes the request's depth
+the slowest single query rather than the sum.
 
-Deliberately last. It needs pool headroom (item 8) to help rather than hurt, and it is
-worth much less once items 1, 2, 6 and 7 have taken the count down — parallelising four
-round trips saves less than not making eleven of them.
+**Deliberately last.** It needs 6a's headroom to help rather than hurt, and it is worth much
+less once Phases 2, 3 and 5 have taken the count down — parallelising four round trips saves
+less than not making eleven of them.
+
+---
 
 ## Where that lands
 
@@ -168,30 +334,47 @@ round trips saves less than not making eleven of them.
 | After | round trips |
 | --- | --- |
 | today | 15 |
-| \+ item 1 (`interpolateParams`) | 9 *(measured)* |
-| \+ item 2 (Account once) | 7 |
-| \+ item 6 (one `list` read) | 5 |
-| \+ item 7 (catalogs cached) | **2** |
+| Phase 2 | 9 *(measured)* |
+| \+ Phase 3 | 7 |
+| \+ Phase 5a | 5 |
+| \+ Phase 5b | **2** |
 
-Only the first of those is measured end to end; the rest are counted, and counting is
-exactly what #49 caught being wrong. **Every one of them should be checked on the rig
-before it is believed** — a `toxiproxy` between the API container and MySQL injecting a
-known per-response delay, timing the endpoint at several delays, where the slope is the
-round-trip count. It cost about an hour to build and it is the reason this list has numbers
-at all.
+**Only the first is measured end to end; the rest are counted, and counting is exactly what
+#49 caught being wrong.** Every phase re-runs the rig. `POST /shopping-list` (2 Recipes)
+goes 50 → ~21 on Phases 2 and 3 alone, with 4b and 5b expected to roughly halve it again —
+an estimate on an estimate, and the route whose cost also grows with list size, so it is
+the one to measure most carefully.
 
-`POST /shopping-list` (2 Recipes) goes 50 → ~21 on items 1 and 2 alone, and items 4 and 7
-should roughly halve it again — but that one is an estimate on an estimate, and it is the
-route whose cost also grows with list size, so it is the one to measure first.
+## Appendix — the measurement rig
 
-## What not to do
+Reproduces #49's method. Total request time is linear in injected latency and **the slope
+is the round-trip count**, which needs no interpretation and is immune to how the driver
+logs itself.
 
-- **Do not reach for a cache to fix a latency number** without checking the round-trip
-  count first. That is how #44 came to reason about a query profile that had never been
-  measured, and how "nine queries at ~160ms" survived long enough to reach an ADR.
-- **Do not optimise `GET /shopping-list` and stop.** It is the endpoint that got measured
-  because ADR-0006 singled it out, but `POST` costs three times as much and is the one that
-  does the work.
-- **Do not wait for ADR-0007's tracing to start.** Per-query spans will make all of this
-  visible permanently and for free, and are strictly better than the rig above for
-  production. They are not a prerequisite for any item here, and the rig already exists.
+```bash
+# 1. Bring the stack up with a toxiproxy between the API and MySQL, with the api
+#    service's DSN pointed at toxiproxy:3306 instead of db:3306.
+#    Use an isolated project name - see CLAUDE.md on worktrees.
+COMPOSE_PROJECT_NAME=bigshop-perf DB_PORT=3319 API_PORT=8091 docker compose ... up -d
+
+# 2. Register the proxy
+curl -s -X POST http://localhost:8474/proxies \
+  -d '{"name":"mysql","listen":"0.0.0.0:3306","upstream":"db:3306","enabled":true}'
+
+# 3. For each latency L in 0 10 25 50: add a downstream latency toxic, warm up
+#    with one request, then time N requests and take the mean.
+curl -s -X POST http://localhost:8474/proxies/mysql/toxics \
+  -d '{"name":"lat","type":"latency","stream":"downstream","attributes":{"latency":25,"jitter":0}}'
+
+# 4. slope = (mean(L=50) - mean(L=10)) / 40  ==  blocking round trips
+```
+
+Downstream-only latency is deliberate: it adds the delay once per *server response*, which
+is exactly the thing a round trip waits for, so fire-and-forget commands like
+`COM_STMT_CLOSE` correctly cost nothing.
+
+For a per-statement breakdown, MySQL's general log gives the census
+(`SET GLOBAL general_log=1`, reading `Prepare`/`Execute`/`Query` lines). Two gotchas that
+cost time the first run: the log file must be owned by `mysql` or mysqld silently writes
+nothing, and the logged `Prepare` count **over-reports** blocking round trips — trust the
+slope over the log.


### PR DESCRIPTION
Takes on [follow-up #49](https://github.com/ianfeather/big-shop/blob/master/follow-ups-resolved.md), which asked why a request seemed to cost ~160ms per query rather than the ~90ms ADR-0006 assumed, and why `GET /shopping-list` issued nine of them. Then turns what it found into an implementable spec.

**The premise in the title was the answer.** The request does not issue nine round trips at ~160ms. It issues **fifteen**, at roughly the ~90ms the ADR assumed all along. Nine was a count of *queries*, and a query is not a round trip: six of the nine carry parameters, and `database/sql` over `go-sql-driver` serves those as server-side prepared statements — `COM_STMT_PREPARE`, wait, `COM_STMT_EXECUTE`, wait — so each costs two. 15 × ~90ms is ~1,350ms of the Lambda's 1,624ms; the rest is the edge-to-`us-east-2` hop plus a per-request Auth0 JWKS fetch nobody had counted.

## How it was measured

Counting is exactly what went wrong the first time, so this was measured. A `toxiproxy` between the API container and MySQL injects a known delay on each server response; total request time is linear in injected latency and **the slope is the round-trip count**.

| Injected latency | `GET /shopping-list` | with `interpolateParams=true` |
| --- | --- | --- |
| 0ms | 6.3ms | 5.8ms |
| 10ms | 185.2ms | 109.8ms |
| 25ms | 415.5ms | 247.0ms |
| 50ms | 788.2ms | 476.9ms |
| **slope** | **15.2 round trips** | **9.2 round trips** |

The second column is the confirmation: `interpolateParams=true` is precisely the difference between a query and a round trip here, and it lands on the nine the ADR counted.

**The connection-establishment hypothesis was real but not the answer.** A TLS MySQL connection costs ~5.0 round trips to establish (plain TCP: ~3.0) — but once per connection, and the samples were warm.

## The spec

`specs/request-model-optimisations.md` — six independently shippable phases, with a censused round-trip baseline for all 25 routes and the rig to verify each change against.

| Route | round trips | account lookups |
| --- | --- | --- |
| `POST /shopping-list` (2 Recipes) | **50** | 9 |
| `PATCH /shopping-list/buy` | **19** | 4 |
| `GET /shopping-list` | **15** | 3 |
| `GET /recipes`, `/account` | 4 | 1 |
| `GET /tags`, `/units`, `/ingredients` | 1 | 0 |

Two things the detail work turned up that change the shape of the fixes:

- **Resolving the Account in middleware — the obvious fix — would make five routes slower.** `/tags`, `/units`, `/ingredients`, `/user` and `/invites` do zero account lookups today. The spec specifies a lazily-resolved `Caller` instead: zero stays zero, nine becomes one.
- **`PATCH /shopping-list/buy` spends 15 of its 19 round trips building a response body `pages/list.tsx:75` discards.** The page already flips the checkbox optimistically. That makes it a deletion rather than an optimisation.

Phase 1 is the JWKS cache, first because it is independent of everything else and the latency is the least of what it fixes — Big Shop's request rate is currently its Auth0 JWKS request rate. It upgrades to `go-jwt-middleware` v2 rather than hand-rolling a cache in the one path where a mistake is an auth bypass, **pinned to v2.3.0**: v2.3.1 declares `go 1.24.0` and v3 declares `go 1.25.0`, while this repo pins Go 1.23 in four places, and v2.3.0 is the last release declaring `go 1.23.0`.

## The one thing fixed here

A token whose `kid` names no key in the tenant's JWKS **panicked the handler** instead of returning 401. Anyone can send one — the audience and issuer checks pass on public values. `net/http` recovers per-connection so the process survived, but the caller got an empty reply and a torn-down connection:

```
$ curl -H "Authorization: Bearer <valid aud/iss, unknown kid>" .../shopping-list
  http=000 exitcode=52   # empty reply from server
```

Now returned as an error, with a regression test verified failing against the old code. The discarded error from `jwt.ParseRSAPublicKeyFromPEM` beside it — which returned a nil key with a nil error — is returned too.

## Also

- **ADR-0006's open question is closed**, with the wrong hypothesis preserved in place rather than deleted.
- **Rebased onto `master` after #88 landed**, and reconciled: #44 is resolved, so Phase 5b now names the cache it has to coexist with (ADR-0009's `units` tag via `internal/pkg/purge`) rather than describing edge caching as proposed; master's #51 is a third path over the same table and the spec says so; and my #51/#52 became **#53/#54** to avoid the collision.

## Testing

`./scripts/build-local.sh` passes (exit 0) post-rebase, and all three required checks are green. Backend and documentation only, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)