### PR TITLE
Restore the single-container Fly build after the sidecar deploy failed

### DIFF
--- a/netlify-functions/recipes/compose.fly.yml
+++ b/netlify-functions/recipes/compose.fly.yml
@@ -1,6 +1,21 @@
 # Multi-container Machine definition for Fly: the Go API plus an OpenTelemetry
 # Collector sidecar, per docs/adr/0007-observability-otel-grafana-cloud.md.
 #
+# !! NOT CURRENTLY WIRED UP. fly.toml points at the Dockerfile, not at this
+# file. !!
+#
+# It was wired up once and the deploy failed: `fly secrets` reached neither
+# container. The collector exited on "Configuration references unset environment
+# variable GRAFANA_CLOUD_OTLP_ENDPOINT"; the API fell back to an empty DSN and
+# died on "dial tcp 127.0.0.1:3306: connect: connection refused". All four
+# secrets existed and read `Deployed` at the time. Fly documents secrets as
+# available to every container in a Machine, so the working hypothesis is that
+# the `environment:` blocks below *replace* the injected environment rather than
+# merging with it - which would mean the fix is to move every value into
+# fly.toml's `[env]` (which does apply to all containers) and declare no
+# `environment:` here at all. Unproven; that is the next thing to test, and it
+# must be tested somewhere other than the machine serving production.
+#
 # NOT a local-development file. `docker-compose.yml` at the repository root is
 # the local stack (MySQL, the API with hot reload, and grafana/otel-lgtm); this
 # one is only ever read by `fly deploy`, via fly.toml's [build.compose]. It is

--- a/netlify-functions/recipes/fly.toml
+++ b/netlify-functions/recipes/fly.toml
@@ -18,17 +18,26 @@ app = "big-shop-api"
 # accepted in ADR-0006; it is still ~90ms better than us-east-2.
 primary_region = "fra"
 
-# Two containers in one Machine: the Go API and an OpenTelemetry Collector
-# sidecar (docs/adr/0007). `file` is explicit because Fly's auto-detection looks
-# for compose.yaml/docker-compose.yml in the build context - this directory -
-# and would find nothing; the repo-root docker-compose.yml is the local
-# development stack and must never be what gets deployed.
+# Single container, deliberately - see compose.fly.yml, which is written and
+# validated but NOT wired up here.
 #
-# This replaces `dockerfile = "Dockerfile"`: the Dockerfile is now named by the
-# `api` service inside the compose file instead. Both keys together would be two
-# answers to the same question.
-[build.compose]
-  file = "compose.fly.yml"
+# It was, briefly, and the deploy failed: under `[build.compose]`, `fly secrets`
+# reached neither container. The collector exited with "Configuration references
+# unset environment variable GRAFANA_CLOUD_OTLP_ENDPOINT", and the API - which
+# has read DSN from a secret since it moved to Fly - fell back to an empty DSN
+# and died on `dial tcp 127.0.0.1:3306: connect: connection refused`. Both
+# containers hit their restart limits and the machine stopped. Fly's docs say
+# "Secrets set with fly secrets are available to every container in the
+# Machine"; that did not hold here, and the likeliest reason is that a compose
+# service's `environment:` block replaces the injected environment rather than
+# merging with it.
+#
+# Restored to the single-container build until that is understood and proved.
+# The Go instrumentation stays shipped and is simply dormant: with no
+# OTEL_EXPORTER_OTLP_ENDPOINT set, telemetry.Setup is a no-op and the process
+# behaves exactly as it did before any of this.
+[build]
+  dockerfile = "Dockerfile"
 
 # The Go process reads five environment variables (grep os.Getenv). Two are
 # public identifiers and live here, in version control, so a deploy cannot


### PR DESCRIPTION
**Production fix.** Restores the single-container Fly build after the sidecar deploy in #91
failed.

## What happened

The deploy built and pushed fine, then the first machine came up with nothing listening on
8080 and health checks timed out. Both containers had exited:

```
otelcol  Configuration references unset environment variable {"name": "GRAFANA_CLOUD_OTLP_ENDPOINT"}
otelcol  Error: invalid configuration: exporters::otlp_http/grafana: at least one endpoint must be specified
api      failed to ping: dial tcp 127.0.0.1:3306: connect: connection refused
```

`fly secrets` reached **neither container**. The API's `127.0.0.1:3306` is the giveaway — that
is what `sql.Open("mysql", "")` falls back to, so `DSN` was empty too. All four secrets existed
and read `Deployed` throughout.

This contradicts Fly's documentation, which states secrets "are available to every container in
the Machine". The working hypothesis is that a compose service's `environment:` block *replaces*
the injected environment rather than merging with it — both of my services declared one. If so
the fix is to move every value into `fly.toml`'s `[env]`, which does apply to all containers,
and declare no `environment:` in compose at all. **Unproven**, and not something to test against
the machine serving production.

## No outage

The app runs two machines and the rolling deploy stopped after the first failed, so the second
served the previous image throughout. `/api/bigshop/health` returned 200 continuously, direct
and via the Netlify rewrite. Redundancy was degraded to one machine until this lands.

Worth noting: the second machine — which I'd flagged as possibly unintentional, since `fly.toml`
talks about "the machine" in the singular — is the only reason this wasn't an outage.

## What this changes

Only the deployment topology. `fly.toml` points back at the `Dockerfile`.

`compose.fly.yml` is kept, unreferenced and marked clearly at the top, because the config itself
is validated and worth keeping. The Go instrumentation also stays shipped and is **dormant**:
with no `OTEL_EXPORTER_OTLP_ENDPOINT` set, `telemetry.Setup` returns a no-op and the process
behaves exactly as it did before any of this work.

Phase 2's production checkpoint is therefore still not met, and the spec's remaining phases are
unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
