### PR TITLE
Cut the per-request round trips: Phases 1-3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,15 @@ services:
       db:
         condition: service_healthy
     environment:
-      DSN: "root:root@tcp(db:3306)/bigshop?parseTime=true"
+      # interpolateParams=true makes the driver interpolate arguments
+      # client-side instead of preparing server-side, which halves the blocking
+      # round trips of every parameterised query (measured: GET /shopping-list
+      # 15.2 -> 9.1). collation is pinned *because of* it, not incidentally:
+      # the driver's guard against the multibyte escape-bypass charsets is
+      # `Collation != "" && unsafeCollations[Collation]`, so leaving the
+      # collation unset disarms it. Keep them together, and never add
+      # multiStatements - see specs/request-model-optimisations.md.
+      DSN: "root:root@tcp(db:3306)/bigshop?parseTime=true&interpolateParams=true&collation=utf8mb4_general_ci"
       DISABLE_AUTH: "true"
       DEV_USER_ID: "local-dev-user"
       # Read by the OTel SDK's own env handling (telemetry.Setup passes no

--- a/docker/README.md
+++ b/docker/README.md
@@ -62,7 +62,10 @@ Your row's `account_id` is the value to enter when the script prompts for it.
   variables UI (see the Netlify Dashboard link in `CLAUDE.md`) rather than
   anywhere in this repo. The `DSN` format is
   `user:password@tcp(host:port)/bigshop?...` (see `main.go`'s
-  `sql.Open("mysql", os.Getenv("DSN"))`).
+  `sql.Open("mysql", os.Getenv("DSN"))`). The query parameters after the `?`
+  are load-bearing rather than incidental - see
+  [technical-architecture.md](../technical-architecture.md#the-dsns-query-parameters)
+  before rewriting one.
 - Port - defaults to `4000`, TiDB Cloud's protocol port (not MySQL's usual
   `3306`). Only enter a different one if yours differs.
 - Password - never passed as an argument or stored anywhere by the script.

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -486,9 +486,10 @@ Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are r
 
     **Designed as Phase 1 of
     [`specs/request-model-optimisations.md`](./specs/request-model-optimisations.md)**,
-    which is where the implementation detail lives — including the one constraint that
-    decides the approach: `go-jwt-middleware` **v2.3.0** is the last release declaring
-    `go 1.23.0`, and this repo pins Go 1.23 in four places.
+    which is where the implementation detail lives. That spec's approach turned on one
+    constraint — `go-jwt-middleware` **v2.3.0** was the last release declaring `go 1.23.0`,
+    and this repo pinned Go 1.23 in four places. **That constraint is gone**: #91 moved the
+    repo to Go 1.25, and the API now runs v2.3.1. Going further is #57.
 
 55. **Photo Import's extraction runs after the response, and nothing establishes that a
     Netlify function stays alive to finish it.** `pages/api/recipe-image.ts` answers `202`
@@ -541,3 +542,42 @@ Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are r
     of read, which is exactly what CLAUDE.md's "a flaky-looking e2e failure gets investigated, not
     re-run-until-green" exists to prevent. And a 500 here is a lie to any client: the browser's
     delete button cannot tell "already gone, refresh your list" from "the API is down".
+
+57. **Upgrade `go-jwt-middleware` to v3.** Split off while removing the Go 1.23 version
+    pins (see #54 and `specs/request-model-optimisations.md`). Once #91 moved the repo to
+    Go 1.25, three pinned dependencies came unstuck at once — `go-sql-driver/mysql` and
+    Huma were straight version bumps and were taken there and then, but
+    `go-jwt-middleware` v2 → v3 is a **major version**, so it is queued here rather than
+    smuggled into an unrelated PR. The API sits at **v2.3.1**, the newest v2, in the
+    meantime; nothing is blocked.
+
+    It is a rewrite of the wiring, not a version swap:
+
+    - **Constructors became options-based and now return errors.**
+      `validator.New(keyFunc, RS256, issuer, []string{audience})` becomes
+      `validator.New(WithKeyFunc(...), WithAlgorithm(...), WithIssuer(...), WithAudience(...))`,
+      and both `jwks.NewCachingProvider` and `jwtmiddleware.New` gained an `error` return.
+      `internal/pkg/app/app.go`'s `newJWTMiddleware` is the only place that has to change,
+      which is the one piece of good news.
+    - **The underlying JWT library changed** from `go-jose` to `lestrrat-go/jwx`. That
+      reaches the tests: `TestKeyLookupFailureIsRefusedNotPanicked` mints its token with
+      go-jose, so either go-jose stays as a test-only dependency or the fixture moves to
+      `jwx`. It has already been rewritten once for the same reason (it used
+      `form3tech-oss/jwt-go` before v2).
+    - **Claims move out of `ContextKey{}`** and into `core.GetClaims[T](ctx)`, so
+      `userMiddleware` changes too.
+
+    Two things to check rather than assume, both of which the v2 work had to pin down:
+
+    - **A missing token must still answer 401, not 400.** v2's `DefaultErrorHandler`
+      answers 400, which is why `authErrorHandler` exists at all; `TestRefusalsAnswer401`
+      guards it and must stay green.
+    - **`CachingProvider`'s TTL semantics.** v2 caches the whole key set for the TTL and
+      does not refresh on an unknown `kid` — an accepted limitation, argued against the
+      tenant publishing two keys at once. v3 adds `WithCache` and
+      `WithStrictJWKSURIOrigin`, so re-read that argument rather than carrying it over.
+
+    Worth doing for more than currency: v3 validates the issuer **before** fetching the
+    JWKS, explicitly to prevent SSRF. On v2 a token carrying an attacker-chosen `iss`
+    reaches the key fetch first, which is the shape #54 flagged as "unauthenticated work"
+    in the first place.

--- a/netlify-functions/recipes/go.mod
+++ b/netlify-functions/recipes/go.mod
@@ -4,11 +4,11 @@ go 1.25.0
 
 require (
 	github.com/XSAM/otelsql v0.43.0
-	github.com/auth0/go-jwt-middleware/v2 v2.3.0
+	github.com/auth0/go-jwt-middleware/v2 v2.3.1
 	github.com/aws/aws-lambda-go v1.22.0
 	github.com/awslabs/aws-lambda-go-api-proxy v0.9.0
-	github.com/danielgtaylor/huma/v2 v2.35.0
-	github.com/go-sql-driver/mysql v1.9.3
+	github.com/danielgtaylor/huma/v2 v2.39.1
+	github.com/go-sql-driver/mysql v1.10.0
 	github.com/gorilla/mux v1.8.1
 	github.com/rs/cors v1.7.0
 	github.com/sendgrid/sendgrid-go v3.10.4+incompatible
@@ -28,7 +28,7 @@ require (
 )
 
 require (
-	filippo.io/edwards25519 v1.1.0 // indirect
+	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect

--- a/netlify-functions/recipes/go.mod
+++ b/netlify-functions/recipes/go.mod
@@ -4,11 +4,10 @@ go 1.25.0
 
 require (
 	github.com/XSAM/otelsql v0.43.0
-	github.com/auth0/go-jwt-middleware v1.0.0
+	github.com/auth0/go-jwt-middleware/v2 v2.3.0
 	github.com/aws/aws-lambda-go v1.22.0
 	github.com/awslabs/aws-lambda-go-api-proxy v0.9.0
 	github.com/danielgtaylor/huma/v2 v2.35.0
-	github.com/form3tech-oss/jwt-go v3.2.2+incompatible
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gorilla/mux v1.8.1
 	github.com/rs/cors v1.7.0
@@ -25,6 +24,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.21.0
 	go.opentelemetry.io/otel/sdk/metric v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
+	gopkg.in/go-jose/go-jose.v2 v2.6.3
 )
 
 require (
@@ -43,7 +43,9 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.11.0 // indirect
+	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/netlify-functions/recipes/go.mod
+++ b/netlify-functions/recipes/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-lambda-go v1.22.0
 	github.com/awslabs/aws-lambda-go-api-proxy v0.9.0
 	github.com/danielgtaylor/huma/v2 v2.35.0
-	github.com/go-sql-driver/mysql v1.5.0
+	github.com/go-sql-driver/mysql v1.9.3
 	github.com/gorilla/mux v1.8.1
 	github.com/rs/cors v1.7.0
 	github.com/sendgrid/sendgrid-go v3.10.4+incompatible
@@ -28,6 +28,7 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect

--- a/netlify-functions/recipes/go.sum
+++ b/netlify-functions/recipes/go.sum
@@ -1,6 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
-filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
@@ -13,8 +13,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/auth0/go-jwt-middleware/v2 v2.3.0 h1:4QREj6cS3d8dS05bEm443jhnqQF97FX9sMBeWqnNRzE=
-github.com/auth0/go-jwt-middleware/v2 v2.3.0/go.mod h1:dL4ObBs1/dj4/W4cYxd8rqAdDGXYyd5rqbpMIxcbVrU=
+github.com/auth0/go-jwt-middleware/v2 v2.3.1 h1:lbDyWE9aLydb3zrank+Gufb9qGJN9u//7EbJK07pRrw=
+github.com/auth0/go-jwt-middleware/v2 v2.3.1/go.mod h1:mqVr0gdB5zuaFyQFWMJH/c/2hehNjbYUD4i8Dpyf+Hc=
 github.com/aws/aws-lambda-go v1.19.1/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
 github.com/aws/aws-lambda-go v1.22.0 h1:X7BKqIdfoJcbsEIi+Lrt5YjX1HnZexIbNWOQgkYKgfE=
 github.com/aws/aws-lambda-go v1.22.0/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
@@ -35,8 +35,8 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/danielgtaylor/huma/v2 v2.35.0 h1:FRg3FgVKcMogVhbNY7FjyTwk+p/orLBR3hQBvXXg7dw=
-github.com/danielgtaylor/huma/v2 v2.35.0/go.mod h1:3elp5brzdyyZsPlDVvf6w8RLnklKp3abolr+5op3fP0=
+github.com/danielgtaylor/huma/v2 v2.39.1 h1:0kwF4ltQoYZ+IU55VPy+BcGekzgF44R64daTGde1H+g=
+github.com/danielgtaylor/huma/v2 v2.39.1/go.mod h1:zcnQ38duIJ3VUHwFaBoZ6x8T+KN/mr33oyqxcj0HTug=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -55,11 +55,16 @@ github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh78=
+github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
+github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
 github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi/v5 v5.3.1 h1:3j4HZLGZQ3JpMCrPJF/Jl3mYJfWLKBfNJ6quurUGCf8=
+github.com/go-chi/chi/v5 v5.3.1/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.4 h1:tG4xh9yMsRCAiodLVTxyrkzSZ9+o0L1Kg/+cPVcbP/8=
 github.com/go-logr/logr v1.4.4/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -70,8 +75,8 @@ github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTM
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.3.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
-github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
-github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
+github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxoWCWfw=
+github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
@@ -218,6 +223,8 @@ github.com/valyala/fasthttp v1.16.0/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=

--- a/netlify-functions/recipes/go.sum
+++ b/netlify-functions/recipes/go.sum
@@ -11,8 +11,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/auth0/go-jwt-middleware v1.0.0 h1:76t55qLQu3xjMFbkirbSCA8ZPcO1ny+20Uq1wkSTRDE=
-github.com/auth0/go-jwt-middleware v1.0.0/go.mod h1:nX2S0GmCyl087kdNSSItfOvMYokq5PSTG1yGIP5Le4U=
+github.com/auth0/go-jwt-middleware/v2 v2.3.0 h1:4QREj6cS3d8dS05bEm443jhnqQF97FX9sMBeWqnNRzE=
+github.com/auth0/go-jwt-middleware/v2 v2.3.0/go.mod h1:dL4ObBs1/dj4/W4cYxd8rqAdDGXYyd5rqbpMIxcbVrU=
 github.com/aws/aws-lambda-go v1.19.1/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
 github.com/aws/aws-lambda-go v1.22.0 h1:X7BKqIdfoJcbsEIi+Lrt5YjX1HnZexIbNWOQgkYKgfE=
 github.com/aws/aws-lambda-go v1.22.0/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
@@ -27,7 +27,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chris-ramon/douceur v0.2.0/go.mod h1:wDW5xjJdeoMm1mRt4sD4c/LbF/mWdEpRXQKjTR8nIBE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -51,8 +50,6 @@ github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod 
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
-github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
-github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -66,7 +63,6 @@ github.com/go-logr/logr v1.4.4 h1:tG4xh9yMsRCAiodLVTxyrkzSZ9+o0L1Kg/+cPVcbP/8=
 github.com/go-logr/logr v1.4.4/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
-github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
@@ -106,8 +102,6 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 h1:l5lAOZEym3oK3SQ2HBHWsJUfbNBiTXJDeW2QDxw9AQ0=
-github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
@@ -127,7 +121,6 @@ github.com/iris-contrib/pongo2 v0.0.1/go.mod h1:Ssh+00+3GAZqSQb30AvBRNxBx7rf0Gqw
 github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrOcOqfqxa4hXw=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kataras/golog v0.0.10/go.mod h1:yJ8YKCmyL+nWjERB90Qwn+bdyBZsaQwU3bTVFgkFIp8=
@@ -198,9 +191,6 @@ github.com/sendgrid/sendgrid-go v3.10.4+incompatible/go.mod h1:QRQt+LX/NmgVEvmdR
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
-github.com/smartystreets/assertions v1.1.0 h1:MkTeG1DMwsrdH7QtLXy5W+fUxWq+vmb6cLmyJ7aRtF0=
-github.com/smartystreets/assertions v1.1.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
-github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -276,6 +266,8 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
+golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -301,6 +293,8 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -370,6 +364,8 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/go-jose/go-jose.v2 v2.6.3 h1:nt80fvSDlhKWQgSWyHyy5CfmlQr+asih51R8PTWNKKs=
+gopkg.in/go-jose/go-jose.v2 v2.6.3/go.mod h1:zzZDPkNNw/c9IE7Z9jr11mBZQhKQTMzoEEIoEdZlFBI=
 gopkg.in/ini.v1 v1.51.1/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=

--- a/netlify-functions/recipes/go.sum
+++ b/netlify-functions/recipes/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
@@ -68,8 +70,8 @@ github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTM
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.3.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
-github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
-github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
+github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=

--- a/netlify-functions/recipes/internal/pkg/app/account.go
+++ b/netlify-functions/recipes/internal/pkg/app/account.go
@@ -20,8 +20,8 @@ type AccountUserInput struct {
 }
 
 func (a *App) getAccount(ctx context.Context, _ *struct{}) (*AccountOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
-	account, err := service.GetAccount(ctx, a.db, userID)
+	caller := callerFrom(ctx)
+	account, err := service.GetAccount(ctx, a.db, caller)
 
 	if err != nil {
 		return nil, fail(ctx, huma.Error500InternalServerError("Failed to get Account from db"), err)
@@ -31,10 +31,10 @@ func (a *App) getAccount(ctx context.Context, _ *struct{}) (*AccountOutput, erro
 }
 
 func (a *App) addUserToAccount(ctx context.Context, input *AccountUserInput) (*AccountOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 	newUser := input.Body
 
-	accountID, err := service.GetAccountID(ctx, a.db, userID)
+	accountID, err := caller.AccountID()
 	if err != nil {
 		// Was: log the guess "current user is not associated with an account"
 		// and discard err - so a TiDB outage was reported, to the logs and to
@@ -52,7 +52,7 @@ func (a *App) addUserToAccount(ctx context.Context, input *AccountUserInput) (*A
 		return nil, fail(ctx, huma.Error500InternalServerError("Failed to add user to account"), err)
 	}
 
-	account, err := service.GetAccount(ctx, a.db, userID)
+	account, err := service.GetAccount(ctx, a.db, caller)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to get Account from db")
 	}
@@ -61,10 +61,10 @@ func (a *App) addUserToAccount(ctx context.Context, input *AccountUserInput) (*A
 }
 
 func (a *App) removeUserFromAccount(ctx context.Context, input *AccountUserInput) (*AccountOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 	outgoingUser := input.Body
 
-	accountID, err := service.GetAccountID(ctx, a.db, userID)
+	accountID, err := caller.AccountID()
 	if err != nil {
 		// Was: log the guess "current user is not associated with an account"
 		// and discard err - so a TiDB outage was reported, to the logs and to
@@ -78,7 +78,7 @@ func (a *App) removeUserFromAccount(ctx context.Context, input *AccountUserInput
 		return nil, fail(ctx, huma.Error500InternalServerError("Failed to remove user from account"), err)
 	}
 
-	account, err := service.GetAccount(ctx, a.db, userID)
+	account, err := service.GetAccount(ctx, a.db, caller)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to get Account from db")
 	}

--- a/netlify-functions/recipes/internal/pkg/app/app.go
+++ b/netlify-functions/recipes/internal/pkg/app/app.go
@@ -3,19 +3,22 @@ package app
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"recipes/internal/pkg/common"
 	"recipes/internal/pkg/purge"
 	"recipes/internal/pkg/telemetry"
 	"sort"
+	"time"
 
-	jwtmiddleware "github.com/auth0/go-jwt-middleware"
+	jwtmiddleware "github.com/auth0/go-jwt-middleware/v2"
+	"github.com/auth0/go-jwt-middleware/v2/jwks"
+	"github.com/auth0/go-jwt-middleware/v2/validator"
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humamux"
-	"github.com/form3tech-oss/jwt-go"
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
 	"github.com/urfave/negroni"
@@ -46,21 +49,6 @@ func (a *App) PurgeConfigured() bool {
 // and gives nothing back on purpose: see purge.Purger.Purge.
 type cachePurger interface {
 	Purge(tag string)
-}
-
-// Jwks will hold the response from the public server
-type Jwks struct {
-	Keys []JSONWebKeys `json:"keys"`
-}
-
-// JSONWebKeys refers to the remove public key data
-type JSONWebKeys struct {
-	Kty string   `json:"kty"`
-	Kid string   `json:"kid"`
-	Use string   `json:"use"`
-	N   string   `json:"n"`
-	E   string   `json:"e"`
-	X5c []string `json:"x5c"`
 }
 
 type contextKey string
@@ -112,14 +100,122 @@ func cacheControlMiddleware(w http.ResponseWriter, r *http.Request, next http.Ha
 	next.ServeHTTP(w, r)
 }
 
-func userMiddleware(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	ctx := context.WithValue(
-		r.Context(),
-		contextKey("userID"),
-		// TODO: Add account ID here too via DB lookup?
-		r.Context().Value("user").(*jwt.Token).Claims.(jwt.MapClaims)["sub"].(string),
+// jwksCacheTTL is how long the tenant's key set is held in process.
+//
+// The trade-off it settles: CachingProvider caches the whole key set for the
+// TTL and does *not* refresh on an unknown `kid`, so a token signed by a key
+// minted inside the current window would be refused until the window expires.
+// Five minutes is chosen against that. The tenant publishes two keys at once,
+// so a new key appears in the JWKS well before Auth0 signs anything with it,
+// which makes the exposure theoretical rather than live.
+const jwksCacheTTL = 5 * time.Minute
+
+// jwtMiddleware builds the negroni handler that validates Auth0 tokens.
+//
+// Built once, when the router is. That is the entire point of the change it
+// came from: `getPemCert` fetched the tenant's JWKS over HTTPS on *every*
+// request, so Big Shop's request rate was its Auth0 request rate, and a rate
+// limit or an incident on that endpoint failed every request rather than just
+// logins. A provider constructed per request would cache nothing and restore
+// exactly that.
+//
+// Unconfigured, it refuses every request rather than returning an error, which
+// looks odd until you notice `go run . openapi` builds this same router with no
+// Auth0 environment at all (main.go's spec-generation mode, and a CI drift
+// gate). Failing here would break the build for a path that never serves a
+// request; refusing every request is the fail-closed answer for the path that
+// does.
+func jwtMiddleware() negroni.HandlerFunc {
+	middleware, err := newJWTMiddleware()
+	if err != nil {
+		log.Printf("auth is not configured, every request will be refused: %v", err)
+		return func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+			unauthorized(w)
+		}
+	}
+
+	// v2 has no HandlerWithNext, which is what v1 handed negroni directly.
+	// CheckJWT wraps a handler instead, so negroni's continuation goes in as
+	// that handler - which keeps this middleware exactly where it sat in the
+	// stack, behind cacheControlMiddleware and the /health carve-out.
+	return func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		middleware.CheckJWT(next).ServeHTTP(w, r)
+	}
+}
+
+func newJWTMiddleware() (*jwtmiddleware.JWTMiddleware, error) {
+	domain := os.Getenv("AUTH0_DOMAIN")
+	audience := os.Getenv("AUTH0_AUDIENCE")
+	if domain == "" || audience == "" {
+		return nil, errors.New("AUTH0_DOMAIN and AUTH0_AUDIENCE are both required")
+	}
+
+	issuerURL, err := url.Parse("https://" + domain + "/")
+	if err != nil {
+		return nil, err
+	}
+
+	provider := jwks.NewCachingProvider(issuerURL, jwksCacheTTL)
+
+	// Issuer and audience are checked by the validator itself, and both are
+	// required rather than checked-if-present - a token this tenant signed for
+	// some other audience is exactly what this API must refuse.
+	jwtValidator, err := validator.New(
+		provider.KeyFunc,
+		validator.RS256,
+		issuerURL.String(),
+		[]string{audience},
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	return jwtmiddleware.New(jwtValidator.ValidateToken, jwtmiddleware.WithErrorHandler(authErrorHandler)), nil
+}
+
+// authErrorHandler answers 401 for a refused token, whether it was missing or
+// invalid.
+//
+// Not cosmetic. v2's DefaultErrorHandler answers a *missing* token with 400 and
+// only an invalid one with 401, where v1 answered 401 for both - so taking the
+// default would change what every unauthenticated request gets back, which is a
+// contract change no part of this work asked for. TestDefaultCacheControl pins
+// it directly.
+func authErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, jwtmiddleware.ErrJWTMissing) || errors.Is(err, jwtmiddleware.ErrJWTInvalid) {
+		unauthorized(w)
+		return
+	}
+	jwtmiddleware.DefaultErrorHandler(w, r, err)
+}
+
+// userMiddleware lifts the authenticated subject out of the validated JWT and
+// puts it in the request context, where the handlers read it.
+//
+// Runs only after the JWT middleware, so the claims should always be present -
+// but the assertion is guarded anyway and answers 401 rather than panicking if
+// they are not. The line this replaced chained three unchecked assertions
+// (`Value("user").(*jwt.Token).Claims.(jwt.MapClaims)["sub"].(string)`), any of
+// which would panic on a shape it did not expect. There is no Recovery
+// middleware in the negroni stack, so that panic is an empty reply rather than
+// a response - the same defect #49 fixed one layer further down.
+func userMiddleware(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	claims, ok := r.Context().Value(jwtmiddleware.ContextKey{}).(*validator.ValidatedClaims)
+	if !ok || claims.RegisteredClaims.Subject == "" {
+		unauthorized(w)
+		return
+	}
+
+	ctx := context.WithValue(r.Context(), contextKey("userID"), claims.RegisteredClaims.Subject)
 	next.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// unauthorized writes the 401 body shape go-jwt-middleware itself uses, so a
+// refusal looks the same wherever in the auth chain it came from.
+func unauthorized(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	_, _ = w.Write([]byte(`{"message":"JWT is invalid."}`))
 }
 
 // devUserMiddleware stands in for the jwt+user middleware pair when
@@ -133,69 +229,6 @@ func devUserMiddleware(w http.ResponseWriter, r *http.Request, next http.Handler
 	}
 	ctx := context.WithValue(r.Context(), contextKey("userID"), devUserID)
 	next.ServeHTTP(w, r.WithContext(ctx))
-}
-
-// normalizeAudience rewrites the `aud` claim into a shape MapClaims.
-// VerifyAudience understands.
-//
-// It accepts only []string or string and returns false for anything else,
-// while encoding/json decodes a JSON array into []interface{} - which is what
-// Auth0 sends whenever a token was requested with an audience. Hence the
-// conversion (https://github.com/form3tech-oss/jwt-go/issues/7).
-//
-// Returns an error rather than asserting. The `claims["aud"].([]interface{})`
-// this replaced panicked outright on a token whose `aud` was absent or a bare
-// string, and there is no Recovery middleware in the negroni stack to turn
-// that into a response - so an unauthenticated request could kill the handler
-// instead of being refused by it.
-func normalizeAudience(claims jwt.MapClaims) error {
-	switch aud := claims["aud"].(type) {
-	case []interface{}:
-		values := make([]string, len(aud))
-		for i, v := range aud {
-			value, ok := v.(string)
-			if !ok {
-				return errors.New("invalid audience")
-			}
-			values[i] = value
-		}
-		claims["aud"] = values
-	case []string, string:
-		// Already a shape VerifyAudience reads.
-	default:
-		return errors.New("missing audience")
-	}
-	return nil
-}
-
-func getPemCert(token *jwt.Token) (string, error) {
-	cert := ""
-	resp, err := http.Get("https://" + os.Getenv("AUTH0_DOMAIN") + "/.well-known/jwks.json")
-
-	if err != nil {
-		return cert, err
-	}
-	defer resp.Body.Close()
-
-	var jwks = Jwks{}
-	err = json.NewDecoder(resp.Body).Decode(&jwks)
-
-	if err != nil {
-		return cert, err
-	}
-
-	for k := range jwks.Keys {
-		if token.Header["kid"] == jwks.Keys[k].Kid {
-			cert = "-----BEGIN CERTIFICATE-----\n" + jwks.Keys[k].X5c[0] + "\n-----END CERTIFICATE-----"
-		}
-	}
-
-	if cert == "" {
-		err := errors.New("unable to find appropriate key")
-		return cert, err
-	}
-
-	return cert, nil
 }
 
 // RouteTemplates lists the path templates registered on an API - "/recipes",
@@ -219,56 +252,6 @@ func RouteTemplates(api huma.API) []string {
 // it, from which the OpenAPI spec can be generated (see the `openapi` mode in
 // main.go) without needing to start a server or hold a DB connection.
 func (a *App) GetRouter(base string) (*negroni.Negroni, huma.API, error) {
-
-	jwtMiddleware := jwtmiddleware.New(jwtmiddleware.Options{
-		ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {
-			claims, ok := token.Claims.(jwt.MapClaims)
-			if !ok {
-				return nil, errors.New("invalid claims")
-			}
-
-			if err := normalizeAudience(claims); err != nil {
-				return nil, err
-			}
-
-			// Both claims are *required*, not merely checked-if-present. With
-			// the `false` this passed before, verifyAud returns true for an
-			// empty `aud` and VerifyIssuer returns true for a token carrying
-			// no `iss` at all - so any token the tenant's key signed was
-			// accepted, whatever it was minted for. The signature check below
-			// meant that was never an open door, but a token issued by this
-			// Auth0 tenant for some other audience is exactly what this API
-			// must refuse.
-			if !claims.VerifyAudience(os.Getenv("AUTH0_AUDIENCE"), true) {
-				return nil, errors.New("invalid audience")
-			}
-
-			iss := "https://" + os.Getenv("AUTH0_DOMAIN") + "/"
-			if !claims.VerifyIssuer(iss, true) {
-				return nil, errors.New("invalid issuer")
-			}
-
-			// Returned, never panicked. Both of these are reachable by an
-			// unauthenticated caller: getPemCert fails whenever the token's
-			// `kid` names no key in the tenant's JWKS, which anyone can send.
-			// The panic this replaces was recovered per-connection by
-			// net/http, so the process survived - but the request got no
-			// response at all (curl reports an empty reply) instead of the
-			// 401 it should. Same defect normalizeAudience's comment above
-			// describes, one branch further down, and the reason it matters
-			// is the same: there is no Recovery middleware in the negroni
-			// stack to turn a panic into a response.
-			cert, err := getPemCert(token)
-			if err != nil {
-				return nil, err
-			}
-			// The error here used to be discarded, which returned a nil key
-			// with a nil error and left the jwt library to fail on it later,
-			// somewhere less obvious.
-			return jwt.ParseRSAPublicKeyFromPEM([]byte(cert))
-		},
-		SigningMethod: jwt.SigningMethodRS256,
-	})
 
 	router := mux.NewRouter()
 
@@ -330,7 +313,7 @@ func (a *App) GetRouter(base string) (*negroni.Negroni, huma.API, error) {
 	if os.Getenv("DISABLE_AUTH") == "true" {
 		n.Use(negroni.HandlerFunc(devUserMiddleware))
 	} else {
-		n.Use(negroni.HandlerFunc(jwtMiddleware.HandlerWithNext))
+		n.Use(jwtMiddleware())
 		n.Use(negroni.HandlerFunc(userMiddleware))
 	}
 	// After the auth pair, deliberately: the server span is opened outside this

--- a/netlify-functions/recipes/internal/pkg/app/app.go
+++ b/netlify-functions/recipes/internal/pkg/app/app.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"recipes/internal/pkg/common"
 	"recipes/internal/pkg/purge"
+	"recipes/internal/pkg/service"
 	"recipes/internal/pkg/telemetry"
 	"sort"
 	"time"
@@ -199,15 +200,42 @@ func authErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
 // which would panic on a shape it did not expect. There is no Recovery
 // middleware in the negroni stack, so that panic is an empty reply rather than
 // a response - the same defect #49 fixed one layer further down.
-func userMiddleware(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+func (a *App) userMiddleware(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	claims, ok := r.Context().Value(jwtmiddleware.ContextKey{}).(*validator.ValidatedClaims)
 	if !ok || claims.RegisteredClaims.Subject == "" {
 		unauthorized(w)
 		return
 	}
 
-	ctx := context.WithValue(r.Context(), contextKey("userID"), claims.RegisteredClaims.Subject)
-	next.ServeHTTP(w, r.WithContext(ctx))
+	next.ServeHTTP(w, r.WithContext(a.withCaller(r.Context(), claims.RegisteredClaims.Subject)))
+}
+
+// withCaller puts a Caller for this request into the context.
+//
+// A method on *App because the Caller needs the database to resolve the
+// Account - lazily, so a route that never asks for an Account still makes no
+// query at all. One Caller per request, never shared.
+//
+// The lookup closes over the request's context, so the one query it may make is
+// attributed to the request that caused it like every other - the middleware
+// runs inside the server span, so this is the same span the handler would have
+// passed in had the Caller taken a context of its own.
+func (a *App) withCaller(ctx context.Context, userID string) context.Context {
+	caller := common.NewCaller(userID, func() (int, error) {
+		return service.GetAccountID(ctx, a.db, userID)
+	})
+	return context.WithValue(ctx, contextKey("caller"), caller)
+}
+
+// callerFrom lifts the request's Caller back out of the context.
+//
+// Panics if it is absent, which is deliberate and safe: every route is behind
+// either userMiddleware or devUserMiddleware, both of which install one, so an
+// absent Caller means the middleware stack has been misassembled - a
+// programming error that should fail loudly in the first test that runs, not
+// resolve to a zero user ID that quietly reads another Account's data.
+func callerFrom(ctx context.Context) *common.Caller {
+	return ctx.Value(contextKey("caller")).(*common.Caller)
 }
 
 // unauthorized writes the 401 body shape go-jwt-middleware itself uses, so a
@@ -222,13 +250,12 @@ func unauthorized(w http.ResponseWriter) {
 // DISABLE_AUTH=true, so the API can be run locally (`go run . dev`) without a
 // real Auth0 token. The user ID it injects must exist in the local DB
 // (account_user) for requests to resolve to an account.
-func devUserMiddleware(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+func (a *App) devUserMiddleware(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	devUserID := os.Getenv("DEV_USER_ID")
 	if devUserID == "" {
 		devUserID = "local-dev-user"
 	}
-	ctx := context.WithValue(r.Context(), contextKey("userID"), devUserID)
-	next.ServeHTTP(w, r.WithContext(ctx))
+	next.ServeHTTP(w, r.WithContext(a.withCaller(r.Context(), devUserID)))
 }
 
 // RouteTemplates lists the path templates registered on an API - "/recipes",
@@ -311,10 +338,10 @@ func (a *App) GetRouter(base string) (*negroni.Negroni, huma.API, error) {
 	}))
 	n.Use(c)
 	if os.Getenv("DISABLE_AUTH") == "true" {
-		n.Use(negroni.HandlerFunc(devUserMiddleware))
+		n.Use(negroni.HandlerFunc(a.devUserMiddleware))
 	} else {
 		n.Use(jwtMiddleware())
-		n.Use(negroni.HandlerFunc(userMiddleware))
+		n.Use(negroni.HandlerFunc(a.userMiddleware))
 	}
 	// After the auth pair, deliberately: the server span is opened outside this
 	// whole stack (main.go wraps it), but the identity that makes the span worth

--- a/netlify-functions/recipes/internal/pkg/app/app.go
+++ b/netlify-functions/recipes/internal/pkg/app/app.go
@@ -111,7 +111,8 @@ func cacheControlMiddleware(w http.ResponseWriter, r *http.Request, next http.Ha
 // which makes the exposure theoretical rather than live.
 const jwksCacheTTL = 5 * time.Minute
 
-// jwtMiddleware builds the negroni handler that validates Auth0 tokens.
+// jwtHandler builds the negroni handler that validates Auth0 tokens, wrapping
+// the *jwtmiddleware.JWTMiddleware that newJWTMiddleware constructs.
 //
 // Built once, when the router is. That is the entire point of the change it
 // came from: `getPemCert` fetched the tenant's JWKS over HTTPS on *every*
@@ -126,12 +127,15 @@ const jwksCacheTTL = 5 * time.Minute
 // gate). Failing here would break the build for a path that never serves a
 // request; refusing every request is the fail-closed answer for the path that
 // does.
-func jwtMiddleware() negroni.HandlerFunc {
+func jwtHandler() negroni.HandlerFunc {
 	middleware, err := newJWTMiddleware()
 	if err != nil {
 		log.Printf("auth is not configured, every request will be refused: %v", err)
 		return func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-			unauthorized(w)
+			// Deliberately the same body a bad token gets. Whether this API is
+			// misconfigured is not something an unauthenticated caller should
+			// be able to read off the response.
+			unauthorized(w, "JWT is invalid.")
 		}
 	}
 
@@ -175,19 +179,23 @@ func newJWTMiddleware() (*jwtmiddleware.JWTMiddleware, error) {
 }
 
 // authErrorHandler answers 401 for a refused token, whether it was missing or
-// invalid.
+// invalid, while still saying which.
 //
 // Not cosmetic. v2's DefaultErrorHandler answers a *missing* token with 400 and
 // only an invalid one with 401, where v1 answered 401 for both - so taking the
 // default would change what every unauthenticated request gets back, which is a
 // contract change no part of this work asked for. TestDefaultCacheControl pins
-// it directly.
+// it directly. Only the status is overridden; the two cases keep the distinct
+// messages the library would have given them.
 func authErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
-	if errors.Is(err, jwtmiddleware.ErrJWTMissing) || errors.Is(err, jwtmiddleware.ErrJWTInvalid) {
-		unauthorized(w)
-		return
+	switch {
+	case errors.Is(err, jwtmiddleware.ErrJWTMissing):
+		unauthorized(w, "JWT is missing.")
+	case errors.Is(err, jwtmiddleware.ErrJWTInvalid):
+		unauthorized(w, "JWT is invalid.")
+	default:
+		jwtmiddleware.DefaultErrorHandler(w, r, err)
 	}
-	jwtmiddleware.DefaultErrorHandler(w, r, err)
 }
 
 // userMiddleware lifts the authenticated subject out of the validated JWT and
@@ -203,7 +211,7 @@ func authErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
 func (a *App) userMiddleware(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	claims, ok := r.Context().Value(jwtmiddleware.ContextKey{}).(*validator.ValidatedClaims)
 	if !ok || claims.RegisteredClaims.Subject == "" {
-		unauthorized(w)
+		unauthorized(w, "JWT is invalid.")
 		return
 	}
 
@@ -240,14 +248,14 @@ func callerFrom(ctx context.Context) *common.Caller {
 
 // unauthorized writes the 401 body shape go-jwt-middleware itself uses, so a
 // refusal looks the same wherever in the auth chain it came from.
-func unauthorized(w http.ResponseWriter) {
+func unauthorized(w http.ResponseWriter, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
-	_, _ = w.Write([]byte(`{"message":"JWT is invalid."}`))
+	_, _ = w.Write([]byte(`{"message":"` + message + `"}`))
 }
 
 // devUserMiddleware stands in for the jwt+user middleware pair when
-// DISABLE_AUTH=true, so the API can be run locally (`go run . dev`) without a
+// DISABLE_AUTH=true, so the API can be run locally (`go run . serve`) without a
 // real Auth0 token. The user ID it injects must exist in the local DB
 // (account_user) for requests to resolve to an account.
 func (a *App) devUserMiddleware(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
@@ -340,7 +348,7 @@ func (a *App) GetRouter(base string) (*negroni.Negroni, huma.API, error) {
 	if os.Getenv("DISABLE_AUTH") == "true" {
 		n.Use(negroni.HandlerFunc(a.devUserMiddleware))
 	} else {
-		n.Use(jwtMiddleware())
+		n.Use(jwtHandler())
 		n.Use(negroni.HandlerFunc(a.userMiddleware))
 	}
 	// After the auth pair, deliberately: the server span is opened outside this

--- a/netlify-functions/recipes/internal/pkg/app/app_test.go
+++ b/netlify-functions/recipes/internal/pkg/app/app_test.go
@@ -40,6 +40,11 @@ func TestRefusalsAnswer401(t *testing.T) {
 		if rec.Code != http.StatusUnauthorized {
 			t.Errorf("status = %d, want 401 (v2's default for a missing token is 400)", rec.Code)
 		}
+		// Only the status is overridden, not the diagnosis - a caller who sent
+		// no token should not be told their token is invalid.
+		if got := rec.Body.String(); !strings.Contains(got, "JWT is missing") {
+			t.Errorf("body = %q, want it to say the JWT is missing", got)
+		}
 	})
 
 	t.Run("when auth is not configured at all", func(t *testing.T) {

--- a/netlify-functions/recipes/internal/pkg/app/app_test.go
+++ b/netlify-functions/recipes/internal/pkg/app/app_test.go
@@ -14,110 +14,55 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
-	"github.com/form3tech-oss/jwt-go"
+	jose "gopkg.in/go-jose/go-jose.v2"
+	josejwt "gopkg.in/go-jose/go-jose.v2/jwt"
 )
 
-const (
-	testAudience = "https://api.bigshop.test"
-	testIssuer   = "https://tenant.eu.auth0.com/"
-)
+const testAudience = "https://api.bigshop.test"
 
-func TestNormalizeAudience(t *testing.T) {
-	t.Run("converts the []interface{} a JSON array decodes to", func(t *testing.T) {
-		claims := jwt.MapClaims{"aud": []interface{}{testAudience, testIssuer + "userinfo"}}
+// A refused request answers 401, whichever way it was refused.
+//
+// This is a guard against a regression the go-jwt-middleware v2 upgrade would
+// otherwise have shipped silently. v1 answered 401 for a missing token; v2's
+// DefaultErrorHandler answers *400* for one, reserving 401 for a token that is
+// present but invalid. Every unauthenticated request to this API would have
+// changed status code, which is a contract change nothing asked for - so
+// app.go passes WithErrorHandler(authErrorHandler) to keep 401.
+//
+// Both cases matter: the missing-token one is what the override exists for, and
+// the unconfigured one is the fail-closed path for a deploy with no Auth0
+// environment, which `go run . openapi` also travels.
+func TestRefusalsAnswer401(t *testing.T) {
+	t.Run("when the token is missing", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		newRouter(t, "").ServeHTTP(rec, httptest.NewRequest(http.MethodGet, testBase+"/shopping-list", nil))
 
-		if err := normalizeAudience(claims); err != nil {
-			t.Fatalf("normalizeAudience() error = %v", err)
-		}
-
-		got, ok := claims["aud"].([]string)
-		if !ok {
-			t.Fatalf("aud is %T, want []string", claims["aud"])
-		}
-		if len(got) != 2 || got[0] != testAudience {
-			t.Errorf("aud = %v", got)
-		}
-	})
-
-	t.Run("leaves a bare string audience alone", func(t *testing.T) {
-		claims := jwt.MapClaims{"aud": testAudience}
-
-		if err := normalizeAudience(claims); err != nil {
-			t.Fatalf("normalizeAudience() error = %v", err)
-		}
-		if claims["aud"] != testAudience {
-			t.Errorf("aud = %v, want it untouched", claims["aud"])
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401 (v2's default for a missing token is 400)", rec.Code)
 		}
 	})
 
-	// Both of these panicked before, taking the request down with no response
-	// rather than refusing it - there is no Recovery middleware in the stack.
-	t.Run("rejects a token carrying no audience", func(t *testing.T) {
-		if err := normalizeAudience(jwt.MapClaims{"iss": testIssuer}); err == nil {
-			t.Error("normalizeAudience() = nil, want an error")
+	t.Run("when auth is not configured at all", func(t *testing.T) {
+		t.Setenv("DISABLE_AUTH", "")
+		t.Setenv("AUTH0_DOMAIN", "")
+		t.Setenv("AUTH0_AUDIENCE", "")
+
+		application, err := NewApp(&common.Env{})
+		if err != nil {
+			t.Fatalf("NewApp() error = %v", err)
 		}
-	})
-
-	t.Run("rejects a non-string value in the audience array", func(t *testing.T) {
-		claims := jwt.MapClaims{"aud": []interface{}{testAudience, 42}}
-
-		if err := normalizeAudience(claims); err == nil {
-			t.Error("normalizeAudience() = nil, want an error")
-		}
-	})
-}
-
-// Guards the `true` (required) argument in GetRouter's VerifyAudience and
-// VerifyIssuer calls. Every case here verified successfully under the `false`
-// this replaced, which meant any token the Auth0 tenant's key had signed was
-// accepted regardless of what it was minted for.
-func TestRequiredClaims(t *testing.T) {
-	t.Run("an empty audience array does not satisfy the audience", func(t *testing.T) {
-		claims := jwt.MapClaims{"aud": []interface{}{}, "iss": testIssuer}
-		if err := normalizeAudience(claims); err != nil {
-			t.Fatalf("normalizeAudience() error = %v", err)
+		// Must still build - `go run . openapi` builds this router with no
+		// Auth0 environment, and a CI job diffs its output.
+		router, _, err := application.GetRouter(testBase)
+		if err != nil {
+			t.Fatalf("GetRouter() error = %v", err)
 		}
 
-		if claims.VerifyAudience(testAudience, true) {
-			t.Error("VerifyAudience() = true for an empty aud")
-		}
-	})
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, testBase+"/shopping-list", nil))
 
-	t.Run("a token minted for another audience does not verify", func(t *testing.T) {
-		claims := jwt.MapClaims{"aud": []interface{}{"https://other-api.test"}, "iss": testIssuer}
-		if err := normalizeAudience(claims); err != nil {
-			t.Fatalf("normalizeAudience() error = %v", err)
-		}
-
-		if claims.VerifyAudience(testAudience, true) {
-			t.Error("VerifyAudience() = true for another audience")
-		}
-	})
-
-	t.Run("a token carrying no issuer does not verify", func(t *testing.T) {
-		claims := jwt.MapClaims{"aud": []string{testAudience}}
-
-		if claims.VerifyIssuer(testIssuer, true) {
-			t.Error("VerifyIssuer() = true for a missing iss")
-		}
-	})
-
-	// The shape Auth0 actually issues: an array holding this API's audience
-	// alongside the tenant's /userinfo endpoint.
-	t.Run("a genuine access token still verifies", func(t *testing.T) {
-		claims := jwt.MapClaims{
-			"aud": []interface{}{testAudience, testIssuer + "userinfo"},
-			"iss": testIssuer,
-		}
-		if err := normalizeAudience(claims); err != nil {
-			t.Fatalf("normalizeAudience() error = %v", err)
-		}
-
-		if !claims.VerifyAudience(testAudience, true) {
-			t.Error("VerifyAudience() = false for a genuine token")
-		}
-		if !claims.VerifyIssuer(testIssuer, true) {
-			t.Error("VerifyIssuer() = false for a genuine token")
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401 - an unconfigured API must refuse, not serve", rec.Code)
 		}
 	})
 }
@@ -134,6 +79,13 @@ const testBase = "/api/bigshop"
 func newRouter(t *testing.T, disableAuth string) http.Handler {
 	t.Helper()
 	t.Setenv("DISABLE_AUTH", disableAuth)
+	// Both are required for the JWT middleware to be built at all - without
+	// them GetRouter installs the refuse-everything handler instead, and a test
+	// asserting a 401 would pass without the middleware under test ever
+	// running. The domain cannot resolve, which is fine: every assertion here
+	// is about a request that is refused before any key lookup happens.
+	t.Setenv("AUTH0_DOMAIN", "tenant.invalid")
+	t.Setenv("AUTH0_AUDIENCE", testAudience)
 	application, err := NewApp(&common.Env{})
 	if err != nil {
 		t.Fatalf("NewApp() error = %v", err)
@@ -439,20 +391,32 @@ func TestKeyLookupFailureIsRefusedNotPanicked(t *testing.T) {
 	// Signed with a throwaway key, so the signature is valid RS256 and parsing
 	// gets as far as the key lookup. Which key signed it is irrelevant - the
 	// lookup fails before anything is verified against it.
+	//
+	// Minted with go-jose because that is what go-jwt-middleware v2 brings;
+	// this was form3tech-oss/jwt-go until that dependency was retired with v1.
+	// Only the construction changed - every assertion below is the original.
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
-		"iss": "https://tenant.invalid/",
-		"aud": []string{testAudience},
-		"sub": "auth0|unknown-kid",
-		"exp": time.Now().Add(time.Hour).Unix(),
-	})
-	token.Header["kid"] = "no-such-key"
-	signed, err := token.SignedString(key)
+	// The `kid` rides on the signing key rather than being set as a raw header,
+	// which is what puts "no-such-key" in the JOSE header and so is the whole
+	// point of the fixture.
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: jose.JSONWebKey{Key: key, KeyID: "no-such-key"}},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
 	if err != nil {
-		t.Fatalf("SignedString() error = %v", err)
+		t.Fatalf("NewSigner() error = %v", err)
+	}
+	signed, err := josejwt.Signed(signer).Claims(josejwt.Claims{
+		Issuer:   "https://tenant.invalid/",
+		Audience: josejwt.Audience{testAudience},
+		Subject:  "auth0|unknown-kid",
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}).CompactSerialize()
+	if err != nil {
+		t.Fatalf("CompactSerialize() error = %v", err)
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/bigshop/shopping-list", nil)

--- a/netlify-functions/recipes/internal/pkg/app/invites.go
+++ b/netlify-functions/recipes/internal/pkg/app/invites.go
@@ -22,7 +22,7 @@ type InvitesOutput struct {
 }
 
 func (a *App) acceptInvite(ctx context.Context, input *InviteTokenInput) (*struct{}, error) {
-	currentUser, err := service.GetUser(ctx, a.db, ctx.Value(contextKey("userID")).(string))
+	currentUser, err := service.GetUser(ctx, a.db, callerFrom(ctx).UserID)
 	if err != nil {
 		return nil, fail(ctx, huma.Error400BadRequest("Error finding current user"), err)
 	}
@@ -51,7 +51,7 @@ func (a *App) acceptInvite(ctx context.Context, input *InviteTokenInput) (*struc
 }
 
 func (a *App) getInvites(ctx context.Context, _ *struct{}) (*InvitesOutput, error) {
-	user, err := service.GetUser(ctx, a.db, ctx.Value(contextKey("userID")).(string))
+	user, err := service.GetUser(ctx, a.db, callerFrom(ctx).UserID)
 	if err != nil {
 		return nil, fail(ctx, huma.Error500InternalServerError("Error finding current user"), err)
 	}

--- a/netlify-functions/recipes/internal/pkg/app/list.go
+++ b/netlify-functions/recipes/internal/pkg/app/list.go
@@ -40,9 +40,9 @@ type ShoppingListHistoryOutput struct {
 }
 
 func (a *App) getList(ctx context.Context, _ *struct{}) (*ShoppingListOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 
-	list, err := service.GetShoppingList(ctx, userID, a.db)
+	list, err := service.GetShoppingList(ctx, caller, a.db)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Error Fetching Shopping List")
 	}
@@ -51,10 +51,10 @@ func (a *App) getList(ctx context.Context, _ *struct{}) (*ShoppingListOutput, er
 }
 
 func (a *App) createList(ctx context.Context, input *CreateListInput) (*ShoppingListOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 	recipeIDs := input.Body
 
-	list, err := service.GenerateShoppingList(ctx, recipeIDs, userID, a.db)
+	list, err := service.GenerateShoppingList(ctx, recipeIDs, caller, a.db)
 
 	if err != nil {
 		if err == service.ErrInvalidRecipeID {
@@ -67,14 +67,14 @@ func (a *App) createList(ctx context.Context, input *CreateListInput) (*Shopping
 }
 
 func (a *App) addExtraListItem(ctx context.Context, input *ListItemInput) (*StatusOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 	extraItem := input.Body
 
 	if extraItem.Name == "" {
 		return nil, huma.Error400BadRequest("Missing item name")
 	}
 
-	if err := service.AddExtraListItem(ctx, userID, extraItem.Name, extraItem.IsBought, a.db); err != nil {
+	if err := service.AddExtraListItem(ctx, caller, extraItem.Name, extraItem.IsBought, a.db); err != nil {
 		return nil, huma.Error500InternalServerError("Cannot add list items")
 	}
 
@@ -82,18 +82,18 @@ func (a *App) addExtraListItem(ctx context.Context, input *ListItemInput) (*Stat
 }
 
 func (a *App) buyListItem(ctx context.Context, input *ListItemInput) (*ShoppingListOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 	listItem := input.Body
 
 	if listItem.Name == "" {
 		return nil, huma.Error400BadRequest("Missing item name")
 	}
 
-	if err := service.BuyListItem(ctx, userID, listItem.Name, listItem.IsBought, a.db); err != nil {
+	if err := service.BuyListItem(ctx, caller, listItem.Name, listItem.IsBought, a.db); err != nil {
 		return nil, huma.Error500InternalServerError("Error marking item as bought")
 	}
 
-	list, err := service.GetShoppingList(ctx, userID, a.db)
+	list, err := service.GetShoppingList(ctx, caller, a.db)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Error getting shopping list")
 	}
@@ -102,14 +102,14 @@ func (a *App) buyListItem(ctx context.Context, input *ListItemInput) (*ShoppingL
 }
 
 func (a *App) clearList(ctx context.Context, _ *struct{}) (*ShoppingListOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 
-	if err := service.RemoveAllListItems(ctx, userID, a.db); err != nil {
+	if err := service.RemoveAllListItems(ctx, caller, a.db); err != nil {
 		return nil, huma.Error500InternalServerError("Error removing list items")
 	}
 
 	// Log clear event for meal planning intelligence
-	if logErr := service.LogShoppingListClearEvent(ctx, userID, a.db); logErr != nil {
+	if logErr := service.LogShoppingListClearEvent(ctx, caller, a.db); logErr != nil {
 		// Recorded, not returned: clearing the list succeeded, and failing the
 		// request because its history row did not get written would be worse
 		// than losing the row.
@@ -120,14 +120,14 @@ func (a *App) clearList(ctx context.Context, _ *struct{}) (*ShoppingListOutput, 
 }
 
 func (a *App) getShoppingListHistory(ctx context.Context, _ *struct{}) (*ShoppingListHistoryOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 
-	recentRecipes, err := service.GetRecentRecipeUsage(ctx, userID, 30, 10, a.db)
+	recentRecipes, err := service.GetRecentRecipeUsage(ctx, caller, 30, 10, a.db)
 	if err != nil {
 		return nil, fail(ctx, huma.Error500InternalServerError("Error getting recent recipes"), err)
 	}
 
-	favoriteRecipes, err := service.GetFavoriteRecipes(ctx, userID, 10, a.db)
+	favoriteRecipes, err := service.GetFavoriteRecipes(ctx, caller, 10, a.db)
 	if err != nil {
 		return nil, fail(ctx, huma.Error500InternalServerError("Error getting favorite recipes"), err)
 	}

--- a/netlify-functions/recipes/internal/pkg/app/recipe.go
+++ b/netlify-functions/recipes/internal/pkg/app/recipe.go
@@ -52,14 +52,14 @@ type AddRecipeOutput struct {
 }
 
 func (a *App) getRecipe(ctx context.Context, input *RecipeByIDInput) (*RecipeOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 
 	var recipe *common.Recipe
 	var err error
 	if id, convErr := strconv.Atoi(input.ID); convErr == nil {
-		recipe, err = service.GetRecipeByID(ctx, id, userID, a.db)
+		recipe, err = service.GetRecipeByID(ctx, id, caller, a.db)
 	} else {
-		recipe, err = service.GetRecipeBySlug(ctx, input.ID, userID, a.db)
+		recipe, err = service.GetRecipeBySlug(ctx, input.ID, caller, a.db)
 	}
 
 	if err != nil {
@@ -76,9 +76,9 @@ func (a *App) getRecipe(ctx context.Context, input *RecipeByIDInput) (*RecipeOut
 }
 
 func (a *App) addRecipe(ctx context.Context, input *RecipeInput) (*AddRecipeOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 
-	id, err := service.AddRecipe(ctx, input.Body, userID, a.db)
+	id, err := service.AddRecipe(ctx, input.Body, caller, a.db)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("could not insert ingredients")
 	}
@@ -89,13 +89,13 @@ func (a *App) addRecipe(ctx context.Context, input *RecipeInput) (*AddRecipeOutp
 }
 
 func (a *App) editRecipe(ctx context.Context, input *RecipeInput) (*StatusOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 
 	if input.Body.ID == 0 {
 		return nil, huma.Error400BadRequest("Error: missing id")
 	}
 
-	if err := service.EditRecipe(ctx, input.Body, userID, a.db); err != nil {
+	if err := service.EditRecipe(ctx, input.Body, caller, a.db); err != nil {
 		return nil, huma.Error500InternalServerError("could not update recipe")
 	}
 
@@ -122,13 +122,13 @@ func (a *App) purgeUnitsCache() {
 }
 
 func (a *App) deleteRecipe(ctx context.Context, input *DeleteRecipeInput) (*StatusOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 
 	if input.Body.ID == 0 {
 		return nil, huma.Error400BadRequest("Error: missing id")
 	}
 
-	if err := service.DeleteRecipe(ctx, common.Recipe{ID: input.Body.ID}, userID, a.db); err != nil {
+	if err := service.DeleteRecipe(ctx, common.Recipe{ID: input.Body.ID}, caller, a.db); err != nil {
 		return nil, huma.Error500InternalServerError("could not delete recipe")
 	}
 

--- a/netlify-functions/recipes/internal/pkg/app/recipes.go
+++ b/netlify-functions/recipes/internal/pkg/app/recipes.go
@@ -21,8 +21,8 @@ type RecipesOutput struct {
 }
 
 func (a *App) getRecipes(ctx context.Context, _ *struct{}) (*RecipesOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
-	recipes, err := service.GetAllRecipes(ctx, a.db, userID)
+	caller := callerFrom(ctx)
+	recipes, err := service.GetAllRecipes(ctx, a.db, caller)
 
 	if err != nil {
 		return nil, fail(ctx, huma.Error500InternalServerError("Failed to get recipes from db"), err)

--- a/netlify-functions/recipes/internal/pkg/app/user.go
+++ b/netlify-functions/recipes/internal/pkg/app/user.go
@@ -25,7 +25,7 @@ type UserOutput struct {
 
 func (a *App) addUser(ctx context.Context, input *UserInput) (*UserOutput, error) {
 	user := input.Body
-	user.ID = ctx.Value(contextKey("userID")).(string)
+	user.ID = callerFrom(ctx).UserID
 
 	if err := service.AddUser(ctx, a.db, user); err != nil {
 		return nil, fail(ctx, huma.Error500InternalServerError("could not add new user"), err)
@@ -61,9 +61,9 @@ type PreferencesInput struct {
 // /user on the landing page, which left no way for any other page to read user
 // state at all.
 func (a *App) getUser(ctx context.Context, _ *struct{}) (*UserOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 
-	user, err := service.GetUser(ctx, a.db, userID)
+	user, err := service.GetUser(ctx, a.db, caller.UserID)
 	if err != nil {
 		// Also the no-rows case: someone who reached an inner page before POST
 		// /user ever ran for them. Not a server fault, and the client treats it
@@ -75,13 +75,13 @@ func (a *App) getUser(ctx context.Context, _ *struct{}) (*UserOutput, error) {
 }
 
 func (a *App) setPreferences(ctx context.Context, input *PreferencesInput) (*UserOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 
-	if err := service.SetShowPantryStaples(ctx, a.db, userID, input.Body.ShowPantryStaples); err != nil {
+	if err := service.SetShowPantryStaples(ctx, a.db, caller.UserID, input.Body.ShowPantryStaples); err != nil {
 		return nil, fail(ctx, huma.Error500InternalServerError("could not save preferences"), err)
 	}
 
-	saved, err := service.GetUser(ctx, a.db, userID)
+	saved, err := service.GetUser(ctx, a.db, caller.UserID)
 	if err != nil {
 		return nil, fail(ctx, huma.Error500InternalServerError("Error fetching saved user"), err)
 	}
@@ -90,13 +90,13 @@ func (a *App) setPreferences(ctx context.Context, input *PreferencesInput) (*Use
 }
 
 func (a *App) completeOnboarding(ctx context.Context, _ *struct{}) (*UserOutput, error) {
-	userID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 
-	if err := service.SetOnboarded(ctx, a.db, userID); err != nil {
+	if err := service.SetOnboarded(ctx, a.db, caller.UserID); err != nil {
 		return nil, fail(ctx, huma.Error500InternalServerError("could not complete onboarding"), err)
 	}
 
-	saved, err := service.GetUser(ctx, a.db, userID)
+	saved, err := service.GetUser(ctx, a.db, caller.UserID)
 	if err != nil {
 		return nil, fail(ctx, huma.Error500InternalServerError("Error fetching saved user"), err)
 	}
@@ -105,22 +105,22 @@ func (a *App) completeOnboarding(ctx context.Context, _ *struct{}) (*UserOutput,
 }
 
 func (a *App) inviteUser(ctx context.Context, input *UserInput) (*struct{}, error) {
-	currentUserID := ctx.Value(contextKey("userID")).(string)
+	caller := callerFrom(ctx)
 	userToInvite := input.Body
 
-	currentUser, err := service.GetUser(ctx, a.db, currentUserID)
+	currentUser, err := service.GetUser(ctx, a.db, caller.UserID)
 	if err != nil {
 		return nil, fail(ctx, huma.Error400BadRequest("Error finding current user"), err)
 	}
 
-	account, err := service.GetAccount(ctx, a.db, currentUserID)
+	account, err := service.GetAccount(ctx, a.db, caller)
 	if err != nil {
 		return nil, fail(ctx, huma.Error400BadRequest("Error finding account for current user"), err)
 	}
 
 	// Generate a token and write it to the invites table
 	token, _ := common.RandToken(32)
-	if err := service.CreateInvite(ctx, a.db, token, account.ID, userToInvite.Email, currentUserID); err != nil {
+	if err := service.CreateInvite(ctx, a.db, token, account.ID, userToInvite.Email, caller.UserID); err != nil {
 		return nil, fail(ctx, huma.Error500InternalServerError("Error creating Invite"), err)
 	}
 

--- a/netlify-functions/recipes/internal/pkg/common/caller.go
+++ b/netlify-functions/recipes/internal/pkg/common/caller.go
@@ -1,0 +1,65 @@
+package common
+
+import "sync"
+
+// Caller is who is making the current request: their user ID, and their
+// Account resolved at most once for the lifetime of that request.
+//
+// It exists because every service function used to be independently
+// responsible for answering "who is this". Twenty-one of them took a
+// `userID string` and immediately looked the Account up for themselves, so a
+// single POST /shopping-list resolved the same Account from the same user ID
+// to the same answer **nine times** - each one a query, and each query two
+// blocking round trips before Phase 2. Nobody noticed precisely because the
+// knowledge was spread across twenty-one functions rather than held in one
+// place.
+//
+// Resolution is *lazy*, which is the whole design and not an optimisation
+// detail. Resolving eagerly in the auth middleware and putting the ID in the
+// context would be simpler, and would make five routes slower: GET /tags,
+// /units, /ingredients, /user and /invites make zero account lookups today,
+// and eager resolution adds one to each. Lazily, zero stays zero and nine
+// becomes one.
+//
+// A Caller belongs to one request and must not be shared between them - the
+// memoised Account is only correct for the user it was built for.
+type Caller struct {
+	// UserID is the authenticated subject, as it appears in account_user.
+	UserID string
+
+	resolve   func() (int, error)
+	once      sync.Once
+	accountID int
+	err       error
+}
+
+// NewCaller builds a Caller for one request.
+//
+// The Account lookup arrives as a function rather than a database handle so
+// that this package does not depend on `service`, which depends on this one.
+// It also keeps the query itself in exactly one place: service.GetAccountID,
+// whose only caller this becomes.
+func NewCaller(userID string, resolve func() (int, error)) *Caller {
+	return &Caller{UserID: userID, resolve: resolve}
+}
+
+// AccountID returns the Account this Caller belongs to, resolving it on first
+// use and returning the same answer - including the same error - to every
+// later call within the request.
+//
+// The error is memoised as deliberately as the value. A user with no
+// account_user row surfaces sql.ErrNoRows here, which handlers turn into a
+// 500, and that behaviour is unchanged from when each service function asked
+// for itself. It matters for POST /user, which is reachable by a genuinely new
+// user who has no Account yet.
+//
+// One caveat, currently unexercised: memoisation means a request that *moves*
+// the caller between Accounts cannot read the new one back through here.
+// PATCH /invite is the only such request, and it carries the invite's account
+// ID explicitly rather than asking - keep it that way.
+func (c *Caller) AccountID() (int, error) {
+	c.once.Do(func() {
+		c.accountID, c.err = c.resolve()
+	})
+	return c.accountID, c.err
+}

--- a/netlify-functions/recipes/internal/pkg/common/caller_test.go
+++ b/netlify-functions/recipes/internal/pkg/common/caller_test.go
@@ -1,0 +1,104 @@
+package common
+
+import (
+	"database/sql"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// The point of the type: nine lookups become one.
+func TestAccountIDResolvesOnce(t *testing.T) {
+	calls := 0
+	caller := NewCaller("auth0|someone", func() (int, error) {
+		calls++
+		return 42, nil
+	})
+
+	for i := 0; i < 9; i++ {
+		id, err := caller.AccountID()
+		if err != nil {
+			t.Fatalf("AccountID() error = %v", err)
+		}
+		if id != 42 {
+			t.Errorf("AccountID() = %d, want 42", id)
+		}
+	}
+
+	if calls != 1 {
+		t.Errorf("resolved %d times, want 1", calls)
+	}
+}
+
+// Nothing resolves an Account until something asks for one. This is what keeps
+// GET /tags, /units, /ingredients, /user and /invites at zero account lookups -
+// resolving eagerly in middleware would add a query to all five.
+func TestAccountIDIsNotResolvedUntilAsked(t *testing.T) {
+	calls := 0
+	caller := NewCaller("auth0|someone", func() (int, error) {
+		calls++
+		return 42, nil
+	})
+
+	if caller.UserID != "auth0|someone" {
+		t.Errorf("UserID = %q", caller.UserID)
+	}
+	if calls != 0 {
+		t.Errorf("resolved %d times before being asked, want 0", calls)
+	}
+}
+
+// The error is memoised as deliberately as the value, and it is returned
+// unwrapped: a user with no account_user row surfaces sql.ErrNoRows, which is
+// what handlers have always turned into a 500. Resolving lazily must not
+// change that.
+func TestAccountIDMemoisesTheError(t *testing.T) {
+	calls := 0
+	caller := NewCaller("auth0|nobody", func() (int, error) {
+		calls++
+		return 0, sql.ErrNoRows
+	})
+
+	for i := 0; i < 3; i++ {
+		id, err := caller.AccountID()
+		if !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("AccountID() error = %v, want sql.ErrNoRows", err)
+		}
+		if id != 0 {
+			t.Errorf("AccountID() = %d, want 0 alongside an error", id)
+		}
+	}
+
+	if calls != 1 {
+		t.Errorf("resolved %d times, want 1 - a failure must not be retried per call", calls)
+	}
+}
+
+// A Caller belongs to one request, but a single request can fan out (Phase 6b
+// intends exactly that), so concurrent first-use must still resolve once.
+func TestAccountIDIsSafeUnderConcurrentFirstUse(t *testing.T) {
+	var mu sync.Mutex
+	calls := 0
+	caller := NewCaller("auth0|someone", func() (int, error) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return 7, nil
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if id, err := caller.AccountID(); id != 7 || err != nil {
+				t.Errorf("AccountID() = %d, %v", id, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if calls != 1 {
+		t.Errorf("resolved %d times under concurrency, want 1", calls)
+	}
+}

--- a/netlify-functions/recipes/internal/pkg/service/account.go
+++ b/netlify-functions/recipes/internal/pkg/service/account.go
@@ -42,8 +42,8 @@ func GetAccountID(ctx context.Context, db dbConn, userID string) (int, error) {
 	return accountID, nil
 }
 
-func GetAccount(ctx context.Context, db *sql.DB, userID string) (a *common.Account, e error) {
-	accountID, err := GetAccountID(ctx, db, userID)
+func GetAccount(ctx context.Context, db *sql.DB, caller *common.Caller) (a *common.Account, e error) {
+	accountID, err := caller.AccountID()
 
 	if err != nil {
 		return nil, fmt.Errorf("resolving account: %w", err)

--- a/netlify-functions/recipes/internal/pkg/service/history.go
+++ b/netlify-functions/recipes/internal/pkg/service/history.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
+	"recipes/internal/pkg/common"
 )
 
 // LogShoppingListEvent logs shopping list changes for meal planning intelligence
-func LogShoppingListEvent(ctx context.Context, userID string, eventType string, recipeIDs []int, db *sql.DB) error {
-	accountID, err := GetAccountID(ctx, db, userID)
+func LogShoppingListEvent(ctx context.Context, caller *common.Caller, eventType string, recipeIDs []int, db *sql.DB) error {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return fmt.Errorf("could not get account ID: %w", err)
 	}
@@ -28,8 +30,8 @@ func LogShoppingListEvent(ctx context.Context, userID string, eventType string, 
 }
 
 // LogShoppingListClearEvent logs when user clears the shopping list
-func LogShoppingListClearEvent(ctx context.Context, userID string, db *sql.DB) error {
-	accountID, err := GetAccountID(ctx, db, userID)
+func LogShoppingListClearEvent(ctx context.Context, caller *common.Caller, db *sql.DB) error {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return fmt.Errorf("could not get account ID: %w", err)
 	}
@@ -47,8 +49,8 @@ func LogShoppingListClearEvent(ctx context.Context, userID string, db *sql.DB) e
 
 // GetRecentRecipeUsage returns recently used recipes for meal planning
 // Groups by date to avoid counting bulk shopping list updates as multiple uses
-func GetRecentRecipeUsage(ctx context.Context, userID string, daysBack int, limit int, db *sql.DB) ([]int, error) {
-	accountID, err := GetAccountID(ctx, db, userID)
+func GetRecentRecipeUsage(ctx context.Context, caller *common.Caller, daysBack int, limit int, db *sql.DB) ([]int, error) {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return nil, fmt.Errorf("could not get account ID: %w", err)
 	}
@@ -90,8 +92,8 @@ func GetRecentRecipeUsage(ctx context.Context, userID string, daysBack int, limi
 
 // GetFavoriteRecipes returns most frequently used recipes
 // Groups by date to avoid counting bulk shopping list updates as multiple uses
-func GetFavoriteRecipes(ctx context.Context, userID string, limit int, db *sql.DB) ([]int, error) {
-	accountID, err := GetAccountID(ctx, db, userID)
+func GetFavoriteRecipes(ctx context.Context, caller *common.Caller, limit int, db *sql.DB) ([]int, error) {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return nil, fmt.Errorf("could not get account ID: %w", err)
 	}

--- a/netlify-functions/recipes/internal/pkg/service/list.go
+++ b/netlify-functions/recipes/internal/pkg/service/list.go
@@ -537,6 +537,17 @@ func GenerateShoppingList(ctx context.Context, recipeIDs []string, caller *commo
 		}
 	}
 
+	// The Caller is already resolved by this point - GetRecipeByID and
+	// GetIngredientListItems above both asked for the Account - so the calls
+	// inside the transaction read a memoised value and issue no query at all.
+	// That is better than it was, where each one re-resolved the Account on the
+	// transaction's own connection.
+	//
+	// Worth keeping that way. The Caller resolves against the pool, not this
+	// tx, so a reordering that made the transaction the *first* thing to ask
+	// would have it take a second connection while this one is held. Nothing
+	// here writes account_user, so it would still be correct - just needlessly
+	// wide at exactly the moment a connection is scarcest.
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, err

--- a/netlify-functions/recipes/internal/pkg/service/list.go
+++ b/netlify-functions/recipes/internal/pkg/service/list.go
@@ -501,21 +501,21 @@ func roundToSignificantFigures(v float64, digits int) float64 {
 // are untouched either way (see CONTEXT.md's "Generate Shopping List"). An Ingredient
 // Item already marked bought carries that state forward if it's still present in the
 // recomputed set, so regenerating the list doesn't silently un-buy things.
-func GenerateShoppingList(ctx context.Context, recipeIDs []string, userID string, db *sql.DB) (*common.ShoppingList, error) {
+func GenerateShoppingList(ctx context.Context, recipeIDs []string, caller *common.Caller, db *sql.DB) (*common.ShoppingList, error) {
 	recipes := make([]common.Recipe, 0)
 	for _, idStr := range recipeIDs {
 		id, err := strconv.Atoi(idStr)
 		if err != nil {
 			return nil, ErrInvalidRecipeID
 		}
-		recipe, err := GetRecipeByID(ctx, id, userID, db)
+		recipe, err := GetRecipeByID(ctx, id, caller, db)
 		if err != nil {
 			return nil, err
 		}
 		recipes = append(recipes, *recipe)
 	}
 
-	previousIngredients, err := GetIngredientListItems(ctx, userID, db)
+	previousIngredients, err := GetIngredientListItems(ctx, caller, db)
 	if err != nil {
 		return nil, err
 	}
@@ -543,11 +543,11 @@ func GenerateShoppingList(ctx context.Context, recipeIDs []string, userID string
 	}
 	defer tx.Rollback()
 
-	if err := RemoveIngredientListItems(ctx, userID, tx); err != nil {
+	if err := RemoveIngredientListItems(ctx, caller, tx); err != nil {
 		return nil, err
 	}
 	if len(combinedIngredients) > 0 {
-		if err := AddIngredientListItems(ctx, userID, combinedIngredients, tx); err != nil {
+		if err := AddIngredientListItems(ctx, caller, combinedIngredients, tx); err != nil {
 			return nil, err
 		}
 	}
@@ -558,27 +558,27 @@ func GenerateShoppingList(ctx context.Context, recipeIDs []string, userID string
 	// Log shopping list history for meal planning intelligence, best-effort - a
 	// logging failure shouldn't fail the whole generate operation.
 	if intRecipeIDs, err := GetRecipeIDsFromStrings(recipeIDs); err == nil {
-		if logErr := LogShoppingListEvent(ctx, userID, "add_recipe", intRecipeIDs, db); logErr != nil {
+		if logErr := LogShoppingListEvent(ctx, caller, "add_recipe", intRecipeIDs, db); logErr != nil {
 			telemetry.RecordWarning(ctx, "log shopping list history", logErr)
 		}
 	}
 
-	return GetShoppingList(ctx, userID, db)
+	return GetShoppingList(ctx, caller, db)
 }
 
 // GetShoppingList returns the full shopping list for a user
-func GetShoppingList(ctx context.Context, userID string, db *sql.DB) (*common.ShoppingList, error) {
-	recipes, err := GetRecipesFromList(ctx, userID, db)
+func GetShoppingList(ctx context.Context, caller *common.Caller, db *sql.DB) (*common.ShoppingList, error) {
+	recipes, err := GetRecipesFromList(ctx, caller, db)
 	if err != nil {
 		return nil, fmt.Errorf("get recipes from list: %w", err)
 	}
 
-	ingredients, err := GetIngredientListItems(ctx, userID, db)
+	ingredients, err := GetIngredientListItems(ctx, caller, db)
 	if err != nil {
 		return nil, fmt.Errorf("get ingredients from list: %w", err)
 	}
 
-	extras, err := GetExtraListItems(ctx, userID, db)
+	extras, err := GetExtraListItems(ctx, caller, db)
 	if err != nil {
 		return nil, fmt.Errorf("get extra list items: %w", err)
 	}
@@ -612,8 +612,8 @@ func GetShoppingList(ctx context.Context, userID string, db *sql.DB) (*common.Sh
 }
 
 // RemoveAllListItems removes all list items for a user
-func RemoveAllListItems(ctx context.Context, userID string, db *sql.DB) error {
-	accountID, err := GetAccountID(ctx, db, userID)
+func RemoveAllListItems(ctx context.Context, caller *common.Caller, db *sql.DB) error {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return fmt.Errorf("delete ingredients: %w", err)
 	}
@@ -624,8 +624,8 @@ func RemoveAllListItems(ctx context.Context, userID string, db *sql.DB) error {
 }
 
 // RemoveIngredientListItems removes all ingredient list items
-func RemoveIngredientListItems(ctx context.Context, userID string, db dbConn) error {
-	accountID, err := GetAccountID(ctx, db, userID)
+func RemoveIngredientListItems(ctx context.Context, caller *common.Caller, db dbConn) error {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return fmt.Errorf("delete ingredients: %w", err)
 	}
@@ -636,8 +636,8 @@ func RemoveIngredientListItems(ctx context.Context, userID string, db dbConn) er
 }
 
 // AddIngredientListItems adds passed ingredients to the db
-func AddIngredientListItems(ctx context.Context, userID string, ingredients map[string]*common.ListIngredient, db dbConn) error {
-	accountID, err := GetAccountID(ctx, db, userID)
+func AddIngredientListItems(ctx context.Context, caller *common.Caller, ingredients map[string]*common.ListIngredient, db dbConn) error {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return fmt.Errorf("add ingredients to shopping list: %w", err)
 	}
@@ -670,8 +670,8 @@ func AddIngredientListItems(ctx context.Context, userID string, ingredients map[
 }
 
 // AddExtraListItem inserts an item of type 'extra'
-func AddExtraListItem(ctx context.Context, userID string, name string, isBought bool, db *sql.DB) error {
-	accountID, err := GetAccountID(ctx, db, userID)
+func AddExtraListItem(ctx context.Context, caller *common.Caller, name string, isBought bool, db *sql.DB) error {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return err
 	}
@@ -687,8 +687,8 @@ func AddExtraListItem(ctx context.Context, userID string, name string, isBought 
 }
 
 // GetRecipesFromList returns recipes used to create the shopping list
-func GetRecipesFromList(ctx context.Context, userID string, db *sql.DB) ([]string, error) {
-	accountID, err := GetAccountID(ctx, db, userID)
+func GetRecipesFromList(ctx context.Context, caller *common.Caller, db *sql.DB) ([]string, error) {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return nil, err
 	}
@@ -714,8 +714,8 @@ func GetRecipesFromList(ctx context.Context, userID string, db *sql.DB) ([]strin
 }
 
 // GetIngredientListItems returns items of type 'ingredient'
-func GetIngredientListItems(ctx context.Context, userID string, db *sql.DB) (map[string]*common.ListIngredient, error) {
-	accountID, err := GetAccountID(ctx, db, userID)
+func GetIngredientListItems(ctx context.Context, caller *common.Caller, db *sql.DB) (map[string]*common.ListIngredient, error) {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return nil, err
 	}
@@ -763,8 +763,8 @@ func GetIngredientListItems(ctx context.Context, userID string, db *sql.DB) (map
 }
 
 // GetExtraListItems returns items of type 'extra'
-func GetExtraListItems(ctx context.Context, userID string, db *sql.DB) (map[string]*common.ListIngredient, error) {
-	accountID, err := GetAccountID(ctx, db, userID)
+func GetExtraListItems(ctx context.Context, caller *common.Caller, db *sql.DB) (map[string]*common.ListIngredient, error) {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return nil, err
 	}
@@ -799,8 +799,8 @@ func GetExtraListItems(ctx context.Context, userID string, db *sql.DB) (map[stri
 }
 
 // BuyListItem toggles the isBought state of a list item in the db
-func BuyListItem(ctx context.Context, userID string, name string, isBought bool, db *sql.DB) error {
-	accountID, err := GetAccountID(ctx, db, userID)
+func BuyListItem(ctx context.Context, caller *common.Caller, name string, isBought bool, db *sql.DB) error {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return err
 	}

--- a/netlify-functions/recipes/internal/pkg/service/recipe.go
+++ b/netlify-functions/recipes/internal/pkg/service/recipe.go
@@ -71,8 +71,8 @@ func getIngredientsByRecipeID(ctx context.Context, id int, db *sql.DB) ([]common
 }
 
 // GetRecipeBySlug fetches a recipe from the database by Slug
-func GetRecipeBySlug(ctx context.Context, slug string, userID string, db *sql.DB) (*common.Recipe, error) {
-	accountID, err := GetAccountID(ctx, db, userID)
+func GetRecipeBySlug(ctx context.Context, slug string, caller *common.Caller, db *sql.DB) (*common.Recipe, error) {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return nil, err
 	}
@@ -140,8 +140,8 @@ func GetRecipeBySlug(ctx context.Context, slug string, userID string, db *sql.DB
 }
 
 // GetRecipeByID fetches a recipe from the database by ID
-func GetRecipeByID(ctx context.Context, id int, userID string, db *sql.DB) (*common.Recipe, error) {
-	accountID, err := GetAccountID(ctx, db, userID)
+func GetRecipeByID(ctx context.Context, id int, caller *common.Caller, db *sql.DB) (*common.Recipe, error) {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return nil, fmt.Errorf("resolving account: %w", err)
 	}
@@ -214,10 +214,10 @@ func GetRecipeByID(ctx context.Context, id int, userID string, db *sql.DB) (*com
 // through (e.g. a bad unit) doesn't leave an orphaned recipe with no Ingredient Lines.
 // Returns the new recipe's ID so the caller can hand it back to the client
 // (e.g. for a post-create redirect) without a follow-up lookup.
-func AddRecipe(ctx context.Context, recipe common.Recipe, userID string, db *sql.DB) (int, error) {
+func AddRecipe(ctx context.Context, recipe common.Recipe, caller *common.Caller, db *sql.DB) (int, error) {
 	recipe = withCanonicalUnits(recipe)
 
-	accountID, err := GetAccountID(ctx, db, userID)
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return 0, err
 	}
@@ -264,10 +264,10 @@ func AddRecipe(ctx context.Context, recipe common.Recipe, userID string, db *sql
 // writes then happen in one transaction, so a failure partway through (e.g. between
 // deleting and reinserting the recipe's Ingredient Lines) doesn't leave the recipe with
 // no Ingredient Lines.
-func EditRecipe(ctx context.Context, recipe common.Recipe, userID string, db *sql.DB) error {
+func EditRecipe(ctx context.Context, recipe common.Recipe, caller *common.Caller, db *sql.DB) error {
 	recipe = withCanonicalUnits(recipe)
 
-	accountID, err := GetAccountID(ctx, db, userID)
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return fmt.Errorf("resolving account: %w", err)
 	}
@@ -318,8 +318,8 @@ func EditRecipe(ctx context.Context, recipe common.Recipe, userID string, db *sq
 }
 
 // DeleteRecipe removes a recipe from the db
-func DeleteRecipe(ctx context.Context, recipe common.Recipe, userID string, db *sql.DB) error {
-	accountID, err := GetAccountID(ctx, db, userID)
+func DeleteRecipe(ctx context.Context, recipe common.Recipe, caller *common.Caller, db *sql.DB) error {
+	accountID, err := caller.AccountID()
 	if err != nil {
 		return fmt.Errorf("resolving account: %w", err)
 	}

--- a/netlify-functions/recipes/internal/pkg/service/recipes.go
+++ b/netlify-functions/recipes/internal/pkg/service/recipes.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"recipes/internal/pkg/common"
 	"recipes/internal/pkg/telemetry"
 )
 
@@ -21,8 +22,12 @@ type Recipe struct {
 // otelsql emits a span only for a call whose context already carries one (see
 // main.go's SpanFilter). Every function in this package now does the same; this
 // one was simply first.
-func GetAllRecipes(ctx context.Context, db *sql.DB, userID string) ([]Recipe, error) {
-	accountID, err := GetAccountID(ctx, db, userID)
+//
+// The Account behind caller.AccountID() is resolved at most once per request,
+// against the request's own context - so it still raises a span, but one per
+// request rather than one per service call, which is the point.
+func GetAllRecipes(ctx context.Context, db *sql.DB, caller *common.Caller) ([]Recipe, error) {
+	accountID, err := caller.AccountID()
 
 	if err != nil {
 		return nil, fmt.Errorf("getting account ID: %w", err)

--- a/specs/request-model-optimisations.md
+++ b/specs/request-model-optimisations.md
@@ -76,6 +76,13 @@ bumping Go everywhere first — which is a reasonable thing to want (it would al
 Huma from v2.35.0, pinned for the same reason) but it is a different piece of work and
 must not be smuggled in here.
 
+> **This constraint has since lifted.** The observability work (#91) moved the repo to
+> **Go 1.25**, so v2.3.1 and v3 are both reachable now, as are Huma past v2.35.0 and
+> `go-sql-driver/mysql` v1.10.0 (Phase 2's amendment 3 pinned v1.9.3 for exactly the same
+> reason). The pins this spec shipped are therefore conservative rather than forced, and
+> nothing depends on them. Taking newer versions is still its own piece of work — the point
+> stands that it should not ride along inside something else.
+
 The upgrade also retires two unmaintained dependencies: `go-jwt-middleware` v1.0.0 and
 `form3tech-oss/jwt-go` (a fork of the abandoned `dgrijalva/jwt-go`).
 

--- a/specs/request-model-optimisations.md
+++ b/specs/request-model-optimisations.md
@@ -76,12 +76,22 @@ bumping Go everywhere first — which is a reasonable thing to want (it would al
 Huma from v2.35.0, pinned for the same reason) but it is a different piece of work and
 must not be smuggled in here.
 
-> **This constraint has since lifted.** The observability work (#91) moved the repo to
-> **Go 1.25**, so v2.3.1 and v3 are both reachable now, as are Huma past v2.35.0 and
-> `go-sql-driver/mysql` v1.10.0 (Phase 2's amendment 3 pinned v1.9.3 for exactly the same
-> reason). The pins this spec shipped are therefore conservative rather than forced, and
-> nothing depends on them. Taking newer versions is still its own piece of work — the point
-> stands that it should not ride along inside something else.
+> **This constraint is gone, and the pins came off with it.** The observability work (#91)
+> moved the repo to **Go 1.25** while this spec was being implemented, which unstuck three
+> pinned dependencies at once. All three were taken:
+>
+> | | was | now |
+> | --- | --- | --- |
+> | `go-jwt-middleware` | v2.3.0 | **v2.3.1** (newest v2) |
+> | `go-sql-driver/mysql` | v1.9.3 | **v1.10.0** (Phase 2, amendment 3) |
+> | `danielgtaylor/huma` | v2.35.0 | **v2.39.1** — no OpenAPI drift, so no `api.d.ts` churn |
+>
+> **`go-jwt-middleware` v3 is deliberately not taken here** — it is a major version and a
+> rewrite of the wiring (options-based constructors returning errors, `go-jose` swapped for
+> `jwx`, claims moved out of `ContextKey{}`), not a version bump. It is **follow-up #57**,
+> which also records the two properties any v3 migration has to re-establish rather than
+> inherit. The original point stands in that direction too: a major upgrade should not ride
+> along inside something else.
 
 The upgrade also retires two unmaintained dependencies: `go-jwt-middleware` v1.0.0 and
 `form3tech-oss/jwt-go` (a fork of the abandoned `dgrijalva/jwt-go`).

--- a/specs/request-model-optimisations.md
+++ b/specs/request-model-optimisations.md
@@ -150,12 +150,11 @@ before Auth0 signs with it, and the exposure is theoretical rather than a live r
 **Decision required from Ian before this is implemented.** Setting `interpolateParams=true`
 on the DSN makes `go-sql-driver` interpolate arguments client-side instead of preparing
 server-side. **Measured: `GET /shopping-list` 15.2 → 9.2 round trips**, and the same ~40%
-comes off every route in the baseline table. One DSN parameter, no code.
+comes off every route in the baseline table. No application code — two DSN parameters and a
+driver bump, for reasons the security review below sets out.
 
-The trade-off is that parameter escaping moves from TiDB into the driver. The driver's
-interpolation is conservative — it refuses on invalid UTF-8 and will not interpolate at all
-under `multiStatements` — but "the database escapes our parameters" is a property to give
-up knowingly or not at all.
+The trade-off is that parameter escaping moves from TiDB into the driver, and
+"the database escapes our parameters" is a property to give up knowingly or not at all.
 
 **If that is not acceptable**, the alternative that keeps server-side prepares is to hold
 `*sql.Stmt` values on the `App` and reuse them, paying the `PREPARE` once per connection
@@ -163,21 +162,125 @@ instead of once per query. Same win, materially more code, and it interacts with
 pool settings because `database/sql` re-prepares a cached `Stmt` on each new connection.
 Ship one or the other, not both.
 
+**Recommendation: take `interpolateParams`.** The escaping is sound for the shape of SQL
+this codebase actually writes (audited below), and the `*sql.Stmt` alternative is a lot of
+code to keep a property most of the MySQL ecosystem already delegates to its driver. But
+take it with the four amendments in the next section, not on the strength of the sentence
+above.
+
+### The security review, done properly
+
+Audited 2026-08-10 against the pinned driver, **`go-sql-driver/mysql v1.5.0`**
+(`netlify-functions/recipes/go.mod:13`), reading that tag's source rather than the current
+docs. An earlier draft of this spec justified the trade-off with two claims about the driver
+that are **false for the version we run**, and they are recorded here so nobody re-derives
+the reassurance from them:
+
+- *"It refuses on invalid UTF-8."* It does not. There is no UTF-8 validation anywhere in
+  v1.5.0's interpolation path; `escapeStringBackslash` iterates bytes.
+- *"It will not interpolate at all under `multiStatements`."* There is no such guard.
+  `Config.normalize()` (`dsn.go:99`) checks unsafe collations and nothing else.
+
+**What actually protects us is the charset guard, and it holds.** `dsn.go:99` refuses to
+build the config when `interpolateParams` is combined with a collation from the
+multibyte-escape-bypass family (`gbk`, `big5`, `sjis`, `cp932`, `gb2312`, `gb18030`). Our
+DSN sets no `collation=`, so v1.5.0 defaults to `utf8mb4_general_ci`, which is safe. The
+failure mode is fail-closed: `sql.Open` errors and the process does not start. Escaping
+covers `\x00 \n \r \x1a ' " \` and switches to quote-doubling when the server advertises
+`NO_BACKSLASH_ESCAPES`.
+
+**The call sites are clean.** Every user value in `internal/pkg/service` is a real
+placeholder. The five `fmt.Sprintf` sites in `recipe.go` (`:391`, `:414`, `:433`, `:463`,
+`:549`) build `(?,?)` lists, not values; the one interpolated *identifier*
+(`setIngredientUnitColumn`, `recipe.go:549`) is a column name chosen from two Go literals
+and is unaffected either way. No `LIKE`/`REGEXP` over user-supplied patterns, no `[]byte`
+arguments, and no static query containing a literal `?` — which matters because the driver
+decides whether to interpolate by counting `?` textually (`strings.Count`), so a `?` inside
+a quoted literal in a query would be substituted into if the arg count happened to match.
+
+So: **no injection exposure.** The four amendments below are what the trade-off actually
+costs.
+
+#### 1. Two DSN parameters must never appear, and only one is enforced
+
+`collation=` set to one of the unsafe six is refused by the driver. `multiStatements` is
+**not** — and it is the parameter that would turn any future escaping defect into stacked
+statements. Neither is in the DSN today. Treat both as invariants of this repo, recorded in
+`technical-architecture.md`'s environment table alongside `interpolateParams` itself.
+
+#### 2. User data and bearer secrets move into query text, which is logged
+
+This is the real consequence and the previous draft did not mention it. Parameterised, an
+invite is sent as `INSERT INTO invite (token, account, email, ...) VALUES (?, ?, ?, ?, ?)`
+with the values on a separate wire path. Interpolated, the literal token and email address
+are *in the statement* (`internal/pkg/service/invite.go:18`, `:64`) — and therefore in
+MySQL's general log, the slow-query log, TiDB Cloud's slow-query UI, and any driver error
+text that reaches our own 25-odd `log.Printf` sites in the service layer. **An invite token
+is a bearer capability**: whoever reads a slow-query log can join an account. Recipe content
+and user emails take the same path.
+
+Accepted, not ignored: TiDB only captures statements past the slow-query threshold, so this
+is an exposure of the slow tail rather than of every request. Note it, and do not add
+statement-level logging to the API without revisiting it.
+
+#### 3. Bump the driver as part of this phase — and pin the collation when you do
+
+v1.5.0 is from January 2020. Interpolation moves security-critical code out of TiDB and into
+that pinned dependency, which changes what keeping it patched is worth. **Go to `v1.9.3`.**
+The same Go-version trap as Phase 1's `go-jwt-middleware` pin applies and has been checked:
+`v1.9.3` declares `go 1.21.0` and is fine against this repo's Go 1.23, while **`v1.10.0`
+declares `go 1.24.0`** and would drag the Go bump into this work.
+
+One catch that makes the bump load-bearing rather than hygienic: from v1.8 the driver's
+`Collation` **defaults to empty** and the guard became
+`cfg.InterpolateParams && cfg.Collation != "" && unsafeCollations[cfg.Collation]`
+(`dsn.go:174` in v1.9.3). With no collation in the DSN the guard is a no-op and the
+connection charset comes from the server default. So the bump must add
+`&collation=utf8mb4_general_ci` to the DSN explicitly — otherwise upgrading *removes* the
+protection described above without any visible change.
+
+#### 4. A footgun for later: `[]byte` arguments
+
+A `[]byte` argument interpolates as `_binary'…'`, which forces a binary comparison — so
+`WHERE name = ?` would become case-**sensitive** and quietly break the case-insensitive
+matching that `migrations/032_pantry_staple.sql:33` and `recipe.go:602` depend on. There are
+no `[]byte` arguments today. There must not be one added without knowing this.
+
 ### Actions
 
-1. Add `&interpolateParams=true` to the DSN in `docker-compose.yml:39` (covers local dev
-   *and* e2e).
-2. Update the production DSN: `fly secrets set DSN='...&interpolateParams=true' -a big-shop-api`.
+1. `go get github.com/go-sql-driver/mysql@v1.9.3` — **before** turning interpolation on, so
+   the two changes are separable if the bump misbehaves. Not `v1.10.0` (see amendment 3).
+2. Add `&interpolateParams=true&collation=utf8mb4_general_ci` to the DSN in
+   `docker-compose.yml:39` (covers local dev *and* e2e). **Both parameters, together** —
+   amendment 3 explains why the collation is not optional once the driver is bumped.
+3. Update the production DSN:
+   `fly secrets set DSN='...&interpolateParams=true&collation=utf8mb4_general_ci' -a big-shop-api`.
    That is the **only** other place it is set — there is no `.env` copy of it by design
    (`docker/README.md`).
-3. Note it in `technical-architecture.md`'s environment table, with a one-line reason, so
-   the next person to rewrite the DSN does not drop it silently.
+4. Note all of it in `technical-architecture.md`'s environment table: what
+   `interpolateParams` buys, why `collation` is pinned next to it, and that
+   **`multiStatements` must never be added** (amendment 1) — so the next person to rewrite
+   the DSN does not drop half of it silently.
 
 ### Verify
 
 Run the rig (appendix) before and after. Expect the `GET /shopping-list` slope to fall from
 ~15.2 to ~9.2. Run `npm run test:e2e` — a mis-escaped parameter would show up as a wrong or
 empty Shopping List, which those specs assert on.
+
+Then check the two properties the security review depends on, because both fail silently:
+
+- **The guard is armed.** Temporarily set `collation=gbk_chinese_ci` in the local DSN and
+  confirm the API refuses to start with `invalid DSN: interpolateParams can not be used
+  with unsafe collations`. If it starts, the collation is not reaching the driver and
+  amendment 3 has bitten.
+- **Round trips actually fell.** The driver falls back to a server-side prepare
+  (`driver.ErrSkip`) for any argument type it cannot interpolate and for statements over
+  `maxAllowedPacket`, so the win is not uniform by construction. The slope is the check.
+
+Non-ASCII is worth one deliberate pass by hand — save a Recipe with an ingredient name
+carrying quotes, a backslash and a multi-byte character (`Crème "brûlée" \ 50%`) and read it
+back — since e2e fixtures are all ASCII and would not notice an escaping regression.
 
 ---
 

--- a/specs/request-model-optimisations.state.md
+++ b/specs/request-model-optimisations.state.md
@@ -1,6 +1,6 @@
 ---
 spec: specs/request-model-optimisations.md
-status: planned
+status: in-progress
 branch: implement/request-model-optimisations
 pr:
 ---
@@ -16,23 +16,30 @@ Phase 2's "Decision required from Ian" gate was answered at planning: take
 `interpolateParams`, with the four amendments from the spec's security review.
 
 ## Session 0: Record the security review in the spec
-Status: pending
+Status: done
 Scope: The Phase 2 security review — corrects two false claims about the driver, adds the
 four amendments (DSN invariants, query-text log exposure, driver bump + collation pin,
 `[]byte` footgun), and states the recommendation.
 Depends on: none
-Commit:
+Commit: dc5b9ff
 Notes: Written before the run started, as an answer to Ian's question about prepared-query
 security. Committed first so the rest of the branch builds on the amended spec.
 
 ## Session 1: Phase 1 — Cache the JWKS
-Status: pending
+Status: done
 Scope: Upgrade `go-jwt-middleware` v1 → v2.3.0, cache the JWKS via `jwks.CachingProvider`,
 rewrite `userMiddleware` for v2 claims, delete `getPemCert`/`Jwks`/`JSONWebKeys`/
 `normalizeAudience` and their tests. Retires `form3tech-oss/jwt-go`.
 Depends on: Session 0
-Commit:
-Notes: Three deviations from the spec's literal instructions, all found by checking v2.3.0's
+Commit: ce9e104
+Notes: Green — gofmt, go vet, `go test ./... -race`, and the openapi drift check all pass;
+`TestKeyLookupFailureIsRefusedNotPanicked`, `TestHealthCarveOut`, `TestDefaultCacheControl`,
+`TestOnlyTheGlobalCatalogsOverrideTheDefault` and `TestEachRouteStampsItsOwnPolicy` verified
+individually. Measured against the real Auth0 tenant: **before** 115ms then ~14-18ms every
+request; **after** 96ms then ~0.02ms. The tenant does publish two keys at once, which is the
+premise the 5-minute TTL rests on — confirmed by the probe.
+
+Three deviations from the spec's literal instructions, all found by checking v2.3.0's
 actual source and all agreed in the approved plan:
   1. v2 has no `HandlerWithNext` — needs a negroni adapter around `CheckJWT`.
   2. v2's default error handler answers a *missing* token with 400 where v1 answered 401.

--- a/specs/request-model-optimisations.state.md
+++ b/specs/request-model-optimisations.state.md
@@ -49,25 +49,57 @@ actual source and all agreed in the approved plan:
      every assertion stays identical.
 
 ## Session 2: Phase 2 — One round trip per query
-Status: pending
+Status: done
 Scope: Bump `go-sql-driver/mysql` v1.5.0 → v1.9.3 (not v1.10.0, which declares go 1.24.0),
 then add `interpolateParams=true` and `collation=utf8mb4_general_ci` to the DSN. Document
 both in `technical-architecture.md`, including that `multiStatements` must never be added.
 Depends on: Session 1
-Commit:
-Notes: Driver bump lands as its own commit before the DSN change, so a driver problem stays
+Commit: ce07b23 (driver bump), 6539840 (interpolation)
+Notes: Green — Go suite, and all 27 e2e tests pass. Measured with the toxiproxy rig:
+
+| Route | before | after |
+| --- | --- | --- |
+| `GET /shopping-list` | 15.2 | **9.1** |
+| `POST /shopping-list` (2 Recipes) | 50.8 | **29.4** |
+| `GET /recipes` | 4.1 | **2.1** |
+| `GET /tags` | 1.0 | 1.0 (no parameters) |
+
+The before column reproduces the spec's censused baseline (15.2, 50, 4, 1) — the rig is
+faithful. Both silent-failure checks done: the unsafe-collation guard is armed (pointing the
+DSN at `gbk_chinese_ci` makes the API refuse to start with the expected panic, which also
+proves the collation reaches the driver), and the round trips genuinely fell. Escaping
+verified by round-tripping quotes, backslashes, newlines and multi-byte UTF-8 through a
+Recipe, since every e2e fixture is ASCII.
+
+Driver bump lands as its own commit before the DSN change, so a driver problem stays
 separable from an interpolation problem. The collation is not optional: from v1.8 the
 unsafe-collation guard is `Collation != "" && unsafeCollations[...]`, so an empty collation
 disarms it. Production DSN is Ian's to set via `fly secrets` after merge — not this run.
 
 ## Session 3: Phase 3 — Resolve the Account once per request
-Status: pending
+Status: done
 Scope: Add `common.Caller` resolving the Account lazily and memoising it; `userMiddleware`
 and `devUserMiddleware` become `*App` methods and put a `*Caller` in the request context;
 21 of 26 service functions take `*common.Caller` instead of `userID string`.
 Depends on: Session 2
-Commit:
-Notes: Lazy, not eager — `/tags`, `/units`, `/ingredients`, `/user` and `/invites` make zero
+Commit: 03e6dac
+Notes: Green — gofmt, vet, `go test ./... -race`, the openapi drift check (no drift; Phase 3
+changes no API surface) and all 27 e2e tests. Censused against MySQL's general log:
+
+| Route | account lookups before → after |
+| --- | --- |
+| `POST /shopping-list` | 9 → **1** |
+| `PATCH /shopping-list/buy` | 4 → **1** |
+| `GET /shopping-list` | 3 → **1** |
+| `GET /tags`, `/units`, `/ingredients`, `/user`, `/invites` | 0 → **0** |
+
+Round-trip slope: `GET /shopping-list` 9.1 → **7.1**, `POST /shopping-list` (2 Recipes)
+29.4 → **20.9** — where the spec projected Phases 2 and 3 together would land it.
+
+`common.Caller` has its own tests (memoisation of both value and error, laziness, and
+concurrent first use under `-race`).
+
+Lazy, not eager — `/tags`, `/units`, `/ingredients`, `/user` and `/invites` make zero
 account lookups today and eager middleware resolution would make all five slower. Error
 behaviour must stay identical: no `account_user` row still surfaces `sql.ErrNoRows` from the
 service function that asked, and still becomes a 500.

--- a/specs/request-model-optimisations.state.md
+++ b/specs/request-model-optimisations.state.md
@@ -1,8 +1,8 @@
 ---
 spec: specs/request-model-optimisations.md
-status: in-progress
+status: complete
 branch: implement/request-model-optimisations
-pr:
+pr: https://github.com/Ianfeather/big-shop/pull/90
 ---
 
 ## Scope of this run

--- a/specs/request-model-optimisations.state.md
+++ b/specs/request-model-optimisations.state.md
@@ -1,0 +1,66 @@
+---
+spec: specs/request-model-optimisations.md
+status: planned
+branch: implement/request-model-optimisations
+pr:
+---
+
+## Scope of this run
+
+Phases 1–3 only, agreed with Ian at planning. Phases 4–6 (4a, 4b, 5a, 5b, 6a, 6b) are
+deliberately deferred to a later run: 4a is a breaking response-shape change, 5b introduces
+process-level mutable cache state, and 6a needs TiDB Serverless's connection ceiling looked
+up first. **The spec therefore does not move to `specs/completed/` at the end of this run.**
+
+Phase 2's "Decision required from Ian" gate was answered at planning: take
+`interpolateParams`, with the four amendments from the spec's security review.
+
+## Session 0: Record the security review in the spec
+Status: pending
+Scope: The Phase 2 security review — corrects two false claims about the driver, adds the
+four amendments (DSN invariants, query-text log exposure, driver bump + collation pin,
+`[]byte` footgun), and states the recommendation.
+Depends on: none
+Commit:
+Notes: Written before the run started, as an answer to Ian's question about prepared-query
+security. Committed first so the rest of the branch builds on the amended spec.
+
+## Session 1: Phase 1 — Cache the JWKS
+Status: pending
+Scope: Upgrade `go-jwt-middleware` v1 → v2.3.0, cache the JWKS via `jwks.CachingProvider`,
+rewrite `userMiddleware` for v2 claims, delete `getPemCert`/`Jwks`/`JSONWebKeys`/
+`normalizeAudience` and their tests. Retires `form3tech-oss/jwt-go`.
+Depends on: Session 0
+Commit:
+Notes: Three deviations from the spec's literal instructions, all found by checking v2.3.0's
+actual source and all agreed in the approved plan:
+  1. v2 has no `HandlerWithNext` — needs a negroni adapter around `CheckJWT`.
+  2. v2's default error handler answers a *missing* token with 400 where v1 answered 401.
+     Must pass `WithErrorHandler` to preserve 401, or the API contract silently changes.
+  3. `TestKeyLookupFailureIsRefusedNotPanicked` mints its token with `form3tech-oss/jwt-go`,
+     so dropping that dep stops it *compiling*. Token construction moves to go-jose.v2;
+     every assertion stays identical.
+
+## Session 2: Phase 2 — One round trip per query
+Status: pending
+Scope: Bump `go-sql-driver/mysql` v1.5.0 → v1.9.3 (not v1.10.0, which declares go 1.24.0),
+then add `interpolateParams=true` and `collation=utf8mb4_general_ci` to the DSN. Document
+both in `technical-architecture.md`, including that `multiStatements` must never be added.
+Depends on: Session 1
+Commit:
+Notes: Driver bump lands as its own commit before the DSN change, so a driver problem stays
+separable from an interpolation problem. The collation is not optional: from v1.8 the
+unsafe-collation guard is `Collation != "" && unsafeCollations[...]`, so an empty collation
+disarms it. Production DSN is Ian's to set via `fly secrets` after merge — not this run.
+
+## Session 3: Phase 3 — Resolve the Account once per request
+Status: pending
+Scope: Add `common.Caller` resolving the Account lazily and memoising it; `userMiddleware`
+and `devUserMiddleware` become `*App` methods and put a `*Caller` in the request context;
+21 of 26 service functions take `*common.Caller` instead of `userID string`.
+Depends on: Session 2
+Commit:
+Notes: Lazy, not eager — `/tags`, `/units`, `/ingredients`, `/user` and `/invites` make zero
+account lookups today and eager middleware resolution would make all five slower. Error
+behaviour must stay identical: no `account_user` row still surfaces `sql.ErrNoRows` from the
+service function that asked, and still becomes a 500.

--- a/technical-architecture.md
+++ b/technical-architecture.md
@@ -55,7 +55,7 @@ Located in `netlify-functions/recipes/`:
   `fly secrets set` alone is not enough, and a missing declaration fails silently
 - `machine_config.json` / `otel-collector.yaml`: the sidecar definition and the
   collector's config, delivered as a real file via per-container `files`
-- `internal/pkg/app/app.go`: App struct, JWT middleware, all route definitions (`GetRouter`, ~line 145)
+- `internal/pkg/app/app.go`: App struct, JWT middleware, all route definitions (`GetRouter`)
 - `internal/pkg/app/*.go`: Feature handlers
 - `internal/pkg/telemetry/`: OpenTelemetry setup (`telemetry.go`) and the HTTP
   instrumentation (`http.go`)
@@ -88,7 +88,7 @@ Instrumentation currently covers `GET /recipes` only — an allow-list in
 `telemetry/http.go` (`phase1Routes`) — which the observability spec widens to
 every route next.
 
-**Route list**: routes are registered in `internal/pkg/app/app.go`'s `GetRouter`, using [Huma](https://github.com/danielgtaylor/huma) (`humamux`, on top of the same `gorilla/mux` router) so each operation's request/response types double as its OpenAPI schema - no separate hand-maintained doc to drift. The generated spec is committed at [`docs/openapi.yaml`](./docs/openapi.yaml); regenerate it with `cd netlify-functions/recipes && go run . openapi > ../../docs/openapi.yaml` (no DB needed - route registration never touches it). `.github/workflows/ci.yml`'s `go` job fails if the committed spec is stale relative to `app.go` (it used to be `build.sh`, i.e. only during a Netlify deploy). All routes except `/health` require Auth0 JWT validation; the user ID is extracted from the JWT `sub` claim and threaded through context to handlers.
+**Route list**: routes are registered in `internal/pkg/app/app.go`'s `GetRouter`, using [Huma](https://github.com/danielgtaylor/huma) (`humamux`, on top of the same `gorilla/mux` router) so each operation's request/response types double as its OpenAPI schema - no separate hand-maintained doc to drift. The generated spec is committed at [`docs/openapi.yaml`](./docs/openapi.yaml); regenerate it with `cd netlify-functions/recipes && go run . openapi > ../../docs/openapi.yaml` (no DB needed - route registration never touches it). `.github/workflows/ci.yml`'s `go` job fails if the committed spec is stale relative to `app.go` (it used to be `build.sh`, i.e. only during a Netlify deploy). All routes except `/health` require Auth0 JWT validation, against a JWKS held in process for 5 minutes by `go-jwt-middleware` v2's `jwks.CachingProvider` (built once, in `GetRouter` - it used to be fetched over HTTPS on every request). `userMiddleware` takes the `sub` claim and puts a **`common.Caller`** in the request context; handlers read it with `callerFrom(ctx)`. A `Caller` carries the user ID and resolves that user's Account **lazily**, at most once per request - so a route that never needs an Account (`/tags`, `/units`, `/ingredients`, `/user`, `/invites`) still makes no lookup at all, while `POST /shopping-list` makes one instead of nine.
 
 ### API Testing
 For authenticated endpoints, copy the `Authorization` header from browser dev tools — no established curl/Postman workflow exists yet.
@@ -422,4 +422,4 @@ Two independent pipelines, one per deployable — an accepted consequence of
 
 **Frontend:** `next@16`, `react@19`, `@tanstack/react-query`, `@auth0/auth0-react@2`, `openai`, `@netlify/blobs`
 
-**Backend (Go):** `gorilla/mux`, `auth0/go-jwt-middleware`, `aws/aws-lambda-go`, `go-sql-driver/mysql`, `sendgrid/sendgrid-go`, `urfave/negroni`
+**Backend (Go):** `gorilla/mux`, `auth0/go-jwt-middleware/v2` (with `go-jose.v2`, which it brings and the tests mint tokens with), `aws/aws-lambda-go`, `go-sql-driver/mysql`, `sendgrid/sendgrid-go`, `urfave/negroni`

--- a/technical-architecture.md
+++ b/technical-architecture.md
@@ -320,10 +320,34 @@ local development and e2e working, where the public value is absolute anyway).
 unproxied origin to every visitor and undo the same-origin property.
 
 **Server-side secrets (set in Netlify UI / local `.env.local`):**
-- `DSN` — TiDB connection string
+- `DSN` — TiDB connection string. Carries two query parameters that are load-bearing rather
+  than incidental, and a third that must never be added — see below.
 - `OPENAI_API_KEY` — GPT-4 Vision + GPT-3.5-turbo
 - `SENDGRID_API_KEY` — Email invitations
 - `AUTH0_DOMAIN` / `AUTH0_AUDIENCE` — Go JWT validation
+
+#### The DSN's query parameters
+
+The DSN is set in exactly two places — `docker-compose.yml`'s `api` service (which covers
+local development *and* e2e) and a Fly secret for production. There is no `.env` copy by
+design (`docker/README.md`). Anyone rewriting it needs all three of these:
+
+| Parameter | Why |
+| --- | --- |
+| `parseTime=true` | `DATETIME`/`TIMESTAMP` columns scan into `time.Time` rather than `[]byte`. |
+| `interpolateParams=true` | The driver interpolates arguments client-side instead of preparing them server-side. A parameterised query costs **two** blocking round trips as a server-side prepare (`COM_STMT_PREPARE`, wait, `COM_STMT_EXECUTE`, wait) and **one** interpolated. Measured on the local stack: `GET /shopping-list` 15.2 → 9.1 round trips, `POST /shopping-list` 50.8 → 29.4. |
+| `collation=utf8mb4_general_ci` | **Pinned because of `interpolateParams`, not for its own sake.** Interpolation moves parameter escaping from TiDB into the driver, and the driver's guard against the multibyte escape-bypass charsets (`gbk`, `big5`, `sjis`, `cp932`, `gb2312`, `gb18030`) is `InterpolateParams && Collation != "" && unsafeCollations[Collation]`. Since driver v1.8 the collation defaults to *empty*, so leaving it unset silently disarms that guard. Drop this and the protection goes with it, with nothing visibly changing. |
+
+**`multiStatements` must never be added.** Unlike an unsafe collation — which the driver
+refuses outright, failing the process at startup — nothing stops `multiStatements` being
+combined with `interpolateParams`, and it is the parameter that would turn any future
+escaping defect into stacked statements.
+
+One accepted consequence of `interpolateParams`: argument values now travel *inside* the
+query text, so they appear in MySQL's general and slow-query logs and in TiDB Cloud's
+slow-query UI. That includes invite tokens and email addresses
+(`internal/pkg/service/invite.go`). Don't add statement-level logging to the API without
+revisiting it. The full analysis is in `specs/request-model-optimisations.md`.
 
 **Fly secrets, read by the Go API only** (`fly secrets set …`, see the
 [runbook](./docs/fly-migration-runbook.md)):


### PR DESCRIPTION
Implements Phases 1–3 of [`specs/request-model-optimisations.md`](../blob/implement/request-model-optimisations/specs/request-model-optimisations.md). Phases 4–6 are deliberately out of scope and the spec stays in `specs/` for a later run.

The spec exists because follow-up #49 found the cost model everyone was reasoning from wrong by a factor of ~1.7: the unit of cost is a **blocking round trip**, not a query, and a parameterised query costs two of them. Nothing here is a fire — the point is to stop building on a mismeasured base.

## What shipped

| Session | Phase | |
| --- | --- | --- |
| 0 | — | Record the Phase 2 security review in the spec |
| 1 | 1 | Cache the JWKS (`go-jwt-middleware` v1 → v2.3.0) |
| 2 | 2 | Bump `go-sql-driver/mysql` to v1.9.3, then interpolate parameters client-side |
| 3 | 3 | Resolve the Account once per request (`common.Caller`) |

## Measured

Every number below is a **slope**, measured with a toxiproxy between the API and MySQL injecting downstream latency: total request time is linear in the injected delay and the slope is the blocking round-trip count. The `before` column reproduces the spec's censused baseline (15.2, 50, 4, 1), which is the evidence the rig is faithful.

| Route | before | + Phase 2 | + Phase 3 |
| --- | --- | --- | --- |
| `GET /shopping-list` | 15.2 | 9.1 | **7.1** |
| `POST /shopping-list` (2 Recipes) | 50.8 | 29.4 | **20.9** |
| `GET /recipes` | 4.1 | 2.1 | **2.1** |
| `GET /tags` | 1.0 | 1.0 | **1.0** |

The spec projected 9 after Phase 2 and 7 after Phase 3, and "50 → ~21" for `POST /shopping-list`. Account lookups per request, censused via MySQL's general log:

| Route | before | after |
| --- | --- | --- |
| `POST /shopping-list` | 9 | **1** |
| `PATCH /shopping-list/buy` | 4 | **1** |
| `GET /shopping-list` | 3 | **1** |
| `GET /tags`, `/units`, `/ingredients`, `/user`, `/invites` | 0 | **0** |

Those last five staying at zero is why `Caller` resolves lazily rather than eagerly in middleware — eager resolution would have made all five *slower*.

And on the auth path, measured against the real Auth0 tenant:

| | before | after |
| --- | --- | --- |
| first request | 115ms | 96ms |
| every subsequent request | ~14–18ms | **~0.02ms** |

## Three things the spec did not anticipate

All in Phase 1, found by checking the spec's snippets against v2.3.0's actual source:

1. **v2 has no `HandlerWithNext`**, which is what v1 handed negroni. `CheckJWT` wraps a handler instead, so it gets a small adapter. Position in the stack is unchanged, so `cacheControlMiddleware` still stamps its 401s.
2. **v2 answers a *missing* token with 400 where v1 answered 401.** That is a contract change for every unauthenticated request and nothing here asked for it, so `WithErrorHandler` keeps 401. `TestRefusalsAnswer401` is new and pins it.
3. **`TestKeyLookupFailureIsRefusedNotPanicked` could not stay byte-for-byte unchanged** — it minted its token with `form3tech-oss/jwt-go`, the dependency Phase 1 drops, so it stopped *compiling* rather than failing. Token construction moved to go-jose; every assertion is the original. Flagged because the spec was emphatic that editing it would be a finding.

`GetRouter` also had to stay buildable with no Auth0 environment, because `go run . openapi` builds the same router and a CI job diffs its output. Unconfigured, it now installs a refuse-everything handler — fail-closed, and covered by a test.

## Security, on Phase 2

Phase 2 was gated on a decision. The spec now carries a full audit (Session 0): **no injection exposure**, but two of the three reassurances the spec originally rested on were false for the pinned driver, and are recorded as false so they don't get re-derived. Three consequences ship with it:

- **`collation=utf8mb4_general_ci` is not optional.** The driver's guard against the multibyte escape-bypass charsets is `InterpolateParams && Collation != "" && unsafeCollations[Collation]`, and since v1.8 the collation defaults to empty — so bumping the driver without pinning the collation would silently disarm it. Verified armed by pointing the DSN at `gbk_chinese_ci` and confirming the API refuses to start.
- **`multiStatements` must never be added.** Unlike an unsafe collation, nothing in the driver refuses it.
- **Argument values now travel inside query text**, so they reach slow-query logs — including invite tokens, which are bearer capabilities. Documented in `technical-architecture.md` as accepted.

## Testing

- `gofmt -l`, `go vet ./...`, `go test ./... -race` — green.
- `docs/openapi.yaml` drift check — no drift.
- **27/27 Playwright e2e tests** pass, run after Phase 2 and again after Phase 3.
- New tests: `TestRefusalsAnswer401` (both refusal paths), and four for `common.Caller` covering memoisation of value *and* error, laziness, and concurrent first use.
- Escaping checked by hand, since every e2e fixture is ASCII: a Recipe whose name, notes, method and ingredient names carry single quotes, double quotes, backslashes, newlines, an em dash and multi-byte UTF-8 round-trips intact.

## Over to you after merge

Production is **not** switched on by this PR. Phase 2 needs:

```
fly secrets set DSN='...&interpolateParams=true&collation=utf8mb4_general_ci' -a big-shop-api
```

That is a production change and yours to run. The ordering is safe either way: until the secret changes, production keeps preparing server-side on the new driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)