### PR TITLE
Observability Phase 3: instrument every route, and stop the service layer logging

### DIFF
--- a/netlify-functions/recipes/internal/pkg/app/account.go
+++ b/netlify-functions/recipes/internal/pkg/app/account.go
@@ -22,7 +22,7 @@ type AccountUserInput struct {
 
 func (a *App) getAccount(ctx context.Context, _ *struct{}) (*AccountOutput, error) {
 	userID := ctx.Value(contextKey("userID")).(string)
-	account, err := service.GetAccount(a.db, userID)
+	account, err := service.GetAccount(ctx, a.db, userID)
 
 	if err != nil {
 		log.Println(err)
@@ -36,10 +36,13 @@ func (a *App) addUserToAccount(ctx context.Context, input *AccountUserInput) (*A
 	userID := ctx.Value(contextKey("userID")).(string)
 	newUser := input.Body
 
-	accountID, err := service.GetAccountID(a.db, userID)
+	accountID, err := service.GetAccountID(ctx, a.db, userID)
 	if err != nil {
-		log.Println("Error: current user is not associated with an account")
-		return nil, huma.Error500InternalServerError("Current user is not associated with an account")
+		// Was: log the guess "current user is not associated with an account"
+		// and discard err - so a TiDB outage was reported, to the logs and to
+		// the user, as a membership problem. serverError puts the real cause on
+		// the span and keeps the client's message opaque.
+		return nil, serverError(ctx, "Could not resolve the current user's account", err)
 	}
 
 	// TODO: Fetch the user ID associated with the email from Auth0
@@ -47,12 +50,12 @@ func (a *App) addUserToAccount(ctx context.Context, input *AccountUserInput) (*A
 	newUser.Name = "Anna Feather"
 
 	// TODO: if the user doesn't exist, we should be able to invite them
-	if err := service.AddUserToAccount(a.db, accountID, newUser); err != nil {
+	if err := service.AddUserToAccount(ctx, a.db, accountID, newUser); err != nil {
 		log.Println("failed to add user to account")
 		return nil, huma.Error500InternalServerError("Failed to add user to account")
 	}
 
-	account, err := service.GetAccount(a.db, userID)
+	account, err := service.GetAccount(ctx, a.db, userID)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to get Account from db")
 	}
@@ -64,19 +67,22 @@ func (a *App) removeUserFromAccount(ctx context.Context, input *AccountUserInput
 	userID := ctx.Value(contextKey("userID")).(string)
 	outgoingUser := input.Body
 
-	accountID, err := service.GetAccountID(a.db, userID)
+	accountID, err := service.GetAccountID(ctx, a.db, userID)
 	if err != nil {
-		log.Println("Error: current user is not associated with an account")
-		return nil, huma.Error500InternalServerError("Current user is not associated with an account")
+		// Was: log the guess "current user is not associated with an account"
+		// and discard err - so a TiDB outage was reported, to the logs and to
+		// the user, as a membership problem. serverError puts the real cause on
+		// the span and keeps the client's message opaque.
+		return nil, serverError(ctx, "Could not resolve the current user's account", err)
 	}
 
 	// TODO: create the concept of admins
-	if err := service.RemoveUserFromAccount(a.db, accountID, outgoingUser); err != nil {
+	if err := service.RemoveUserFromAccount(ctx, a.db, accountID, outgoingUser); err != nil {
 		log.Println("failed to remove user frorm account")
 		return nil, huma.Error500InternalServerError("Failed to remove user frorm account")
 	}
 
-	account, err := service.GetAccount(a.db, userID)
+	account, err := service.GetAccount(ctx, a.db, userID)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Failed to get Account from db")
 	}
@@ -85,7 +91,7 @@ func (a *App) removeUserFromAccount(ctx context.Context, input *AccountUserInput
 }
 
 func (a *App) registerAccountRoutes(api huma.API) {
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "get-account",
 		Method:      http.MethodGet,
 		Path:        "/account",
@@ -93,7 +99,7 @@ func (a *App) registerAccountRoutes(api huma.API) {
 		Tags:        []string{"Account"},
 	}, a.getAccount)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "add-user-to-account",
 		Method:      http.MethodPost,
 		Path:        "/account/add",
@@ -101,7 +107,7 @@ func (a *App) registerAccountRoutes(api huma.API) {
 		Tags:        []string{"Account"},
 	}, a.addUserToAccount)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "remove-user-from-account",
 		Method:      http.MethodDelete,
 		Path:        "/account/remove",

--- a/netlify-functions/recipes/internal/pkg/app/account.go
+++ b/netlify-functions/recipes/internal/pkg/app/account.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"recipes/internal/pkg/common"
 	"recipes/internal/pkg/service"
@@ -25,8 +24,7 @@ func (a *App) getAccount(ctx context.Context, _ *struct{}) (*AccountOutput, erro
 	account, err := service.GetAccount(ctx, a.db, userID)
 
 	if err != nil {
-		log.Println(err)
-		return nil, huma.Error500InternalServerError("Failed to get Account from db")
+		return nil, fail(ctx, huma.Error500InternalServerError("Failed to get Account from db"), err)
 	}
 
 	return &AccountOutput{Body: *account}, nil
@@ -40,9 +38,9 @@ func (a *App) addUserToAccount(ctx context.Context, input *AccountUserInput) (*A
 	if err != nil {
 		// Was: log the guess "current user is not associated with an account"
 		// and discard err - so a TiDB outage was reported, to the logs and to
-		// the user, as a membership problem. serverError puts the real cause on
-		// the span and keeps the client's message opaque.
-		return nil, serverError(ctx, "Could not resolve the current user's account", err)
+		// the user, as a membership problem. fail() puts the real cause on the
+		// span and keeps the client's message opaque.
+		return nil, fail(ctx, huma.Error500InternalServerError("Could not resolve the current user's account"), err)
 	}
 
 	// TODO: Fetch the user ID associated with the email from Auth0
@@ -51,8 +49,7 @@ func (a *App) addUserToAccount(ctx context.Context, input *AccountUserInput) (*A
 
 	// TODO: if the user doesn't exist, we should be able to invite them
 	if err := service.AddUserToAccount(ctx, a.db, accountID, newUser); err != nil {
-		log.Println("failed to add user to account")
-		return nil, huma.Error500InternalServerError("Failed to add user to account")
+		return nil, fail(ctx, huma.Error500InternalServerError("Failed to add user to account"), err)
 	}
 
 	account, err := service.GetAccount(ctx, a.db, userID)
@@ -71,15 +68,14 @@ func (a *App) removeUserFromAccount(ctx context.Context, input *AccountUserInput
 	if err != nil {
 		// Was: log the guess "current user is not associated with an account"
 		// and discard err - so a TiDB outage was reported, to the logs and to
-		// the user, as a membership problem. serverError puts the real cause on
-		// the span and keeps the client's message opaque.
-		return nil, serverError(ctx, "Could not resolve the current user's account", err)
+		// the user, as a membership problem. fail() puts the real cause on the
+		// span and keeps the client's message opaque.
+		return nil, fail(ctx, huma.Error500InternalServerError("Could not resolve the current user's account"), err)
 	}
 
 	// TODO: create the concept of admins
 	if err := service.RemoveUserFromAccount(ctx, a.db, accountID, outgoingUser); err != nil {
-		log.Println("failed to remove user frorm account")
-		return nil, huma.Error500InternalServerError("Failed to remove user frorm account")
+		return nil, fail(ctx, huma.Error500InternalServerError("Failed to remove user from account"), err)
 	}
 
 	account, err := service.GetAccount(ctx, a.db, userID)

--- a/netlify-functions/recipes/internal/pkg/app/app.go
+++ b/netlify-functions/recipes/internal/pkg/app/app.go
@@ -10,6 +10,7 @@ import (
 	"recipes/internal/pkg/common"
 	"recipes/internal/pkg/purge"
 	"recipes/internal/pkg/telemetry"
+	"sort"
 
 	jwtmiddleware "github.com/auth0/go-jwt-middleware"
 	"github.com/danielgtaylor/huma/v2"
@@ -197,6 +198,23 @@ func getPemCert(token *jwt.Token) (string, error) {
 	return cert, nil
 }
 
+// RouteTemplates lists the path templates registered on an API - "/recipes",
+// "/recipe/{id}" and so on.
+//
+// This is the authority for what counts as a known route, and it comes from the
+// router itself rather than a hand-kept list precisely so it cannot drift: add
+// an operation and its template is in here the moment it is registered. What
+// depends on that is telemetry's label cardinality - see telemetry.route.
+func RouteTemplates(api huma.API) []string {
+	paths := api.OpenAPI().Paths
+	templates := make([]string, 0, len(paths))
+	for p := range paths {
+		templates = append(templates, p)
+	}
+	sort.Strings(templates)
+	return templates
+}
+
 // GetRouter returns the application router and the Huma API instance backing
 // it, from which the OpenAPI spec can be generated (see the `openapi` mode in
 // main.go) without needing to start a server or hold a DB connection.
@@ -323,7 +341,7 @@ func (a *App) GetRouter(base string) (*negroni.Negroni, huma.API, error) {
 	// The accessor is passed in rather than let telemetry read the context
 	// itself, because contextKey is unexported and Go compares context keys by
 	// type - see telemetry.Middleware's comment.
-	n.Use(negroni.HandlerFunc(telemetry.Middleware(base, func(r *http.Request) string {
+	n.Use(negroni.HandlerFunc(telemetry.Middleware(base, RouteTemplates(api), func(r *http.Request) string {
 		sub, _ := r.Context().Value(contextKey("userID")).(string)
 		return sub
 	})))

--- a/netlify-functions/recipes/internal/pkg/app/ingredients.go
+++ b/netlify-functions/recipes/internal/pkg/app/ingredients.go
@@ -50,7 +50,7 @@ func (o *IngredientsOutput) withCachePolicy() *IngredientsOutput {
 }
 
 func (a *App) getIngredients(ctx context.Context, _ *struct{}) (*IngredientsOutput, error) {
-	ingredients, err := service.GetAllIngredients(a.db)
+	ingredients, err := service.GetAllIngredients(ctx, a.db)
 
 	if err != nil {
 		log.Println(err)
@@ -66,7 +66,7 @@ func (a *App) getIngredients(ctx context.Context, _ *struct{}) (*IngredientsOutp
 }
 
 func (a *App) registerIngredientsRoutes(api huma.API) {
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "list-ingredients",
 		Method:      http.MethodGet,
 		Path:        "/ingredients",

--- a/netlify-functions/recipes/internal/pkg/app/ingredients.go
+++ b/netlify-functions/recipes/internal/pkg/app/ingredients.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"log"
 	"net/http"
 
 	"recipes/internal/pkg/service"
@@ -53,8 +52,7 @@ func (a *App) getIngredients(ctx context.Context, _ *struct{}) (*IngredientsOutp
 	ingredients, err := service.GetAllIngredients(ctx, a.db)
 
 	if err != nil {
-		log.Println(err)
-		return nil, huma.Error500InternalServerError("Failed to get ingredients from db")
+		return nil, fail(ctx, huma.Error500InternalServerError("Failed to get ingredients from db"), err)
 	}
 
 	names := make([]IngredientName, len(ingredients))

--- a/netlify-functions/recipes/internal/pkg/app/invites.go
+++ b/netlify-functions/recipes/internal/pkg/app/invites.go
@@ -23,30 +23,30 @@ type InvitesOutput struct {
 }
 
 func (a *App) acceptInvite(ctx context.Context, input *InviteTokenInput) (*struct{}, error) {
-	currentUser, err := service.GetUser(a.db, ctx.Value(contextKey("userID")).(string))
+	currentUser, err := service.GetUser(ctx, a.db, ctx.Value(contextKey("userID")).(string))
 	if err != nil {
 		log.Println("Error finding current user")
 		return nil, huma.Error400BadRequest("Error finding current user")
 	}
 
-	accountID, err := service.GetInvite(a.db, input.Body.Token, currentUser.Email)
+	accountID, err := service.GetInvite(ctx, a.db, input.Body.Token, currentUser.Email)
 	if err != nil {
 		log.Println("Error finding invite")
 		return nil, huma.Error400BadRequest("Error finding invite")
 	}
 
 	// Disable old user account
-	if err := service.DisableUserAccount(a.db, *currentUser); err != nil {
+	if err := service.DisableUserAccount(ctx, a.db, *currentUser); err != nil {
 		return nil, huma.Error500InternalServerError("Error disabling user account")
 	}
 
 	// Add user to the account
-	if err := service.AddUserToAccount(a.db, *accountID, *currentUser); err != nil {
+	if err := service.AddUserToAccount(ctx, a.db, *accountID, *currentUser); err != nil {
 		return nil, huma.Error500InternalServerError("Error adding user to the account")
 	}
 
 	// remove the invite
-	if err := service.DeleteInvite(a.db, *accountID, currentUser.Email); err != nil {
+	if err := service.DeleteInvite(ctx, a.db, *accountID, currentUser.Email); err != nil {
 		return nil, huma.Error500InternalServerError("Error deleting invite")
 	}
 
@@ -54,13 +54,13 @@ func (a *App) acceptInvite(ctx context.Context, input *InviteTokenInput) (*struc
 }
 
 func (a *App) getInvites(ctx context.Context, _ *struct{}) (*InvitesOutput, error) {
-	user, err := service.GetUser(a.db, ctx.Value(contextKey("userID")).(string))
+	user, err := service.GetUser(ctx, a.db, ctx.Value(contextKey("userID")).(string))
 	if err != nil {
 		log.Println("Error finding current user")
 		return nil, huma.Error500InternalServerError("Error finding current user")
 	}
 
-	invites, err := service.GetInvites(a.db, user.Email)
+	invites, err := service.GetInvites(ctx, a.db, user.Email)
 	if err != nil {
 		log.Println("Error finding invites")
 		return nil, huma.Error404NotFound("Error finding invites")
@@ -70,7 +70,7 @@ func (a *App) getInvites(ctx context.Context, _ *struct{}) (*InvitesOutput, erro
 }
 
 func (a *App) rejectInvite(ctx context.Context, input *InviteTokenInput) (*struct{}, error) {
-	if err := service.DeleteInviteByToken(a.db, input.Body.Token); err != nil {
+	if err := service.DeleteInviteByToken(ctx, a.db, input.Body.Token); err != nil {
 		return nil, huma.Error500InternalServerError("Error deleting invite")
 	}
 
@@ -78,7 +78,7 @@ func (a *App) rejectInvite(ctx context.Context, input *InviteTokenInput) (*struc
 }
 
 func (a *App) registerInviteRoutes(api huma.API) {
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "accept-invite",
 		Method:      http.MethodPost,
 		Path:        "/invite/accept",
@@ -86,7 +86,7 @@ func (a *App) registerInviteRoutes(api huma.API) {
 		Tags:        []string{"Invites"},
 	}, a.acceptInvite)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "list-invites",
 		Method:      http.MethodGet,
 		Path:        "/invites",
@@ -94,7 +94,7 @@ func (a *App) registerInviteRoutes(api huma.API) {
 		Tags:        []string{"Invites"},
 	}, a.getInvites)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "reject-invite",
 		Method:      http.MethodPost,
 		Path:        "/invite/reject",

--- a/netlify-functions/recipes/internal/pkg/app/invites.go
+++ b/netlify-functions/recipes/internal/pkg/app/invites.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"recipes/internal/pkg/common"
 	"recipes/internal/pkg/service"
@@ -25,14 +24,12 @@ type InvitesOutput struct {
 func (a *App) acceptInvite(ctx context.Context, input *InviteTokenInput) (*struct{}, error) {
 	currentUser, err := service.GetUser(ctx, a.db, ctx.Value(contextKey("userID")).(string))
 	if err != nil {
-		log.Println("Error finding current user")
-		return nil, huma.Error400BadRequest("Error finding current user")
+		return nil, fail(ctx, huma.Error400BadRequest("Error finding current user"), err)
 	}
 
 	accountID, err := service.GetInvite(ctx, a.db, input.Body.Token, currentUser.Email)
 	if err != nil {
-		log.Println("Error finding invite")
-		return nil, huma.Error400BadRequest("Error finding invite")
+		return nil, fail(ctx, huma.Error400BadRequest("Error finding invite"), err)
 	}
 
 	// Disable old user account
@@ -56,14 +53,12 @@ func (a *App) acceptInvite(ctx context.Context, input *InviteTokenInput) (*struc
 func (a *App) getInvites(ctx context.Context, _ *struct{}) (*InvitesOutput, error) {
 	user, err := service.GetUser(ctx, a.db, ctx.Value(contextKey("userID")).(string))
 	if err != nil {
-		log.Println("Error finding current user")
-		return nil, huma.Error500InternalServerError("Error finding current user")
+		return nil, fail(ctx, huma.Error500InternalServerError("Error finding current user"), err)
 	}
 
 	invites, err := service.GetInvites(ctx, a.db, user.Email)
 	if err != nil {
-		log.Println("Error finding invites")
-		return nil, huma.Error404NotFound("Error finding invites")
+		return nil, fail(ctx, huma.Error404NotFound("Error finding invites"), err)
 	}
 
 	return &InvitesOutput{Body: invites}, nil

--- a/netlify-functions/recipes/internal/pkg/app/list.go
+++ b/netlify-functions/recipes/internal/pkg/app/list.go
@@ -2,10 +2,10 @@ package app
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"recipes/internal/pkg/common"
 	"recipes/internal/pkg/service"
+	"recipes/internal/pkg/telemetry"
 
 	"github.com/danielgtaylor/huma/v2"
 )
@@ -60,8 +60,7 @@ func (a *App) createList(ctx context.Context, input *CreateListInput) (*Shopping
 		if err == service.ErrInvalidRecipeID {
 			return nil, huma.Error400BadRequest("Cannot parse recipe id")
 		}
-		log.Println("Cannot generate shopping list")
-		return nil, huma.Error500InternalServerError("Cannot generate shopping list")
+		return nil, fail(ctx, huma.Error500InternalServerError("Cannot generate shopping list"), err)
 	}
 
 	return &ShoppingListOutput{Body: *list}, nil
@@ -111,8 +110,10 @@ func (a *App) clearList(ctx context.Context, _ *struct{}) (*ShoppingListOutput, 
 
 	// Log clear event for meal planning intelligence
 	if logErr := service.LogShoppingListClearEvent(ctx, userID, a.db); logErr != nil {
-		// Log error but don't fail the main operation
-		log.Printf("Failed to log shopping list clear: %v", logErr)
+		// Recorded, not returned: clearing the list succeeded, and failing the
+		// request because its history row did not get written would be worse
+		// than losing the row.
+		telemetry.RecordWarning(ctx, "log shopping list clear", logErr)
 	}
 
 	return &ShoppingListOutput{Body: common.ShoppingList{}}, nil
@@ -123,14 +124,12 @@ func (a *App) getShoppingListHistory(ctx context.Context, _ *struct{}) (*Shoppin
 
 	recentRecipes, err := service.GetRecentRecipeUsage(ctx, userID, 30, 10, a.db)
 	if err != nil {
-		log.Printf("Error getting recent recipes: %v", err)
-		return nil, huma.Error500InternalServerError("Error getting recent recipes")
+		return nil, fail(ctx, huma.Error500InternalServerError("Error getting recent recipes"), err)
 	}
 
 	favoriteRecipes, err := service.GetFavoriteRecipes(ctx, userID, 10, a.db)
 	if err != nil {
-		log.Printf("Error getting favorite recipes: %v", err)
-		return nil, huma.Error500InternalServerError("Error getting favorite recipes")
+		return nil, fail(ctx, huma.Error500InternalServerError("Error getting favorite recipes"), err)
 	}
 
 	resp := &ShoppingListHistoryOutput{}

--- a/netlify-functions/recipes/internal/pkg/app/list.go
+++ b/netlify-functions/recipes/internal/pkg/app/list.go
@@ -42,7 +42,7 @@ type ShoppingListHistoryOutput struct {
 func (a *App) getList(ctx context.Context, _ *struct{}) (*ShoppingListOutput, error) {
 	userID := ctx.Value(contextKey("userID")).(string)
 
-	list, err := service.GetShoppingList(userID, a.db)
+	list, err := service.GetShoppingList(ctx, userID, a.db)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Error Fetching Shopping List")
 	}
@@ -54,7 +54,7 @@ func (a *App) createList(ctx context.Context, input *CreateListInput) (*Shopping
 	userID := ctx.Value(contextKey("userID")).(string)
 	recipeIDs := input.Body
 
-	list, err := service.GenerateShoppingList(recipeIDs, userID, a.db)
+	list, err := service.GenerateShoppingList(ctx, recipeIDs, userID, a.db)
 
 	if err != nil {
 		if err == service.ErrInvalidRecipeID {
@@ -75,7 +75,7 @@ func (a *App) addExtraListItem(ctx context.Context, input *ListItemInput) (*Stat
 		return nil, huma.Error400BadRequest("Missing item name")
 	}
 
-	if err := service.AddExtraListItem(userID, extraItem.Name, extraItem.IsBought, a.db); err != nil {
+	if err := service.AddExtraListItem(ctx, userID, extraItem.Name, extraItem.IsBought, a.db); err != nil {
 		return nil, huma.Error500InternalServerError("Cannot add list items")
 	}
 
@@ -90,11 +90,11 @@ func (a *App) buyListItem(ctx context.Context, input *ListItemInput) (*ShoppingL
 		return nil, huma.Error400BadRequest("Missing item name")
 	}
 
-	if err := service.BuyListItem(userID, listItem.Name, listItem.IsBought, a.db); err != nil {
+	if err := service.BuyListItem(ctx, userID, listItem.Name, listItem.IsBought, a.db); err != nil {
 		return nil, huma.Error500InternalServerError("Error marking item as bought")
 	}
 
-	list, err := service.GetShoppingList(userID, a.db)
+	list, err := service.GetShoppingList(ctx, userID, a.db)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Error getting shopping list")
 	}
@@ -105,12 +105,12 @@ func (a *App) buyListItem(ctx context.Context, input *ListItemInput) (*ShoppingL
 func (a *App) clearList(ctx context.Context, _ *struct{}) (*ShoppingListOutput, error) {
 	userID := ctx.Value(contextKey("userID")).(string)
 
-	if err := service.RemoveAllListItems(userID, a.db); err != nil {
+	if err := service.RemoveAllListItems(ctx, userID, a.db); err != nil {
 		return nil, huma.Error500InternalServerError("Error removing list items")
 	}
 
 	// Log clear event for meal planning intelligence
-	if logErr := service.LogShoppingListClearEvent(userID, a.db); logErr != nil {
+	if logErr := service.LogShoppingListClearEvent(ctx, userID, a.db); logErr != nil {
 		// Log error but don't fail the main operation
 		log.Printf("Failed to log shopping list clear: %v", logErr)
 	}
@@ -121,13 +121,13 @@ func (a *App) clearList(ctx context.Context, _ *struct{}) (*ShoppingListOutput, 
 func (a *App) getShoppingListHistory(ctx context.Context, _ *struct{}) (*ShoppingListHistoryOutput, error) {
 	userID := ctx.Value(contextKey("userID")).(string)
 
-	recentRecipes, err := service.GetRecentRecipeUsage(userID, 30, 10, a.db)
+	recentRecipes, err := service.GetRecentRecipeUsage(ctx, userID, 30, 10, a.db)
 	if err != nil {
 		log.Printf("Error getting recent recipes: %v", err)
 		return nil, huma.Error500InternalServerError("Error getting recent recipes")
 	}
 
-	favoriteRecipes, err := service.GetFavoriteRecipes(userID, 10, a.db)
+	favoriteRecipes, err := service.GetFavoriteRecipes(ctx, userID, 10, a.db)
 	if err != nil {
 		log.Printf("Error getting favorite recipes: %v", err)
 		return nil, huma.Error500InternalServerError("Error getting favorite recipes")
@@ -140,7 +140,7 @@ func (a *App) getShoppingListHistory(ctx context.Context, _ *struct{}) (*Shoppin
 }
 
 func (a *App) registerListRoutes(api huma.API) {
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "get-shopping-list",
 		Method:      http.MethodGet,
 		Path:        "/shopping-list",
@@ -148,7 +148,7 @@ func (a *App) registerListRoutes(api huma.API) {
 		Tags:        []string{"Shopping List"},
 	}, a.getList)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "create-shopping-list",
 		Method:      http.MethodPost,
 		Path:        "/shopping-list",
@@ -157,7 +157,7 @@ func (a *App) registerListRoutes(api huma.API) {
 		Tags:        []string{"Shopping List"},
 	}, a.createList)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "buy-shopping-list-item",
 		Method:      http.MethodPatch,
 		Path:        "/shopping-list/buy",
@@ -165,7 +165,7 @@ func (a *App) registerListRoutes(api huma.API) {
 		Tags:        []string{"Shopping List"},
 	}, a.buyListItem)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "add-extra-list-item",
 		Method:      http.MethodPost,
 		Path:        "/shopping-list/extra",
@@ -173,7 +173,7 @@ func (a *App) registerListRoutes(api huma.API) {
 		Tags:        []string{"Shopping List"},
 	}, a.addExtraListItem)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "clear-shopping-list",
 		Method:      http.MethodDelete,
 		Path:        "/shopping-list/clear",
@@ -181,7 +181,7 @@ func (a *App) registerListRoutes(api huma.API) {
 		Tags:        []string{"Shopping List"},
 	}, a.clearList)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "get-shopping-list-history",
 		Method:      http.MethodGet,
 		Path:        "/shopping-list/history",

--- a/netlify-functions/recipes/internal/pkg/app/recipe.go
+++ b/netlify-functions/recipes/internal/pkg/app/recipe.go
@@ -56,9 +56,9 @@ func (a *App) getRecipe(ctx context.Context, input *RecipeByIDInput) (*RecipeOut
 	var recipe *common.Recipe
 	var err error
 	if id, convErr := strconv.Atoi(input.ID); convErr == nil {
-		recipe, err = service.GetRecipeByID(id, userID, a.db)
+		recipe, err = service.GetRecipeByID(ctx, id, userID, a.db)
 	} else {
-		recipe, err = service.GetRecipeBySlug(input.ID, userID, a.db)
+		recipe, err = service.GetRecipeBySlug(ctx, input.ID, userID, a.db)
 	}
 
 	if err != nil {
@@ -74,7 +74,7 @@ func (a *App) getRecipe(ctx context.Context, input *RecipeByIDInput) (*RecipeOut
 func (a *App) addRecipe(ctx context.Context, input *RecipeInput) (*AddRecipeOutput, error) {
 	userID := ctx.Value(contextKey("userID")).(string)
 
-	id, err := service.AddRecipe(input.Body, userID, a.db)
+	id, err := service.AddRecipe(ctx, input.Body, userID, a.db)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("could not insert ingredients")
 	}
@@ -91,7 +91,7 @@ func (a *App) editRecipe(ctx context.Context, input *RecipeInput) (*StatusOutput
 		return nil, huma.Error400BadRequest("Error: missing id")
 	}
 
-	if err := service.EditRecipe(input.Body, userID, a.db); err != nil {
+	if err := service.EditRecipe(ctx, input.Body, userID, a.db); err != nil {
 		return nil, huma.Error500InternalServerError("could not update recipe")
 	}
 
@@ -124,7 +124,7 @@ func (a *App) deleteRecipe(ctx context.Context, input *DeleteRecipeInput) (*Stat
 		return nil, huma.Error400BadRequest("Error: missing id")
 	}
 
-	if err := service.DeleteRecipe(common.Recipe{ID: input.Body.ID}, userID, a.db); err != nil {
+	if err := service.DeleteRecipe(ctx, common.Recipe{ID: input.Body.ID}, userID, a.db); err != nil {
 		return nil, huma.Error500InternalServerError("could not delete recipe")
 	}
 
@@ -132,7 +132,7 @@ func (a *App) deleteRecipe(ctx context.Context, input *DeleteRecipeInput) (*Stat
 }
 
 func (a *App) registerRecipeRoutes(api huma.API) {
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "get-recipe",
 		Method:      http.MethodGet,
 		Path:        "/recipe/{id}",
@@ -141,7 +141,7 @@ func (a *App) registerRecipeRoutes(api huma.API) {
 		Tags:        []string{"Recipes"},
 	}, a.getRecipe)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID:   "add-recipe",
 		Method:        http.MethodPost,
 		Path:          "/recipe",
@@ -150,7 +150,7 @@ func (a *App) registerRecipeRoutes(api huma.API) {
 		DefaultStatus: http.StatusCreated,
 	}, a.addRecipe)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "edit-recipe",
 		Method:      http.MethodPut,
 		Path:        "/recipe",
@@ -158,7 +158,7 @@ func (a *App) registerRecipeRoutes(api huma.API) {
 		Tags:        []string{"Recipes"},
 	}, a.editRecipe)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "delete-recipe",
 		Method:      http.MethodDelete,
 		Path:        "/recipe",

--- a/netlify-functions/recipes/internal/pkg/app/recipe.go
+++ b/netlify-functions/recipes/internal/pkg/app/recipe.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"net/http"
 	"recipes/internal/pkg/common"
 	"recipes/internal/pkg/service"
@@ -62,7 +63,10 @@ func (a *App) getRecipe(ctx context.Context, input *RecipeByIDInput) (*RecipeOut
 	}
 
 	if err != nil {
-		if err == sql.ErrNoRows {
+		// errors.Is, not ==: the service layer wraps its errors now, and a
+		// sentinel compared by identity stops matching the moment anything in
+		// the call chain adds context to it.
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, huma.Error404NotFound("Recipe not found")
 		}
 		return nil, huma.Error500InternalServerError("Failed to parse recipe from db")

--- a/netlify-functions/recipes/internal/pkg/app/recipes.go
+++ b/netlify-functions/recipes/internal/pkg/app/recipes.go
@@ -48,7 +48,7 @@ func (a *App) getRecipes(ctx context.Context, _ *struct{}) (*RecipesOutput, erro
 }
 
 func (a *App) registerRecipesRoutes(api huma.API) {
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "list-recipes",
 		Method:      http.MethodGet,
 		Path:        "/recipes",

--- a/netlify-functions/recipes/internal/pkg/app/recipes.go
+++ b/netlify-functions/recipes/internal/pkg/app/recipes.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"log"
 	"net/http"
 
 	"recipes/internal/pkg/service"
@@ -26,8 +25,7 @@ func (a *App) getRecipes(ctx context.Context, _ *struct{}) (*RecipesOutput, erro
 	recipes, err := service.GetAllRecipes(ctx, a.db, userID)
 
 	if err != nil {
-		log.Println(err)
-		return nil, huma.Error500InternalServerError("Failed to get recipes from db")
+		return nil, fail(ctx, huma.Error500InternalServerError("Failed to get recipes from db"), err)
 	}
 
 	summaries := make([]RecipeSummary, len(recipes))

--- a/netlify-functions/recipes/internal/pkg/app/register.go
+++ b/netlify-functions/recipes/internal/pkg/app/register.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"net/http"
 
@@ -20,11 +21,11 @@ import (
 // A real `huma.UseMiddleware` middleware cannot do it: middleware sees
 // huma.Context, which exposes Status() but not the error the handler returned.
 // Recording from there would capture that *something* 500'd - which the status
-// code already says - and lose the cause entirely. That matters more after
-// Session 4 deletes the `log.Println(err)` calls, because at that point the
-// span is the only place the cause could live. Wrapping the handler is one
-// token per registration and no logic at any call site, which is the spirit of
-// the rule if not its letter.
+// code already says - and lose the cause entirely. That is now the whole ball
+// game: the `log.Println(err)` calls that used to hold the cause are gone, so
+// the span is the only place it lives. Wrapping the handler is one token per
+// registration and no logic at any call site, which is the spirit of the rule
+// if not its letter.
 func register[I, O any](api huma.API, op huma.Operation, handler func(context.Context, *I) (*O, error)) {
 	huma.Register(api, op, func(ctx context.Context, in *I) (*O, error) {
 		out, err := handler(ctx, in)
@@ -46,8 +47,8 @@ func statusOf(err error) int {
 	return http.StatusInternalServerError
 }
 
-// serverError records the real cause of a 500 on the request's span and returns
-// an error carrying only the client-facing message.
+// fail records the real cause on the request's span and returns the
+// client-facing error unchanged.
 //
 // Both halves matter, and doing it the obvious way gets both wrong. Passing the
 // cause to huma.Error500InternalServerError(msg, err) looks like it attaches it
@@ -59,10 +60,27 @@ func statusOf(err error) int {
 // the generic message and never the cause.
 //
 // So the cause goes to the span here, explicitly, and the returned error stays
-// opaque. register() will additionally record that outer message - two
-// exception events on the span, the cause and what the caller was told, which
-// is worth more than either alone when reading a trace back.
-func serverError(ctx context.Context, msg string, cause error) error {
-	telemetry.RecordHandlerError(ctx, cause, http.StatusInternalServerError)
-	return huma.Error500InternalServerError(msg)
+// whatever the handler decided the client should see. register() will
+// additionally record that outer message - two exception events on the span,
+// the cause and what the caller was told, which is worth more than either alone
+// when reading a trace back.
+//
+// The span is marked failed on the *cause*, not on the status the client is
+// told, and those are not the same judgement. Several handlers answer a failed
+// database call with a 400 or a 404 - app/invites.go does it three times - so
+// deriving the span status from the client's status would let a TiDB outage
+// record as a client mistake and vanish from the error rate. That is the
+// account.go bug ADR-0008 §3 describes, rebuilt out of status codes instead of
+// messages.
+//
+// sql.ErrNoRows is the exception, because it is the one cause that is routinely
+// *expected*: "no such Recipe" is the API working. Its cause is still recorded,
+// only the red flag is withheld.
+func fail(ctx context.Context, clientErr, cause error) error {
+	status := http.StatusInternalServerError
+	if errors.Is(cause, sql.ErrNoRows) {
+		status = statusOf(clientErr)
+	}
+	telemetry.RecordHandlerError(ctx, cause, status)
+	return clientErr
 }

--- a/netlify-functions/recipes/internal/pkg/app/register.go
+++ b/netlify-functions/recipes/internal/pkg/app/register.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"recipes/internal/pkg/telemetry"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// register is huma.Register with error recording wrapped around the handler.
+//
+// ADR-0008 §3 asks for "a single error-recording middleware at the handler
+// boundary [that] calls span.RecordError and sets the span status, capturing
+// every handler error with no per-call-site work". This is that, in the only
+// shape Huma actually allows.
+//
+// A real `huma.UseMiddleware` middleware cannot do it: middleware sees
+// huma.Context, which exposes Status() but not the error the handler returned.
+// Recording from there would capture that *something* 500'd - which the status
+// code already says - and lose the cause entirely. That matters more after
+// Session 4 deletes the `log.Println(err)` calls, because at that point the
+// span is the only place the cause could live. Wrapping the handler is one
+// token per registration and no logic at any call site, which is the spirit of
+// the rule if not its letter.
+func register[I, O any](api huma.API, op huma.Operation, handler func(context.Context, *I) (*O, error)) {
+	huma.Register(api, op, func(ctx context.Context, in *I) (*O, error) {
+		out, err := handler(ctx, in)
+		if err != nil {
+			telemetry.RecordHandlerError(ctx, err, statusOf(err))
+		}
+		return out, err
+	})
+}
+
+// statusOf digs the HTTP status out of a Huma error, defaulting to 500 for
+// anything that is not one - an unwrapped error escaping a handler is a bug,
+// and 500 is both what Huma will send and the right thing to flag.
+func statusOf(err error) int {
+	var se huma.StatusError
+	if errors.As(err, &se) {
+		return se.GetStatus()
+	}
+	return http.StatusInternalServerError
+}
+
+// serverError records the real cause of a 500 on the request's span and returns
+// an error carrying only the client-facing message.
+//
+// Both halves matter, and doing it the obvious way gets both wrong. Passing the
+// cause to huma.Error500InternalServerError(msg, err) looks like it attaches it
+// for us; what it actually does is append err.Error() to ErrorModel.Errors,
+// which is tagged `json:"errors,omitempty"` and therefore **serialised to the
+// client** - so a TiDB failure would put its connection string or schema detail
+// in an HTTP response body. And it would still not reach the span, because
+// ErrorModel.Error() returns only Detail, so register()'s span.RecordError sees
+// the generic message and never the cause.
+//
+// So the cause goes to the span here, explicitly, and the returned error stays
+// opaque. register() will additionally record that outer message - two
+// exception events on the span, the cause and what the caller was told, which
+// is worth more than either alone when reading a trace back.
+func serverError(ctx context.Context, msg string, cause error) error {
+	telemetry.RecordHandlerError(ctx, cause, http.StatusInternalServerError)
+	return huma.Error500InternalServerError(msg)
+}

--- a/netlify-functions/recipes/internal/pkg/app/tags.go
+++ b/netlify-functions/recipes/internal/pkg/app/tags.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"log"
 	"net/http"
 
 	"recipes/internal/pkg/service"
@@ -48,8 +47,7 @@ func (a *App) getTags(ctx context.Context, _ *struct{}) (*TagsOutput, error) {
 	tags, err := service.GetAllTags(ctx, a.db)
 
 	if err != nil {
-		log.Println(err)
-		return nil, huma.Error500InternalServerError("Failed to get tags from db")
+		return nil, fail(ctx, huma.Error500InternalServerError("Failed to get tags from db"), err)
 	}
 
 	// Success path only. An error returns before this, so the 500 keeps the

--- a/netlify-functions/recipes/internal/pkg/app/tags.go
+++ b/netlify-functions/recipes/internal/pkg/app/tags.go
@@ -45,7 +45,7 @@ func (o *TagsOutput) withCachePolicy() *TagsOutput {
 }
 
 func (a *App) getTags(ctx context.Context, _ *struct{}) (*TagsOutput, error) {
-	tags, err := service.GetAllTags(a.db)
+	tags, err := service.GetAllTags(ctx, a.db)
 
 	if err != nil {
 		log.Println(err)
@@ -58,7 +58,7 @@ func (a *App) getTags(ctx context.Context, _ *struct{}) (*TagsOutput, error) {
 }
 
 func (a *App) registerTagsRoutes(api huma.API) {
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "list-tags",
 		Method:      http.MethodGet,
 		Path:        "/tags",

--- a/netlify-functions/recipes/internal/pkg/app/units.go
+++ b/netlify-functions/recipes/internal/pkg/app/units.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"log"
 	"net/http"
 
 	"recipes/internal/pkg/service"
@@ -60,8 +59,7 @@ func (a *App) getUnits(ctx context.Context, _ *struct{}) (*UnitsOutput, error) {
 	units, err := service.GetAllUnits(ctx, a.db)
 
 	if err != nil {
-		log.Println(err)
-		return nil, huma.Error500InternalServerError("Failed to get units from db")
+		return nil, fail(ctx, huma.Error500InternalServerError("Failed to get units from db"), err)
 	}
 
 	// Success path only - Huma writes an output struct's headers only when it

--- a/netlify-functions/recipes/internal/pkg/app/units.go
+++ b/netlify-functions/recipes/internal/pkg/app/units.go
@@ -57,7 +57,7 @@ func (o *UnitsOutput) withCachePolicy() *UnitsOutput {
 }
 
 func (a *App) getUnits(ctx context.Context, _ *struct{}) (*UnitsOutput, error) {
-	units, err := service.GetAllUnits(a.db)
+	units, err := service.GetAllUnits(ctx, a.db)
 
 	if err != nil {
 		log.Println(err)
@@ -71,7 +71,7 @@ func (a *App) getUnits(ctx context.Context, _ *struct{}) (*UnitsOutput, error) {
 }
 
 func (a *App) registerUnitsRoutes(api huma.API) {
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "list-units",
 		Method:      http.MethodGet,
 		Path:        "/units",

--- a/netlify-functions/recipes/internal/pkg/app/user.go
+++ b/netlify-functions/recipes/internal/pkg/app/user.go
@@ -28,12 +28,12 @@ func (a *App) addUser(ctx context.Context, input *UserInput) (*UserOutput, error
 	user := input.Body
 	user.ID = ctx.Value(contextKey("userID")).(string)
 
-	if err := service.AddUser(a.db, user); err != nil {
+	if err := service.AddUser(ctx, a.db, user); err != nil {
 		log.Println("Error: could not add new user")
 		return nil, huma.Error500InternalServerError("could not add new user")
 	}
 
-	if err := service.CreateAccount(a.db, user); err != nil {
+	if err := service.CreateAccount(ctx, a.db, user); err != nil {
 		log.Println("Error creating account for user")
 		return nil, huma.Error500InternalServerError("Error creating account for user")
 	}
@@ -41,7 +41,7 @@ func (a *App) addUser(ctx context.Context, input *UserInput) (*UserOutput, error
 	// Re-fetch rather than echoing the input body: `onboarded` is server-managed
 	// (untouched by the upsert in AddUser for existing rows), so the caller needs
 	// the DB's current value to know whether to show the onboarding screen.
-	saved, err := service.GetUser(a.db, user.ID)
+	saved, err := service.GetUser(ctx, a.db, user.ID)
 	if err != nil {
 		log.Println("Error fetching saved user")
 		return nil, huma.Error500InternalServerError("Error fetching saved user")
@@ -67,7 +67,7 @@ type PreferencesInput struct {
 func (a *App) getUser(ctx context.Context, _ *struct{}) (*UserOutput, error) {
 	userID := ctx.Value(contextKey("userID")).(string)
 
-	user, err := service.GetUser(a.db, userID)
+	user, err := service.GetUser(ctx, a.db, userID)
 	if err != nil {
 		// Also the no-rows case: someone who reached an inner page before POST
 		// /user ever ran for them. Not a server fault, and the client treats it
@@ -82,12 +82,12 @@ func (a *App) getUser(ctx context.Context, _ *struct{}) (*UserOutput, error) {
 func (a *App) setPreferences(ctx context.Context, input *PreferencesInput) (*UserOutput, error) {
 	userID := ctx.Value(contextKey("userID")).(string)
 
-	if err := service.SetShowPantryStaples(a.db, userID, input.Body.ShowPantryStaples); err != nil {
+	if err := service.SetShowPantryStaples(ctx, a.db, userID, input.Body.ShowPantryStaples); err != nil {
 		log.Println("Error saving preferences")
 		return nil, huma.Error500InternalServerError("could not save preferences")
 	}
 
-	saved, err := service.GetUser(a.db, userID)
+	saved, err := service.GetUser(ctx, a.db, userID)
 	if err != nil {
 		log.Println("Error fetching saved user")
 		return nil, huma.Error500InternalServerError("Error fetching saved user")
@@ -99,12 +99,12 @@ func (a *App) setPreferences(ctx context.Context, input *PreferencesInput) (*Use
 func (a *App) completeOnboarding(ctx context.Context, _ *struct{}) (*UserOutput, error) {
 	userID := ctx.Value(contextKey("userID")).(string)
 
-	if err := service.SetOnboarded(a.db, userID); err != nil {
+	if err := service.SetOnboarded(ctx, a.db, userID); err != nil {
 		log.Println("Error completing onboarding")
 		return nil, huma.Error500InternalServerError("could not complete onboarding")
 	}
 
-	saved, err := service.GetUser(a.db, userID)
+	saved, err := service.GetUser(ctx, a.db, userID)
 	if err != nil {
 		log.Println("Error fetching saved user")
 		return nil, huma.Error500InternalServerError("Error fetching saved user")
@@ -117,13 +117,13 @@ func (a *App) inviteUser(ctx context.Context, input *UserInput) (*struct{}, erro
 	currentUserID := ctx.Value(contextKey("userID")).(string)
 	userToInvite := input.Body
 
-	currentUser, err := service.GetUser(a.db, currentUserID)
+	currentUser, err := service.GetUser(ctx, a.db, currentUserID)
 	if err != nil {
 		log.Println("Error finding current user")
 		return nil, huma.Error400BadRequest("Error finding current user")
 	}
 
-	account, err := service.GetAccount(a.db, currentUserID)
+	account, err := service.GetAccount(ctx, a.db, currentUserID)
 	if err != nil {
 		log.Println("Error finding account for current user")
 		return nil, huma.Error400BadRequest("Error finding account for current user")
@@ -131,7 +131,7 @@ func (a *App) inviteUser(ctx context.Context, input *UserInput) (*struct{}, erro
 
 	// Generate a token and write it to the invites table
 	token, _ := common.RandToken(32)
-	if err := service.CreateInvite(a.db, token, account.ID, userToInvite.Email, currentUserID); err != nil {
+	if err := service.CreateInvite(ctx, a.db, token, account.ID, userToInvite.Email, currentUserID); err != nil {
 		log.Println("Error creating Invite")
 		return nil, huma.Error500InternalServerError("Error creating Invite")
 	}
@@ -156,7 +156,7 @@ func (a *App) inviteUser(ctx context.Context, input *UserInput) (*struct{}, erro
 }
 
 func (a *App) registerUserRoutes(api huma.API) {
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "add-user",
 		Method:      http.MethodPost,
 		Path:        "/user",
@@ -164,7 +164,7 @@ func (a *App) registerUserRoutes(api huma.API) {
 		Tags:        []string{"Users"},
 	}, a.addUser)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "get-user",
 		Method:      http.MethodGet,
 		Path:        "/user",
@@ -172,7 +172,7 @@ func (a *App) registerUserRoutes(api huma.API) {
 		Tags:        []string{"Users"},
 	}, a.getUser)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "set-preferences",
 		Method:      http.MethodPatch,
 		Path:        "/user/preferences",
@@ -180,7 +180,7 @@ func (a *App) registerUserRoutes(api huma.API) {
 		Tags:        []string{"Users"},
 	}, a.setPreferences)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "complete-onboarding",
 		Method:      http.MethodPatch,
 		Path:        "/user/onboarding",
@@ -188,7 +188,7 @@ func (a *App) registerUserRoutes(api huma.API) {
 		Tags:        []string{"Users"},
 	}, a.completeOnboarding)
 
-	huma.Register(api, huma.Operation{
+	register(api, huma.Operation{
 		OperationID: "invite-user",
 		Method:      http.MethodPost,
 		Path:        "/invite",

--- a/netlify-functions/recipes/internal/pkg/app/user.go
+++ b/netlify-functions/recipes/internal/pkg/app/user.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"recipes/internal/pkg/common"
@@ -29,13 +28,11 @@ func (a *App) addUser(ctx context.Context, input *UserInput) (*UserOutput, error
 	user.ID = ctx.Value(contextKey("userID")).(string)
 
 	if err := service.AddUser(ctx, a.db, user); err != nil {
-		log.Println("Error: could not add new user")
-		return nil, huma.Error500InternalServerError("could not add new user")
+		return nil, fail(ctx, huma.Error500InternalServerError("could not add new user"), err)
 	}
 
 	if err := service.CreateAccount(ctx, a.db, user); err != nil {
-		log.Println("Error creating account for user")
-		return nil, huma.Error500InternalServerError("Error creating account for user")
+		return nil, fail(ctx, huma.Error500InternalServerError("Error creating account for user"), err)
 	}
 
 	// Re-fetch rather than echoing the input body: `onboarded` is server-managed
@@ -43,8 +40,7 @@ func (a *App) addUser(ctx context.Context, input *UserInput) (*UserOutput, error
 	// the DB's current value to know whether to show the onboarding screen.
 	saved, err := service.GetUser(ctx, a.db, user.ID)
 	if err != nil {
-		log.Println("Error fetching saved user")
-		return nil, huma.Error500InternalServerError("Error fetching saved user")
+		return nil, fail(ctx, huma.Error500InternalServerError("Error fetching saved user"), err)
 	}
 
 	return &UserOutput{Body: *saved}, nil
@@ -72,8 +68,7 @@ func (a *App) getUser(ctx context.Context, _ *struct{}) (*UserOutput, error) {
 		// Also the no-rows case: someone who reached an inner page before POST
 		// /user ever ran for them. Not a server fault, and the client treats it
 		// as "no preferences recorded yet" rather than as an error.
-		log.Println("Error fetching user")
-		return nil, huma.Error404NotFound("user not found")
+		return nil, fail(ctx, huma.Error404NotFound("user not found"), err)
 	}
 
 	return &UserOutput{Body: *user}, nil
@@ -83,14 +78,12 @@ func (a *App) setPreferences(ctx context.Context, input *PreferencesInput) (*Use
 	userID := ctx.Value(contextKey("userID")).(string)
 
 	if err := service.SetShowPantryStaples(ctx, a.db, userID, input.Body.ShowPantryStaples); err != nil {
-		log.Println("Error saving preferences")
-		return nil, huma.Error500InternalServerError("could not save preferences")
+		return nil, fail(ctx, huma.Error500InternalServerError("could not save preferences"), err)
 	}
 
 	saved, err := service.GetUser(ctx, a.db, userID)
 	if err != nil {
-		log.Println("Error fetching saved user")
-		return nil, huma.Error500InternalServerError("Error fetching saved user")
+		return nil, fail(ctx, huma.Error500InternalServerError("Error fetching saved user"), err)
 	}
 
 	return &UserOutput{Body: *saved}, nil
@@ -100,14 +93,12 @@ func (a *App) completeOnboarding(ctx context.Context, _ *struct{}) (*UserOutput,
 	userID := ctx.Value(contextKey("userID")).(string)
 
 	if err := service.SetOnboarded(ctx, a.db, userID); err != nil {
-		log.Println("Error completing onboarding")
-		return nil, huma.Error500InternalServerError("could not complete onboarding")
+		return nil, fail(ctx, huma.Error500InternalServerError("could not complete onboarding"), err)
 	}
 
 	saved, err := service.GetUser(ctx, a.db, userID)
 	if err != nil {
-		log.Println("Error fetching saved user")
-		return nil, huma.Error500InternalServerError("Error fetching saved user")
+		return nil, fail(ctx, huma.Error500InternalServerError("Error fetching saved user"), err)
 	}
 
 	return &UserOutput{Body: *saved}, nil
@@ -119,21 +110,18 @@ func (a *App) inviteUser(ctx context.Context, input *UserInput) (*struct{}, erro
 
 	currentUser, err := service.GetUser(ctx, a.db, currentUserID)
 	if err != nil {
-		log.Println("Error finding current user")
-		return nil, huma.Error400BadRequest("Error finding current user")
+		return nil, fail(ctx, huma.Error400BadRequest("Error finding current user"), err)
 	}
 
 	account, err := service.GetAccount(ctx, a.db, currentUserID)
 	if err != nil {
-		log.Println("Error finding account for current user")
-		return nil, huma.Error400BadRequest("Error finding account for current user")
+		return nil, fail(ctx, huma.Error400BadRequest("Error finding account for current user"), err)
 	}
 
 	// Generate a token and write it to the invites table
 	token, _ := common.RandToken(32)
 	if err := service.CreateInvite(ctx, a.db, token, account.ID, userToInvite.Email, currentUserID); err != nil {
-		log.Println("Error creating Invite")
-		return nil, huma.Error500InternalServerError("Error creating Invite")
+		return nil, fail(ctx, huma.Error500InternalServerError("Error creating Invite"), err)
 	}
 
 	// Send the email
@@ -148,8 +136,7 @@ func (a *App) inviteUser(ctx context.Context, input *UserInput) (*struct{}, erro
 	message := mail.NewSingleEmail(from, subject, to, "", fmt.Sprintf(htmlContent, currentUser.Name, token))
 	client := sendgrid.NewSendClient(os.Getenv("SENDGRID_API_KEY"))
 	if _, err := client.Send(message); err != nil {
-		log.Println(err)
-		return nil, huma.Error400BadRequest("Error sending email")
+		return nil, fail(ctx, huma.Error400BadRequest("Error sending email"), err)
 	}
 
 	return nil, nil

--- a/netlify-functions/recipes/internal/pkg/service/account.go
+++ b/netlify-functions/recipes/internal/pkg/service/account.go
@@ -1,23 +1,24 @@
 package service
 
 import (
+	"context"
 	"database/sql"
 	"log"
 	"recipes/internal/pkg/common"
 )
 
 // CreateAccount creates a new account for a user
-func CreateAccount(db *sql.DB, user common.User) error {
+func CreateAccount(ctx context.Context, db *sql.DB, user common.User) error {
 	var accountID int
 	accountQuery := `SELECT account_id FROM account_user WHERE user_id = ?`
-	err := db.QueryRow(accountQuery, user.ID).Scan(accountID)
+	err := db.QueryRowContext(ctx, accountQuery, user.ID).Scan(accountID)
 	if err != nil && err == sql.ErrNoRows {
 		// create a new account
-		res, _ := db.Exec(`INSERT INTO account (id) VALUES (null)`)
+		res, _ := db.ExecContext(ctx, `INSERT INTO account (id) VALUES (null)`)
 		id, _ := res.LastInsertId()
 		accountID = int(id)
 		accountUserQuery := `INSERT INTO account_user (user_id, account_id) VALUES (?, ?)`
-		_, err = db.Exec(accountUserQuery, user.ID, accountID)
+		_, err = db.ExecContext(ctx, accountUserQuery, user.ID, accountID)
 		if err != nil {
 			log.Println("Error creating new account")
 			return err
@@ -27,18 +28,18 @@ func CreateAccount(db *sql.DB, user common.User) error {
 }
 
 // GetAccountID returns the account ID for a user
-func GetAccountID(db dbConn, userID string) (int, error) {
+func GetAccountID(ctx context.Context, db dbConn, userID string) (int, error) {
 	var accountID int
 	accountQuery := `SELECT account_id from account_user WHERE user_id = ? AND enabled = true;`
-	if err := db.QueryRow(accountQuery, userID).Scan(&accountID); err != nil {
+	if err := db.QueryRowContext(ctx, accountQuery, userID).Scan(&accountID); err != nil {
 		// TODO: Return an error of type unknown user
 		return 0, err
 	}
 	return accountID, nil
 }
 
-func GetAccount(db *sql.DB, userID string) (a *common.Account, e error) {
-	accountID, err := GetAccountID(db, userID)
+func GetAccount(ctx context.Context, db *sql.DB, userID string) (a *common.Account, e error) {
+	accountID, err := GetAccountID(ctx, db, userID)
 
 	if err != nil {
 		log.Println("Error querying account table")
@@ -50,7 +51,7 @@ func GetAccount(db *sql.DB, userID string) (a *common.Account, e error) {
 			LEFT JOIN user on user.id = account_user.user_id
 			WHERE account_id = ? AND enabled = true;
 	`
-	results, err := db.Query(accountQuery, accountID)
+	results, err := db.QueryContext(ctx, accountQuery, accountID)
 
 	if err != nil {
 		log.Println("Error querying account table")
@@ -75,20 +76,20 @@ func GetAccount(db *sql.DB, userID string) (a *common.Account, e error) {
 	return account, nil
 }
 
-func AddUserToAccount(db *sql.DB, accountID int, user common.User) error {
+func AddUserToAccount(ctx context.Context, db *sql.DB, accountID int, user common.User) error {
 	// TODO: if the user doesn't exist in our user table we need to add them first
 	// Exec, not Query: these are writes, and Query returns an *sql.Rows that
 	// nothing closed - holding the connection until the garbage collector got
 	// to it. The first one's error was also being discarded entirely.
 	userQuery := `INSERT INTO user (id, name) VALUES (?,?) ON DUPLICATE KEY UPDATE id=id;`
-	if _, err := db.Exec(userQuery, user.ID, user.Name); err != nil {
+	if _, err := db.ExecContext(ctx, userQuery, user.ID, user.Name); err != nil {
 		log.Println("Error adding user")
 		log.Println(err)
 		return err
 	}
 
 	accountQuery := `INSERT INTO account_user (user_id, account_id) VALUES (?,?);`
-	_, err := db.Exec(accountQuery, user.ID, accountID)
+	_, err := db.ExecContext(ctx, accountQuery, user.ID, accountID)
 	if err != nil {
 		log.Println("Error adding user to account")
 		log.Println(err)
@@ -97,9 +98,9 @@ func AddUserToAccount(db *sql.DB, accountID int, user common.User) error {
 	return nil
 }
 
-func DisableUserAccount(db *sql.DB, user common.User) error {
+func DisableUserAccount(ctx context.Context, db *sql.DB, user common.User) error {
 	query := `UPDATE account_user SET enabled = false WHERE user_id = ?`
-	_, err := db.Exec(query, user.ID)
+	_, err := db.ExecContext(ctx, query, user.ID)
 	if err != nil {
 		log.Println("Error disable user account")
 		log.Println(err)
@@ -108,9 +109,9 @@ func DisableUserAccount(db *sql.DB, user common.User) error {
 	return nil
 }
 
-func RemoveUserFromAccount(db *sql.DB, accountID int, user common.User) error {
+func RemoveUserFromAccount(ctx context.Context, db *sql.DB, accountID int, user common.User) error {
 	accountQuery := `DELETE FROM account_user WHERE user_id = ? AND account_id = ?;`
-	_, err := db.Exec(accountQuery, user.ID, accountID)
+	_, err := db.ExecContext(ctx, accountQuery, user.ID, accountID)
 	if err != nil {
 		log.Println("Error removing user from account")
 		return err

--- a/netlify-functions/recipes/internal/pkg/service/account.go
+++ b/netlify-functions/recipes/internal/pkg/service/account.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 	"database/sql"
-	"log"
+	"fmt"
 	"recipes/internal/pkg/common"
 )
 
@@ -14,14 +14,18 @@ func CreateAccount(ctx context.Context, db *sql.DB, user common.User) error {
 	err := db.QueryRowContext(ctx, accountQuery, user.ID).Scan(accountID)
 	if err != nil && err == sql.ErrNoRows {
 		// create a new account
-		res, _ := db.ExecContext(ctx, `INSERT INTO account (id) VALUES (null)`)
-		id, _ := res.LastInsertId()
+		res, err := db.ExecContext(ctx, `INSERT INTO account (id) VALUES (null)`)
+		if err != nil {
+			return fmt.Errorf("creating account: %w", err)
+		}
+		id, err := res.LastInsertId()
+		if err != nil {
+			return fmt.Errorf("reading new account id: %w", err)
+		}
 		accountID = int(id)
 		accountUserQuery := `INSERT INTO account_user (user_id, account_id) VALUES (?, ?)`
-		_, err = db.ExecContext(ctx, accountUserQuery, user.ID, accountID)
-		if err != nil {
-			log.Println("Error creating new account")
-			return err
+		if _, err := db.ExecContext(ctx, accountUserQuery, user.ID, accountID); err != nil {
+			return fmt.Errorf("linking user to new account: %w", err)
 		}
 	}
 	return nil
@@ -42,8 +46,7 @@ func GetAccount(ctx context.Context, db *sql.DB, userID string) (a *common.Accou
 	accountID, err := GetAccountID(ctx, db, userID)
 
 	if err != nil {
-		log.Println("Error querying account table")
-		return nil, err
+		return nil, fmt.Errorf("resolving account: %w", err)
 	}
 
 	accountQuery := `
@@ -54,8 +57,7 @@ func GetAccount(ctx context.Context, db *sql.DB, userID string) (a *common.Accou
 	results, err := db.QueryContext(ctx, accountQuery, accountID)
 
 	if err != nil {
-		log.Println("Error querying account table")
-		return nil, err
+		return nil, fmt.Errorf("querying the account's users: %w", err)
 	}
 	defer results.Close()
 
@@ -83,17 +85,13 @@ func AddUserToAccount(ctx context.Context, db *sql.DB, accountID int, user commo
 	// to it. The first one's error was also being discarded entirely.
 	userQuery := `INSERT INTO user (id, name) VALUES (?,?) ON DUPLICATE KEY UPDATE id=id;`
 	if _, err := db.ExecContext(ctx, userQuery, user.ID, user.Name); err != nil {
-		log.Println("Error adding user")
-		log.Println(err)
-		return err
+		return fmt.Errorf("adding user: %w", err)
 	}
 
 	accountQuery := `INSERT INTO account_user (user_id, account_id) VALUES (?,?);`
 	_, err := db.ExecContext(ctx, accountQuery, user.ID, accountID)
 	if err != nil {
-		log.Println("Error adding user to account")
-		log.Println(err)
-		return err
+		return fmt.Errorf("adding user to account: %w", err)
 	}
 	return nil
 }
@@ -102,9 +100,7 @@ func DisableUserAccount(ctx context.Context, db *sql.DB, user common.User) error
 	query := `UPDATE account_user SET enabled = false WHERE user_id = ?`
 	_, err := db.ExecContext(ctx, query, user.ID)
 	if err != nil {
-		log.Println("Error disable user account")
-		log.Println(err)
-		return err
+		return fmt.Errorf("disabling user account: %w", err)
 	}
 	return nil
 }
@@ -113,8 +109,7 @@ func RemoveUserFromAccount(ctx context.Context, db *sql.DB, accountID int, user 
 	accountQuery := `DELETE FROM account_user WHERE user_id = ? AND account_id = ?;`
 	_, err := db.ExecContext(ctx, accountQuery, user.ID, accountID)
 	if err != nil {
-		log.Println("Error removing user from account")
-		return err
+		return fmt.Errorf("removing user from account: %w", err)
 	}
 	return nil
 }

--- a/netlify-functions/recipes/internal/pkg/service/catalog.go
+++ b/netlify-functions/recipes/internal/pkg/service/catalog.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"database/sql"
 )
 
@@ -79,10 +80,10 @@ func (i IngredientInfo) UnitSize(unit string, units UnitCatalog) (float64, bool)
 // Only Ingredients with something curated appear; IngredientCatalog.Get
 // supplies the default for everything else, so this doesn't need a row per
 // Ingredient just to say "nothing set".
-func GetIngredientCatalog(db *sql.DB, units UnitCatalog) (IngredientCatalog, error) {
+func GetIngredientCatalog(ctx context.Context, db *sql.DB, units UnitCatalog) (IngredientCatalog, error) {
 	catalog := make(IngredientCatalog)
 
-	baseUnits, err := db.Query(`
+	baseUnits, err := db.QueryContext(ctx, `
 		SELECT ingredient.name, base.name, display.name, ingredient.pantry_staple
 		FROM ingredient
 		LEFT JOIN unit AS base ON base.id = ingredient.base_unit_id
@@ -125,7 +126,7 @@ func GetIngredientCatalog(db *sql.DB, units UnitCatalog) (IngredientCatalog, err
 		return nil, err
 	}
 
-	sizes, err := db.Query(`
+	sizes, err := db.QueryContext(ctx, `
 		SELECT ingredient.name, unit.name, ingredient_unit_size.size
 		FROM ingredient_unit_size
 		INNER JOIN ingredient ON ingredient.id = ingredient_unit_size.ingredient_id

--- a/netlify-functions/recipes/internal/pkg/service/history.go
+++ b/netlify-functions/recipes/internal/pkg/service/history.go
@@ -10,7 +10,7 @@ import (
 func LogShoppingListEvent(ctx context.Context, userID string, eventType string, recipeIDs []int, db *sql.DB) error {
 	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
-		return fmt.Errorf("could not get account ID: %v", err)
+		return fmt.Errorf("could not get account ID: %w", err)
 	}
 
 	// Log each recipe as a separate event
@@ -21,7 +21,7 @@ func LogShoppingListEvent(ctx context.Context, userID string, eventType string, 
 			VALUES (?, ?, ?)
 		`
 		if _, err := db.ExecContext(ctx, query, accountID, eventType, recipeID); err != nil {
-			return fmt.Errorf("could not log shopping list event: %v", err)
+			return fmt.Errorf("could not log shopping list event: %w", err)
 		}
 	}
 	return nil
@@ -31,7 +31,7 @@ func LogShoppingListEvent(ctx context.Context, userID string, eventType string, 
 func LogShoppingListClearEvent(ctx context.Context, userID string, db *sql.DB) error {
 	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
-		return fmt.Errorf("could not get account ID: %v", err)
+		return fmt.Errorf("could not get account ID: %w", err)
 	}
 
 	query := `
@@ -40,7 +40,7 @@ func LogShoppingListClearEvent(ctx context.Context, userID string, db *sql.DB) e
 		VALUES (?, 'clear_list')
 	`
 	if _, err := db.ExecContext(ctx, query, accountID); err != nil {
-		return fmt.Errorf("could not log clear event: %v", err)
+		return fmt.Errorf("could not log clear event: %w", err)
 	}
 	return nil
 }
@@ -50,7 +50,7 @@ func LogShoppingListClearEvent(ctx context.Context, userID string, db *sql.DB) e
 func GetRecentRecipeUsage(ctx context.Context, userID string, daysBack int, limit int, db *sql.DB) ([]int, error) {
 	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
-		return nil, fmt.Errorf("could not get account ID: %v", err)
+		return nil, fmt.Errorf("could not get account ID: %w", err)
 	}
 
 	query := `
@@ -71,7 +71,7 @@ func GetRecentRecipeUsage(ctx context.Context, userID string, daysBack int, limi
 
 	rows, err := db.QueryContext(ctx, query, accountID, daysBack, limit)
 	if err != nil {
-		return nil, fmt.Errorf("could not query recent usage: %v", err)
+		return nil, fmt.Errorf("could not query recent usage: %w", err)
 	}
 	defer rows.Close()
 
@@ -80,7 +80,7 @@ func GetRecentRecipeUsage(ctx context.Context, userID string, daysBack int, limi
 		var recipeID int
 		var lastUsed string // We don't need the date, just the ID
 		if err := rows.Scan(&recipeID, &lastUsed); err != nil {
-			return nil, fmt.Errorf("could not scan recipe usage: %v", err)
+			return nil, fmt.Errorf("could not scan recipe usage: %w", err)
 		}
 		recentRecipeIDs = append(recentRecipeIDs, recipeID)
 	}
@@ -93,7 +93,7 @@ func GetRecentRecipeUsage(ctx context.Context, userID string, daysBack int, limi
 func GetFavoriteRecipes(ctx context.Context, userID string, limit int, db *sql.DB) ([]int, error) {
 	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
-		return nil, fmt.Errorf("could not get account ID: %v", err)
+		return nil, fmt.Errorf("could not get account ID: %w", err)
 	}
 
 	query := `
@@ -114,7 +114,7 @@ func GetFavoriteRecipes(ctx context.Context, userID string, limit int, db *sql.D
 
 	rows, err := db.QueryContext(ctx, query, accountID, limit)
 	if err != nil {
-		return nil, fmt.Errorf("could not query favorites: %v", err)
+		return nil, fmt.Errorf("could not query favorites: %w", err)
 	}
 	defer rows.Close()
 
@@ -123,7 +123,7 @@ func GetFavoriteRecipes(ctx context.Context, userID string, limit int, db *sql.D
 		var recipeID int
 		var usageCount int
 		if err := rows.Scan(&recipeID, &usageCount); err != nil {
-			return nil, fmt.Errorf("could not scan favorite recipes: %v", err)
+			return nil, fmt.Errorf("could not scan favorite recipes: %w", err)
 		}
 		favoriteRecipeIDs = append(favoriteRecipeIDs, recipeID)
 	}

--- a/netlify-functions/recipes/internal/pkg/service/history.go
+++ b/netlify-functions/recipes/internal/pkg/service/history.go
@@ -1,13 +1,14 @@
 package service
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 )
 
 // LogShoppingListEvent logs shopping list changes for meal planning intelligence
-func LogShoppingListEvent(userID string, eventType string, recipeIDs []int, db *sql.DB) error {
-	accountID, err := GetAccountID(db, userID)
+func LogShoppingListEvent(ctx context.Context, userID string, eventType string, recipeIDs []int, db *sql.DB) error {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		return fmt.Errorf("could not get account ID: %v", err)
 	}
@@ -19,7 +20,7 @@ func LogShoppingListEvent(userID string, eventType string, recipeIDs []int, db *
 			(account_id, event_type, recipe_id)
 			VALUES (?, ?, ?)
 		`
-		if _, err := db.Exec(query, accountID, eventType, recipeID); err != nil {
+		if _, err := db.ExecContext(ctx, query, accountID, eventType, recipeID); err != nil {
 			return fmt.Errorf("could not log shopping list event: %v", err)
 		}
 	}
@@ -27,8 +28,8 @@ func LogShoppingListEvent(userID string, eventType string, recipeIDs []int, db *
 }
 
 // LogShoppingListClearEvent logs when user clears the shopping list
-func LogShoppingListClearEvent(userID string, db *sql.DB) error {
-	accountID, err := GetAccountID(db, userID)
+func LogShoppingListClearEvent(ctx context.Context, userID string, db *sql.DB) error {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		return fmt.Errorf("could not get account ID: %v", err)
 	}
@@ -38,7 +39,7 @@ func LogShoppingListClearEvent(userID string, db *sql.DB) error {
 		(account_id, event_type)
 		VALUES (?, 'clear_list')
 	`
-	if _, err := db.Exec(query, accountID); err != nil {
+	if _, err := db.ExecContext(ctx, query, accountID); err != nil {
 		return fmt.Errorf("could not log clear event: %v", err)
 	}
 	return nil
@@ -46,8 +47,8 @@ func LogShoppingListClearEvent(userID string, db *sql.DB) error {
 
 // GetRecentRecipeUsage returns recently used recipes for meal planning
 // Groups by date to avoid counting bulk shopping list updates as multiple uses
-func GetRecentRecipeUsage(userID string, daysBack int, limit int, db *sql.DB) ([]int, error) {
-	accountID, err := GetAccountID(db, userID)
+func GetRecentRecipeUsage(ctx context.Context, userID string, daysBack int, limit int, db *sql.DB) ([]int, error) {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		return nil, fmt.Errorf("could not get account ID: %v", err)
 	}
@@ -68,7 +69,7 @@ func GetRecentRecipeUsage(userID string, daysBack int, limit int, db *sql.DB) ([
 		LIMIT ?
 	`
 
-	rows, err := db.Query(query, accountID, daysBack, limit)
+	rows, err := db.QueryContext(ctx, query, accountID, daysBack, limit)
 	if err != nil {
 		return nil, fmt.Errorf("could not query recent usage: %v", err)
 	}
@@ -89,8 +90,8 @@ func GetRecentRecipeUsage(userID string, daysBack int, limit int, db *sql.DB) ([
 
 // GetFavoriteRecipes returns most frequently used recipes
 // Groups by date to avoid counting bulk shopping list updates as multiple uses
-func GetFavoriteRecipes(userID string, limit int, db *sql.DB) ([]int, error) {
-	accountID, err := GetAccountID(db, userID)
+func GetFavoriteRecipes(ctx context.Context, userID string, limit int, db *sql.DB) ([]int, error) {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		return nil, fmt.Errorf("could not get account ID: %v", err)
 	}
@@ -111,7 +112,7 @@ func GetFavoriteRecipes(userID string, limit int, db *sql.DB) ([]int, error) {
 		LIMIT ?
 	`
 
-	rows, err := db.Query(query, accountID, limit)
+	rows, err := db.QueryContext(ctx, query, accountID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("could not query favorites: %v", err)
 	}

--- a/netlify-functions/recipes/internal/pkg/service/ingredients.go
+++ b/netlify-functions/recipes/internal/pkg/service/ingredients.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"database/sql"
 )
 
@@ -10,9 +11,9 @@ type Ingredient struct {
 }
 
 // GetAllIngredients returns all recipes in the recipe table
-func GetAllIngredients(db *sql.DB) ([]Ingredient, error) {
+func GetAllIngredients(ctx context.Context, db *sql.DB) ([]Ingredient, error) {
 	query := "SELECT name FROM ingredient ORDER BY lower(name);"
-	results, err := db.Query(query)
+	results, err := db.QueryContext(ctx, query)
 	// err was previously never checked here, so a failed query dereferenced a
 	// nil *sql.Rows on the next line and panicked instead of returning.
 	if err != nil {

--- a/netlify-functions/recipes/internal/pkg/service/invite.go
+++ b/netlify-functions/recipes/internal/pkg/service/invite.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log"
@@ -8,14 +9,14 @@ import (
 	"time"
 )
 
-func CreateInvite(db *sql.DB, token string, accountID int, email string, userID string) error {
+func CreateInvite(ctx context.Context, db *sql.DB, token string, accountID int, email string, userID string) error {
 	inviteQuery := `
 		INSERT INTO invite (token, account, email, admin_id, expires)
 			VALUES (?, ?, ?, ?, ?)
 			ON DUPLICATE KEY UPDATE email=email;
 	`
 
-	_, err := db.Exec(inviteQuery, token, accountID, email, userID, time.Now().AddDate(0, 0, 30))
+	_, err := db.ExecContext(ctx, inviteQuery, token, accountID, email, userID, time.Now().AddDate(0, 0, 30))
 	if err != nil {
 		log.Println("Error adding invite")
 		log.Println(err)
@@ -24,14 +25,14 @@ func CreateInvite(db *sql.DB, token string, accountID int, email string, userID 
 	return nil
 }
 
-func GetInvites(db *sql.DB, email string) (i []common.Invite, e error) {
+func GetInvites(ctx context.Context, db *sql.DB, email string) (i []common.Invite, e error) {
 	query := `
 		SELECT token, name
 			FROM invite
 			LEFT JOIN user on user.id = invite.admin_id
 			WHERE invite.email = ? AND invite.expires > ?;`
 
-	results, err := db.Query(query, email, time.Now())
+	results, err := db.QueryContext(ctx, query, email, time.Now())
 
 	if err != nil {
 		log.Println("Error querying invites")
@@ -57,12 +58,12 @@ func GetInvites(db *sql.DB, email string) (i []common.Invite, e error) {
 
 }
 
-func GetInvite(db *sql.DB, token string, email string) (a *int, e error) {
+func GetInvite(ctx context.Context, db *sql.DB, token string, email string) (a *int, e error) {
 	var accountID int
 	fmt.Println(email)
 	fmt.Println(token)
 	inviteQuery := `SELECT account from invite WHERE email = ? and token = ?;`
-	if err := db.QueryRow(inviteQuery, email, token).Scan(&accountID); err != nil {
+	if err := db.QueryRowContext(ctx, inviteQuery, email, token).Scan(&accountID); err != nil {
 		log.Println("Error querying invite")
 		log.Println(err)
 		return nil, err
@@ -70,9 +71,9 @@ func GetInvite(db *sql.DB, token string, email string) (a *int, e error) {
 	return &accountID, nil
 }
 
-func DeleteInvite(db *sql.DB, accountID int, email string) error {
+func DeleteInvite(ctx context.Context, db *sql.DB, accountID int, email string) error {
 	inviteQuery := `DELETE from invite WHERE account = ? and email = ?;`
-	_, err := db.Exec(inviteQuery, accountID, email)
+	_, err := db.ExecContext(ctx, inviteQuery, accountID, email)
 	if err != nil {
 		log.Println("Error deleting invite")
 		log.Println(err)
@@ -81,9 +82,9 @@ func DeleteInvite(db *sql.DB, accountID int, email string) error {
 	return nil
 }
 
-func DeleteInviteByToken(db *sql.DB, token string) error {
+func DeleteInviteByToken(ctx context.Context, db *sql.DB, token string) error {
 	inviteQuery := `DELETE from invite WHERE token = ?;`
-	_, err := db.Exec(inviteQuery, token)
+	_, err := db.ExecContext(ctx, inviteQuery, token)
 	if err != nil {
 		log.Println("Error deleting invite")
 		log.Println(err)

--- a/netlify-functions/recipes/internal/pkg/service/invite.go
+++ b/netlify-functions/recipes/internal/pkg/service/invite.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
 	"recipes/internal/pkg/common"
 	"time"
 )
@@ -18,9 +17,7 @@ func CreateInvite(ctx context.Context, db *sql.DB, token string, accountID int, 
 
 	_, err := db.ExecContext(ctx, inviteQuery, token, accountID, email, userID, time.Now().AddDate(0, 0, 30))
 	if err != nil {
-		log.Println("Error adding invite")
-		log.Println(err)
-		return err
+		return fmt.Errorf("adding invite: %w", err)
 	}
 	return nil
 }
@@ -35,9 +32,7 @@ func GetInvites(ctx context.Context, db *sql.DB, email string) (i []common.Invit
 	results, err := db.QueryContext(ctx, query, email, time.Now())
 
 	if err != nil {
-		log.Println("Error querying invites")
-		log.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("querying invites: %w", err)
 	}
 	defer results.Close()
 
@@ -60,13 +55,9 @@ func GetInvites(ctx context.Context, db *sql.DB, email string) (i []common.Invit
 
 func GetInvite(ctx context.Context, db *sql.DB, token string, email string) (a *int, e error) {
 	var accountID int
-	fmt.Println(email)
-	fmt.Println(token)
 	inviteQuery := `SELECT account from invite WHERE email = ? and token = ?;`
 	if err := db.QueryRowContext(ctx, inviteQuery, email, token).Scan(&accountID); err != nil {
-		log.Println("Error querying invite")
-		log.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("querying invite: %w", err)
 	}
 	return &accountID, nil
 }
@@ -75,9 +66,7 @@ func DeleteInvite(ctx context.Context, db *sql.DB, accountID int, email string) 
 	inviteQuery := `DELETE from invite WHERE account = ? and email = ?;`
 	_, err := db.ExecContext(ctx, inviteQuery, accountID, email)
 	if err != nil {
-		log.Println("Error deleting invite")
-		log.Println(err)
-		return err
+		return fmt.Errorf("deleting invite: %w", err)
 	}
 	return nil
 }
@@ -86,9 +75,7 @@ func DeleteInviteByToken(ctx context.Context, db *sql.DB, token string) error {
 	inviteQuery := `DELETE from invite WHERE token = ?;`
 	_, err := db.ExecContext(ctx, inviteQuery, token)
 	if err != nil {
-		log.Println("Error deleting invite")
-		log.Println(err)
-		return err
+		return fmt.Errorf("deleting invite: %w", err)
 	}
 	return nil
 }

--- a/netlify-functions/recipes/internal/pkg/service/list.go
+++ b/netlify-functions/recipes/internal/pkg/service/list.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	"recipes/internal/pkg/common"
+	"recipes/internal/pkg/telemetry"
 	"sort"
 	"strconv"
 
@@ -559,7 +559,7 @@ func GenerateShoppingList(ctx context.Context, recipeIDs []string, userID string
 	// logging failure shouldn't fail the whole generate operation.
 	if intRecipeIDs, err := GetRecipeIDsFromStrings(recipeIDs); err == nil {
 		if logErr := LogShoppingListEvent(ctx, userID, "add_recipe", intRecipeIDs, db); logErr != nil {
-			log.Printf("Failed to log shopping list history: %v", logErr)
+			telemetry.RecordWarning(ctx, "log shopping list history", logErr)
 		}
 	}
 
@@ -570,20 +570,17 @@ func GenerateShoppingList(ctx context.Context, recipeIDs []string, userID string
 func GetShoppingList(ctx context.Context, userID string, db *sql.DB) (*common.ShoppingList, error) {
 	recipes, err := GetRecipesFromList(ctx, userID, db)
 	if err != nil {
-		fmt.Println("could not get recipes from list")
-		return nil, err
+		return nil, fmt.Errorf("get recipes from list: %w", err)
 	}
 
 	ingredients, err := GetIngredientListItems(ctx, userID, db)
 	if err != nil {
-		fmt.Println("could not get ingredients from list")
-		return nil, err
+		return nil, fmt.Errorf("get ingredients from list: %w", err)
 	}
 
 	extras, err := GetExtraListItems(ctx, userID, db)
 	if err != nil {
-		fmt.Println("could not get extra list items")
-		return nil, err
+		return nil, fmt.Errorf("get extra list items: %w", err)
 	}
 
 	// Display Units are applied here rather than when the list is generated, so
@@ -618,12 +615,10 @@ func GetShoppingList(ctx context.Context, userID string, db *sql.DB) (*common.Sh
 func RemoveAllListItems(ctx context.Context, userID string, db *sql.DB) error {
 	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
-		fmt.Println("could not delete ingredients")
-		return err
+		return fmt.Errorf("delete ingredients: %w", err)
 	}
 	if _, err := db.ExecContext(ctx, "DELETE FROM list WHERE account_id = ?;", accountID); err != nil {
-		fmt.Println("could not delete ingredients")
-		return err
+		return fmt.Errorf("delete ingredients: %w", err)
 	}
 	return nil
 }
@@ -632,12 +627,10 @@ func RemoveAllListItems(ctx context.Context, userID string, db *sql.DB) error {
 func RemoveIngredientListItems(ctx context.Context, userID string, db dbConn) error {
 	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
-		fmt.Println("could not delete ingredients")
-		return err
+		return fmt.Errorf("delete ingredients: %w", err)
 	}
 	if _, err := db.ExecContext(ctx, "DELETE FROM list WHERE account_id = ? AND type = 'ingredient';", accountID); err != nil {
-		fmt.Println("could not delete ingredients")
-		return err
+		return fmt.Errorf("delete ingredients: %w", err)
 	}
 	return nil
 }
@@ -646,8 +639,7 @@ func RemoveIngredientListItems(ctx context.Context, userID string, db dbConn) er
 func AddIngredientListItems(ctx context.Context, userID string, ingredients map[string]*common.ListIngredient, db dbConn) error {
 	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
-		fmt.Println("could not add ingredients to shopping list")
-		return err
+		return fmt.Errorf("add ingredients to shopping list: %w", err)
 	}
 
 	sqlStr := "INSERT INTO list(account_id, name, type, quantity, department, is_bought, recipe_id, unit_id) VALUES "
@@ -672,9 +664,7 @@ func AddIngredientListItems(ctx context.Context, userID string, ingredients map[
 
 	sqlStr = sqlStr[0 : len(sqlStr)-1]
 	if _, err := db.ExecContext(ctx, sqlStr, vals...); err != nil {
-		fmt.Println(err)
-		fmt.Println("could not add ingredients to shopping list")
-		return err
+		return fmt.Errorf("add ingredients to shopping list: %w", err)
 	}
 	return nil
 }

--- a/netlify-functions/recipes/internal/pkg/service/list.go
+++ b/netlify-functions/recipes/internal/pkg/service/list.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -500,31 +501,31 @@ func roundToSignificantFigures(v float64, digits int) float64 {
 // are untouched either way (see CONTEXT.md's "Generate Shopping List"). An Ingredient
 // Item already marked bought carries that state forward if it's still present in the
 // recomputed set, so regenerating the list doesn't silently un-buy things.
-func GenerateShoppingList(recipeIDs []string, userID string, db *sql.DB) (*common.ShoppingList, error) {
+func GenerateShoppingList(ctx context.Context, recipeIDs []string, userID string, db *sql.DB) (*common.ShoppingList, error) {
 	recipes := make([]common.Recipe, 0)
 	for _, idStr := range recipeIDs {
 		id, err := strconv.Atoi(idStr)
 		if err != nil {
 			return nil, ErrInvalidRecipeID
 		}
-		recipe, err := GetRecipeByID(id, userID, db)
+		recipe, err := GetRecipeByID(ctx, id, userID, db)
 		if err != nil {
 			return nil, err
 		}
 		recipes = append(recipes, *recipe)
 	}
 
-	previousIngredients, err := GetIngredientListItems(userID, db)
+	previousIngredients, err := GetIngredientListItems(ctx, userID, db)
 	if err != nil {
 		return nil, err
 	}
 
 	// Loaded here and passed in, so CombineIngredients stays a pure function.
-	units, err := GetUnitCatalog(db)
+	units, err := GetUnitCatalog(ctx, db)
 	if err != nil {
 		return nil, err
 	}
-	ingredientCatalog, err := GetIngredientCatalog(db, units)
+	ingredientCatalog, err := GetIngredientCatalog(ctx, db, units)
 	if err != nil {
 		return nil, err
 	}
@@ -536,17 +537,17 @@ func GenerateShoppingList(recipeIDs []string, userID string, db *sql.DB) (*commo
 		}
 	}
 
-	tx, err := db.Begin()
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
 
-	if err := RemoveIngredientListItems(userID, tx); err != nil {
+	if err := RemoveIngredientListItems(ctx, userID, tx); err != nil {
 		return nil, err
 	}
 	if len(combinedIngredients) > 0 {
-		if err := AddIngredientListItems(userID, combinedIngredients, tx); err != nil {
+		if err := AddIngredientListItems(ctx, userID, combinedIngredients, tx); err != nil {
 			return nil, err
 		}
 	}
@@ -557,29 +558,29 @@ func GenerateShoppingList(recipeIDs []string, userID string, db *sql.DB) (*commo
 	// Log shopping list history for meal planning intelligence, best-effort - a
 	// logging failure shouldn't fail the whole generate operation.
 	if intRecipeIDs, err := GetRecipeIDsFromStrings(recipeIDs); err == nil {
-		if logErr := LogShoppingListEvent(userID, "add_recipe", intRecipeIDs, db); logErr != nil {
+		if logErr := LogShoppingListEvent(ctx, userID, "add_recipe", intRecipeIDs, db); logErr != nil {
 			log.Printf("Failed to log shopping list history: %v", logErr)
 		}
 	}
 
-	return GetShoppingList(userID, db)
+	return GetShoppingList(ctx, userID, db)
 }
 
 // GetShoppingList returns the full shopping list for a user
-func GetShoppingList(userID string, db *sql.DB) (*common.ShoppingList, error) {
-	recipes, err := GetRecipesFromList(userID, db)
+func GetShoppingList(ctx context.Context, userID string, db *sql.DB) (*common.ShoppingList, error) {
+	recipes, err := GetRecipesFromList(ctx, userID, db)
 	if err != nil {
 		fmt.Println("could not get recipes from list")
 		return nil, err
 	}
 
-	ingredients, err := GetIngredientListItems(userID, db)
+	ingredients, err := GetIngredientListItems(ctx, userID, db)
 	if err != nil {
 		fmt.Println("could not get ingredients from list")
 		return nil, err
 	}
 
-	extras, err := GetExtraListItems(userID, db)
+	extras, err := GetExtraListItems(ctx, userID, db)
 	if err != nil {
 		fmt.Println("could not get extra list items")
 		return nil, err
@@ -588,11 +589,11 @@ func GetShoppingList(userID string, db *sql.DB) (*common.ShoppingList, error) {
 	// Display Units are applied here rather than when the list is generated, so
 	// correcting a Unit Size or Display Unit improves a Shopping List that's
 	// already been generated. Extras carry no Amounts, so they're untouched.
-	units, err := GetUnitCatalog(db)
+	units, err := GetUnitCatalog(ctx, db)
 	if err != nil {
 		return nil, err
 	}
-	ingredientCatalog, err := GetIngredientCatalog(db, units)
+	ingredientCatalog, err := GetIngredientCatalog(ctx, db, units)
 	if err != nil {
 		return nil, err
 	}
@@ -614,13 +615,13 @@ func GetShoppingList(userID string, db *sql.DB) (*common.ShoppingList, error) {
 }
 
 // RemoveAllListItems removes all list items for a user
-func RemoveAllListItems(userID string, db *sql.DB) error {
-	accountID, err := GetAccountID(db, userID)
+func RemoveAllListItems(ctx context.Context, userID string, db *sql.DB) error {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		fmt.Println("could not delete ingredients")
 		return err
 	}
-	if _, err := db.Exec("DELETE FROM list WHERE account_id = ?;", accountID); err != nil {
+	if _, err := db.ExecContext(ctx, "DELETE FROM list WHERE account_id = ?;", accountID); err != nil {
 		fmt.Println("could not delete ingredients")
 		return err
 	}
@@ -628,13 +629,13 @@ func RemoveAllListItems(userID string, db *sql.DB) error {
 }
 
 // RemoveIngredientListItems removes all ingredient list items
-func RemoveIngredientListItems(userID string, db dbConn) error {
-	accountID, err := GetAccountID(db, userID)
+func RemoveIngredientListItems(ctx context.Context, userID string, db dbConn) error {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		fmt.Println("could not delete ingredients")
 		return err
 	}
-	if _, err := db.Exec("DELETE FROM list WHERE account_id = ? AND type = 'ingredient';", accountID); err != nil {
+	if _, err := db.ExecContext(ctx, "DELETE FROM list WHERE account_id = ? AND type = 'ingredient';", accountID); err != nil {
 		fmt.Println("could not delete ingredients")
 		return err
 	}
@@ -642,8 +643,8 @@ func RemoveIngredientListItems(userID string, db dbConn) error {
 }
 
 // AddIngredientListItems adds passed ingredients to the db
-func AddIngredientListItems(userID string, ingredients map[string]*common.ListIngredient, db dbConn) error {
-	accountID, err := GetAccountID(db, userID)
+func AddIngredientListItems(ctx context.Context, userID string, ingredients map[string]*common.ListIngredient, db dbConn) error {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		fmt.Println("could not add ingredients to shopping list")
 		return err
@@ -670,7 +671,7 @@ func AddIngredientListItems(userID string, ingredients map[string]*common.ListIn
 	}
 
 	sqlStr = sqlStr[0 : len(sqlStr)-1]
-	if _, err := db.Exec(sqlStr, vals...); err != nil {
+	if _, err := db.ExecContext(ctx, sqlStr, vals...); err != nil {
 		fmt.Println(err)
 		fmt.Println("could not add ingredients to shopping list")
 		return err
@@ -679,8 +680,8 @@ func AddIngredientListItems(userID string, ingredients map[string]*common.ListIn
 }
 
 // AddExtraListItem inserts an item of type 'extra'
-func AddExtraListItem(userID string, name string, isBought bool, db *sql.DB) error {
-	accountID, err := GetAccountID(db, userID)
+func AddExtraListItem(ctx context.Context, userID string, name string, isBought bool, db *sql.DB) error {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		return err
 	}
@@ -689,21 +690,21 @@ func AddExtraListItem(userID string, name string, isBought bool, db *sql.DB) err
 			(account_id, name, type, quantity, department, is_bought, unit_id)
 			VALUES (?, ?, ?, ?, '', ?, ?)
 	`
-	if _, err := db.Exec(query, accountID, name, "extra", 0, isBought, 1); err != nil {
+	if _, err := db.ExecContext(ctx, query, accountID, name, "extra", 0, isBought, 1); err != nil {
 		return err
 	}
 	return nil
 }
 
 // GetRecipesFromList returns recipes used to create the shopping list
-func GetRecipesFromList(userID string, db *sql.DB) ([]string, error) {
-	accountID, err := GetAccountID(db, userID)
+func GetRecipesFromList(ctx context.Context, userID string, db *sql.DB) ([]string, error) {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		return nil, err
 	}
 
 	query := "SELECT DISTINCT recipe_id FROM list WHERE account_id = ? and type = 'ingredient';"
-	results, err := db.Query(query, accountID)
+	results, err := db.QueryContext(ctx, query, accountID)
 
 	if err != nil {
 		return nil, err
@@ -723,8 +724,8 @@ func GetRecipesFromList(userID string, db *sql.DB) ([]string, error) {
 }
 
 // GetIngredientListItems returns items of type 'ingredient'
-func GetIngredientListItems(userID string, db *sql.DB) (map[string]*common.ListIngredient, error) {
-	accountID, err := GetAccountID(db, userID)
+func GetIngredientListItems(ctx context.Context, userID string, db *sql.DB) (map[string]*common.ListIngredient, error) {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -734,7 +735,7 @@ func GetIngredientListItems(userID string, db *sql.DB) (map[string]*common.ListI
 	// like - otherwise "50 g + 2 tbsp" could render either way round between
 	// requests.
 	query := "SELECT list.name as name, unit.name as unit, quantity, department, is_bought as isBought FROM list INNER JOIN unit on unit_id = unit.id WHERE account_id = ? and type = 'ingredient' ORDER BY list.id;"
-	results, err := db.Query(query, accountID)
+	results, err := db.QueryContext(ctx, query, accountID)
 
 	if err != nil {
 		return nil, err
@@ -772,13 +773,13 @@ func GetIngredientListItems(userID string, db *sql.DB) (map[string]*common.ListI
 }
 
 // GetExtraListItems returns items of type 'extra'
-func GetExtraListItems(userID string, db *sql.DB) (map[string]*common.ListIngredient, error) {
-	accountID, err := GetAccountID(db, userID)
+func GetExtraListItems(ctx context.Context, userID string, db *sql.DB) (map[string]*common.ListIngredient, error) {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		return nil, err
 	}
 	query := "SELECT list.name as name, is_bought as isBought FROM list WHERE account_id = ? and type = 'extra' ORDER BY list.id;"
-	results, err := db.Query(query, accountID)
+	results, err := db.QueryContext(ctx, query, accountID)
 
 	if err != nil {
 		return nil, err
@@ -808,12 +809,12 @@ func GetExtraListItems(userID string, db *sql.DB) (map[string]*common.ListIngred
 }
 
 // BuyListItem toggles the isBought state of a list item in the db
-func BuyListItem(userID string, name string, isBought bool, db *sql.DB) error {
-	accountID, err := GetAccountID(db, userID)
+func BuyListItem(ctx context.Context, userID string, name string, isBought bool, db *sql.DB) error {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		return err
 	}
-	if _, err := db.Exec("UPDATE list SET is_bought = ? WHERE name = ? AND account_id = ?", isBought, name, accountID); err != nil {
+	if _, err := db.ExecContext(ctx, "UPDATE list SET is_bought = ? WHERE name = ? AND account_id = ?", isBought, name, accountID); err != nil {
 		return err
 	}
 	return nil

--- a/netlify-functions/recipes/internal/pkg/service/recipe.go
+++ b/netlify-functions/recipes/internal/pkg/service/recipe.go
@@ -3,11 +3,11 @@ package service
 import (
 	"context"
 	"recipes/internal/pkg/common"
+	"recipes/internal/pkg/telemetry"
 	"strings"
 
 	"database/sql"
 	"fmt"
-	"log"
 )
 
 // execer is the minimal interface insertIngredients, insertUnits, insertParts, and
@@ -46,8 +46,7 @@ func getIngredientsByRecipeID(ctx context.Context, id int, db *sql.DB) ([]common
 	ingredients := make([]common.Ingredient, 0)
 
 	if err != nil {
-		log.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("querying ingredients for recipe %d: %w", id, err)
 	}
 	defer results.Close()
 
@@ -57,8 +56,7 @@ func getIngredientsByRecipeID(ctx context.Context, id int, db *sql.DB) ([]common
 		err = results.Scan(&ingredient.Name, &ingredient.Unit, &ingredient.Quantity, &department)
 
 		if err != nil {
-			log.Println(err)
-			return nil, err
+			return nil, fmt.Errorf("scanning ingredient row for recipe %d: %w", id, err)
 		}
 
 		if department.Valid {
@@ -88,8 +86,7 @@ func GetRecipeBySlug(ctx context.Context, slug string, userID string, db *sql.DB
 	results, err := db.QueryContext(ctx, query, slug, accountID)
 
 	if err != nil {
-		log.Println("Error querying recipe")
-		return nil, err
+		return nil, fmt.Errorf("querying recipe: %w", err)
 	}
 	defer results.Close()
 	for results.Next() {
@@ -131,8 +128,7 @@ func GetRecipeBySlug(ctx context.Context, slug string, userID string, db *sql.DB
 		ingredients, err := getIngredientsByRecipeID(ctx, recipe.ID, db)
 
 		if err != nil {
-			log.Println(err)
-			return nil, err
+			return nil, fmt.Errorf("loading ingredients: %w", err)
 		}
 
 		recipe.Ingredients = ingredients
@@ -147,8 +143,7 @@ func GetRecipeBySlug(ctx context.Context, slug string, userID string, db *sql.DB
 func GetRecipeByID(ctx context.Context, id int, userID string, db *sql.DB) (*common.Recipe, error) {
 	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
-		log.Println(err)
-		return nil, err
+		return nil, fmt.Errorf("resolving account: %w", err)
 	}
 	recipe := &common.Recipe{Ingredients: []common.Ingredient{}, Tags: []string{}}
 	query := `
@@ -160,8 +155,7 @@ func GetRecipeByID(ctx context.Context, id int, userID string, db *sql.DB) (*com
 	results, err := db.QueryContext(ctx, query, id, accountID)
 
 	if err != nil {
-		log.Println("Error querying recipe")
-		return nil, err
+		return nil, fmt.Errorf("querying recipe: %w", err)
 	}
 	defer results.Close()
 
@@ -204,8 +198,7 @@ func GetRecipeByID(ctx context.Context, id int, userID string, db *sql.DB) (*com
 		ingredients, err := getIngredientsByRecipeID(ctx, id, db)
 
 		if err != nil {
-			log.Println(err)
-			return nil, err
+			return nil, fmt.Errorf("loading ingredients: %w", err)
 		}
 
 		recipe.Ingredients = ingredients
@@ -238,8 +231,7 @@ func AddRecipe(ctx context.Context, recipe common.Recipe, userID string, db *sql
 	query := "INSERT INTO recipe (name, slug, remote_url, notes, method, account_id) VALUES (?, ?, ?, ?, ?, ?);"
 	res, err := tx.ExecContext(ctx, query, recipe.Name, common.Slugify(recipe.Name), recipe.RemoteURL, recipe.Notes, recipe.Method, accountID)
 	if err != nil {
-		fmt.Println("could not insert recipe")
-		return 0, err
+		return 0, fmt.Errorf("insert recipe: %w", err)
 	}
 
 	id, err := res.LastInsertId()
@@ -277,53 +269,50 @@ func EditRecipe(ctx context.Context, recipe common.Recipe, userID string, db *sq
 
 	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
-		return err
+		return fmt.Errorf("resolving account: %w", err)
 	}
 	var id string
 	// Checking to see if this recipe exists for this user
 	if err := db.QueryRowContext(ctx, "SELECT id FROM recipe WHERE id=? AND account_id = ?;", recipe.ID, accountID).Scan(&id); err == sql.ErrNoRows {
-		fmt.Println("no results")
+		// Returned unwrapped: it is a sentinel, and its identity is the whole
+		// message. Wrapping it would add "no results:" to an error that already
+		// says exactly that, and break any caller comparing against it.
 		return err
 	} else if err != nil {
-		return err
+		return fmt.Errorf("checking the recipe exists: %w", err)
 	}
 
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("starting transaction: %w", err)
 	}
 	defer tx.Rollback()
 
 	updateQuery := "UPDATE recipe SET name=?, remote_url=?, notes=?, method=? WHERE id=? AND account_id=?"
 	if _, err := tx.ExecContext(ctx, updateQuery, recipe.Name, recipe.RemoteURL, recipe.Notes, recipe.Method, recipe.ID, accountID); err != nil {
-		log.Println(err)
-		return err
+		return fmt.Errorf("updating recipe %d: %w", recipe.ID, err)
 	}
 
 	if err := insertIngredients(ctx, recipe, tx); err != nil {
-		log.Println(err)
-		return err
+		return fmt.Errorf("inserting ingredients: %w", err)
 	}
 
 	if err := insertUnits(ctx, recipe, tx); err != nil {
-		log.Println(err)
-		return err
+		return fmt.Errorf("inserting units: %w", err)
 	}
 	classifyNewIngredients(ctx, recipe, tx)
 
 	// Delete the existing relationships between recipe & ingredients
 	if _, err := tx.ExecContext(ctx, "DELETE FROM part WHERE recipe_id=?", recipe.ID); err != nil {
-		log.Println(err)
-		return err
+		return fmt.Errorf("clearing recipe %d's ingredient links: %w", recipe.ID, err)
 	}
 
 	if err := insertParts(ctx, recipe, tx); err != nil {
-		log.Println(err)
-		return err
+		return fmt.Errorf("inserting ingredient links: %w", err)
 	}
 
 	if err = insertTags(ctx, recipe, tx); err != nil {
-		return err
+		return fmt.Errorf("inserting tags: %w", err)
 	}
 	return tx.Commit()
 }
@@ -332,12 +321,14 @@ func EditRecipe(ctx context.Context, recipe common.Recipe, userID string, db *sq
 func DeleteRecipe(ctx context.Context, recipe common.Recipe, userID string, db *sql.DB) error {
 	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
-		return err
+		return fmt.Errorf("resolving account: %w", err)
 	}
 	var id string
 	// Checking to see if this recipe exists for this user
 	if err := db.QueryRowContext(ctx, "SELECT id FROM recipe WHERE id=? AND account_id = ?;", recipe.ID, accountID).Scan(&id); err == sql.ErrNoRows {
-		fmt.Println("no results")
+		// Returned unwrapped: it is a sentinel, and its identity is the whole
+		// message. Wrapping it would add "no results:" to an error that already
+		// says exactly that, and break any caller comparing against it.
 		return err
 	} else if err != nil {
 		return err
@@ -392,8 +383,7 @@ func insertIngredients(ctx context.Context, recipe common.Recipe, db execer) err
 	query := fmt.Sprintf("INSERT INTO ingredient (name) VALUES %s ON DUPLICATE KEY UPDATE id=id;", strings.Join(placeholders, ","))
 
 	if _, err := db.ExecContext(ctx, query, placeholderValues...); err != nil {
-		fmt.Println("could not insert ingredients")
-		return err
+		return fmt.Errorf("insert ingredients: %w", err)
 	}
 	return nil
 }
@@ -415,8 +405,7 @@ func insertUnits(ctx context.Context, recipe common.Recipe, db execer) error {
 	query := fmt.Sprintf("INSERT INTO unit (name) VALUES %s ON DUPLICATE KEY UPDATE id=id;", strings.Join(placeholders, ","))
 
 	if _, err := db.ExecContext(ctx, query, placeholderValues...); err != nil {
-		fmt.Println("could not insert units")
-		return err
+		return fmt.Errorf("insert units: %w", err)
 	}
 	return nil
 }
@@ -434,8 +423,7 @@ func insertParts(ctx context.Context, recipe common.Recipe, db execer) error {
 	query := fmt.Sprintf("INSERT INTO part (recipe_id, ingredient_id, unit_id, quantity) VALUES %s;", strings.Join(placeholders, ","))
 
 	if _, err := db.ExecContext(ctx, query, placeholderValues...); err != nil {
-		fmt.Println("could not insert part")
-		return err
+		return fmt.Errorf("insert part: %w", err)
 	}
 
 	return nil
@@ -445,8 +433,7 @@ func insertTags(ctx context.Context, recipe common.Recipe, db execer) error {
 	removeQuery := "DELETE FROM recipe_tag WHERE recipe_id = ?;"
 	_, err := db.ExecContext(ctx, removeQuery, recipe.ID)
 	if err != nil {
-		fmt.Println("could not remove tags")
-		return err
+		return fmt.Errorf("remove tags: %w", err)
 	}
 
 	placeholders := []string{}
@@ -463,9 +450,7 @@ func insertTags(ctx context.Context, recipe common.Recipe, db execer) error {
 	}
 	_, err = db.ExecContext(ctx, fmt.Sprintf(addQuery, strings.Join(placeholders, ",")), placeholderValues...)
 	if err != nil {
-		fmt.Println("could not add tags")
-		fmt.Println(err)
-		return err
+		return fmt.Errorf("add tags: %w", err)
 	}
 
 	return nil
@@ -529,7 +514,7 @@ func classifyNewIngredients(ctx context.Context, recipe common.Recipe, db execer
 				WHERE i.name = ? AND u.name = ? AND NOT i.curated
 				ON DUPLICATE KEY UPDATE ingredient_unit_size.ingredient_id = ingredient_unit_size.ingredient_id;`
 			if _, err := db.ExecContext(ctx, query, size, ingredient.Name, unit); err != nil {
-				log.Printf("could not set unit size %q for %q: %v", unit, ingredient.Name, err)
+				telemetry.RecordWarning(ctx, "set ingredient unit size", err)
 			}
 		}
 	}
@@ -551,7 +536,7 @@ func setIngredientUnitColumn(ctx context.Context, db execer, column, unitName, i
 		UPDATE ingredient SET %s = (SELECT id FROM unit WHERE name = ?)
 		WHERE name = ? AND %s IS NULL AND NOT curated;`, column, column)
 	if _, err := db.ExecContext(ctx, query, unitName, ingredientName); err != nil {
-		log.Printf("could not set %s for %q: %v", column, ingredientName, err)
+		telemetry.RecordWarning(ctx, "set ingredient "+column, err)
 	}
 }
 
@@ -569,7 +554,7 @@ func setIngredientUnitColumn(ctx context.Context, db execer, column, unitName, i
 func setPantryStaple(ctx context.Context, db execer, ingredientName string) {
 	query := `UPDATE ingredient SET pantry_staple = TRUE WHERE name = ? AND NOT curated;`
 	if _, err := db.ExecContext(ctx, query, ingredientName); err != nil {
-		log.Printf("could not set pantry_staple for %q: %v", ingredientName, err)
+		telemetry.RecordWarning(ctx, "set ingredient pantry_staple", err)
 	}
 }
 

--- a/netlify-functions/recipes/internal/pkg/service/recipe.go
+++ b/netlify-functions/recipes/internal/pkg/service/recipe.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"recipes/internal/pkg/common"
 	"strings"
 
@@ -13,7 +14,7 @@ import (
 // insertTags need - satisfied by both *sql.DB and *sql.Tx, so AddRecipe/EditRecipe can pass
 // either a bare connection or an in-flight transaction through the same call sites.
 type execer interface {
-	Exec(query string, args ...interface{}) (sql.Result, error)
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 }
 
 // dbConn is the minimal interface GetAccountID needs, and so - transitively - anything
@@ -22,10 +23,10 @@ type execer interface {
 // and *sql.Tx.
 type dbConn interface {
 	execer
-	QueryRow(query string, args ...interface{}) *sql.Row
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 }
 
-func getIngredientsByRecipeID(id int, db *sql.DB) ([]common.Ingredient, error) {
+func getIngredientsByRecipeID(ctx context.Context, id int, db *sql.DB) ([]common.Ingredient, error) {
 	query := `
 		SELECT
 			ingredient.name as name,
@@ -41,7 +42,7 @@ func getIngredientsByRecipeID(id int, db *sql.DB) ([]common.Ingredient, error) {
 		WHERE
 		recipe_id = ?;
 	`
-	results, err := db.Query(query, id)
+	results, err := db.QueryContext(ctx, query, id)
 	ingredients := make([]common.Ingredient, 0)
 
 	if err != nil {
@@ -72,8 +73,8 @@ func getIngredientsByRecipeID(id int, db *sql.DB) ([]common.Ingredient, error) {
 }
 
 // GetRecipeBySlug fetches a recipe from the database by Slug
-func GetRecipeBySlug(slug string, userID string, db *sql.DB) (*common.Recipe, error) {
-	accountID, err := GetAccountID(db, userID)
+func GetRecipeBySlug(ctx context.Context, slug string, userID string, db *sql.DB) (*common.Recipe, error) {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +85,7 @@ func GetRecipeBySlug(slug string, userID string, db *sql.DB) (*common.Recipe, er
 			LEFT JOIN recipe_tag on recipe.id = recipe_tag.recipe_id
 			WHERE slug = ? AND account_id = ?;`
 
-	results, err := db.Query(query, slug, accountID)
+	results, err := db.QueryContext(ctx, query, slug, accountID)
 
 	if err != nil {
 		log.Println("Error querying recipe")
@@ -127,7 +128,7 @@ func GetRecipeBySlug(slug string, userID string, db *sql.DB) (*common.Recipe, er
 			recipe.Tags = []string{tag.String}
 		}
 
-		ingredients, err := getIngredientsByRecipeID(recipe.ID, db)
+		ingredients, err := getIngredientsByRecipeID(ctx, recipe.ID, db)
 
 		if err != nil {
 			log.Println(err)
@@ -143,8 +144,8 @@ func GetRecipeBySlug(slug string, userID string, db *sql.DB) (*common.Recipe, er
 }
 
 // GetRecipeByID fetches a recipe from the database by ID
-func GetRecipeByID(id int, userID string, db *sql.DB) (*common.Recipe, error) {
-	accountID, err := GetAccountID(db, userID)
+func GetRecipeByID(ctx context.Context, id int, userID string, db *sql.DB) (*common.Recipe, error) {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		log.Println(err)
 		return nil, err
@@ -156,7 +157,7 @@ func GetRecipeByID(id int, userID string, db *sql.DB) (*common.Recipe, error) {
 			LEFT JOIN recipe_tag on recipe.id = recipe_tag.recipe_id
 			WHERE recipe.id = ? AND account_id = ?;`
 
-	results, err := db.Query(query, id, accountID)
+	results, err := db.QueryContext(ctx, query, id, accountID)
 
 	if err != nil {
 		log.Println("Error querying recipe")
@@ -200,7 +201,7 @@ func GetRecipeByID(id int, userID string, db *sql.DB) (*common.Recipe, error) {
 			recipe.Tags = []string{tag.String}
 		}
 
-		ingredients, err := getIngredientsByRecipeID(id, db)
+		ingredients, err := getIngredientsByRecipeID(ctx, id, db)
 
 		if err != nil {
 			log.Println(err)
@@ -220,22 +221,22 @@ func GetRecipeByID(id int, userID string, db *sql.DB) (*common.Recipe, error) {
 // through (e.g. a bad unit) doesn't leave an orphaned recipe with no Ingredient Lines.
 // Returns the new recipe's ID so the caller can hand it back to the client
 // (e.g. for a post-create redirect) without a follow-up lookup.
-func AddRecipe(recipe common.Recipe, userID string, db *sql.DB) (int, error) {
+func AddRecipe(ctx context.Context, recipe common.Recipe, userID string, db *sql.DB) (int, error) {
 	recipe = withCanonicalUnits(recipe)
 
-	accountID, err := GetAccountID(db, userID)
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		return 0, err
 	}
 
-	tx, err := db.Begin()
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, err
 	}
 	defer tx.Rollback()
 
 	query := "INSERT INTO recipe (name, slug, remote_url, notes, method, account_id) VALUES (?, ?, ?, ?, ?, ?);"
-	res, err := tx.Exec(query, recipe.Name, common.Slugify(recipe.Name), recipe.RemoteURL, recipe.Notes, recipe.Method, accountID)
+	res, err := tx.ExecContext(ctx, query, recipe.Name, common.Slugify(recipe.Name), recipe.RemoteURL, recipe.Notes, recipe.Method, accountID)
 	if err != nil {
 		fmt.Println("could not insert recipe")
 		return 0, err
@@ -247,17 +248,17 @@ func AddRecipe(recipe common.Recipe, userID string, db *sql.DB) (int, error) {
 	}
 	recipe.ID = int(id)
 
-	if err = insertIngredients(recipe, tx); err != nil {
+	if err = insertIngredients(ctx, recipe, tx); err != nil {
 		return 0, err
 	}
-	if err = insertUnits(recipe, tx); err != nil {
+	if err = insertUnits(ctx, recipe, tx); err != nil {
 		return 0, err
 	}
-	classifyNewIngredients(recipe, tx)
-	if err = insertParts(recipe, tx); err != nil {
+	classifyNewIngredients(ctx, recipe, tx)
+	if err = insertParts(ctx, recipe, tx); err != nil {
 		return 0, err
 	}
-	if err = insertTags(recipe, tx); err != nil {
+	if err = insertTags(ctx, recipe, tx); err != nil {
 		return 0, err
 	}
 	if err = tx.Commit(); err != nil {
@@ -271,71 +272,71 @@ func AddRecipe(recipe common.Recipe, userID string, db *sql.DB) (int, error) {
 // writes then happen in one transaction, so a failure partway through (e.g. between
 // deleting and reinserting the recipe's Ingredient Lines) doesn't leave the recipe with
 // no Ingredient Lines.
-func EditRecipe(recipe common.Recipe, userID string, db *sql.DB) error {
+func EditRecipe(ctx context.Context, recipe common.Recipe, userID string, db *sql.DB) error {
 	recipe = withCanonicalUnits(recipe)
 
-	accountID, err := GetAccountID(db, userID)
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		return err
 	}
 	var id string
 	// Checking to see if this recipe exists for this user
-	if err := db.QueryRow("SELECT id FROM recipe WHERE id=? AND account_id = ?;", recipe.ID, accountID).Scan(&id); err == sql.ErrNoRows {
+	if err := db.QueryRowContext(ctx, "SELECT id FROM recipe WHERE id=? AND account_id = ?;", recipe.ID, accountID).Scan(&id); err == sql.ErrNoRows {
 		fmt.Println("no results")
 		return err
 	} else if err != nil {
 		return err
 	}
 
-	tx, err := db.Begin()
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
 
 	updateQuery := "UPDATE recipe SET name=?, remote_url=?, notes=?, method=? WHERE id=? AND account_id=?"
-	if _, err := tx.Exec(updateQuery, recipe.Name, recipe.RemoteURL, recipe.Notes, recipe.Method, recipe.ID, accountID); err != nil {
+	if _, err := tx.ExecContext(ctx, updateQuery, recipe.Name, recipe.RemoteURL, recipe.Notes, recipe.Method, recipe.ID, accountID); err != nil {
 		log.Println(err)
 		return err
 	}
 
-	if err := insertIngredients(recipe, tx); err != nil {
+	if err := insertIngredients(ctx, recipe, tx); err != nil {
 		log.Println(err)
 		return err
 	}
 
-	if err := insertUnits(recipe, tx); err != nil {
+	if err := insertUnits(ctx, recipe, tx); err != nil {
 		log.Println(err)
 		return err
 	}
-	classifyNewIngredients(recipe, tx)
+	classifyNewIngredients(ctx, recipe, tx)
 
 	// Delete the existing relationships between recipe & ingredients
-	if _, err := tx.Exec("DELETE FROM part WHERE recipe_id=?", recipe.ID); err != nil {
+	if _, err := tx.ExecContext(ctx, "DELETE FROM part WHERE recipe_id=?", recipe.ID); err != nil {
 		log.Println(err)
 		return err
 	}
 
-	if err := insertParts(recipe, tx); err != nil {
+	if err := insertParts(ctx, recipe, tx); err != nil {
 		log.Println(err)
 		return err
 	}
 
-	if err = insertTags(recipe, tx); err != nil {
+	if err = insertTags(ctx, recipe, tx); err != nil {
 		return err
 	}
 	return tx.Commit()
 }
 
 // DeleteRecipe removes a recipe from the db
-func DeleteRecipe(recipe common.Recipe, userID string, db *sql.DB) error {
-	accountID, err := GetAccountID(db, userID)
+func DeleteRecipe(ctx context.Context, recipe common.Recipe, userID string, db *sql.DB) error {
+	accountID, err := GetAccountID(ctx, db, userID)
 	if err != nil {
 		return err
 	}
 	var id string
 	// Checking to see if this recipe exists for this user
-	if err := db.QueryRow("SELECT id FROM recipe WHERE id=? AND account_id = ?;", recipe.ID, accountID).Scan(&id); err == sql.ErrNoRows {
+	if err := db.QueryRowContext(ctx, "SELECT id FROM recipe WHERE id=? AND account_id = ?;", recipe.ID, accountID).Scan(&id); err == sql.ErrNoRows {
 		fmt.Println("no results")
 		return err
 	} else if err != nil {
@@ -343,17 +344,17 @@ func DeleteRecipe(recipe common.Recipe, userID string, db *sql.DB) error {
 	}
 
 	// Delete the existing relationships between recipe & ingredients
-	if _, err := db.Exec("DELETE FROM part WHERE recipe_id=?;", recipe.ID); err != nil {
+	if _, err := db.ExecContext(ctx, "DELETE FROM part WHERE recipe_id=?;", recipe.ID); err != nil {
 		return err
 	}
 
 	// Delete the existing relationships between recipe & tags
-	if _, err := db.Exec("DELETE FROM recipe_tag WHERE recipe_id=?;", recipe.ID); err != nil {
+	if _, err := db.ExecContext(ctx, "DELETE FROM recipe_tag WHERE recipe_id=?;", recipe.ID); err != nil {
 		return err
 	}
 
 	// Delete the recipe items from the shopping list
-	if _, err := db.Exec("DELETE FROM list WHERE recipe_id=? and account_id=?;", recipe.ID, accountID); err != nil {
+	if _, err := db.ExecContext(ctx, "DELETE FROM list WHERE recipe_id=? and account_id=?;", recipe.ID, accountID); err != nil {
 		return err
 	}
 
@@ -367,18 +368,18 @@ func DeleteRecipe(recipe common.Recipe, userID string, db *sql.DB) error {
 	// `recipe_id IS NOT NULL`, and a Recipe that no longer exists cannot be
 	// suggested - so a nulled row would be dead weight. It also matches what
 	// this function already does with the Recipe's parts, tags and list items.
-	if _, err := db.Exec("DELETE FROM shopping_list_event WHERE recipe_id=? AND account_id=?;", recipe.ID, accountID); err != nil {
+	if _, err := db.ExecContext(ctx, "DELETE FROM shopping_list_event WHERE recipe_id=? AND account_id=?;", recipe.ID, accountID); err != nil {
 		return err
 	}
 
-	if _, err := db.Exec("DELETE FROM recipe WHERE id=? and account_id = ?;", recipe.ID, accountID); err != nil {
+	if _, err := db.ExecContext(ctx, "DELETE FROM recipe WHERE id=? and account_id = ?;", recipe.ID, accountID); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func insertIngredients(recipe common.Recipe, db execer) error {
+func insertIngredients(ctx context.Context, recipe common.Recipe, db execer) error {
 	if len(recipe.Ingredients) == 0 {
 		return nil
 	}
@@ -390,7 +391,7 @@ func insertIngredients(recipe common.Recipe, db execer) error {
 	}
 	query := fmt.Sprintf("INSERT INTO ingredient (name) VALUES %s ON DUPLICATE KEY UPDATE id=id;", strings.Join(placeholders, ","))
 
-	if _, err := db.Exec(query, placeholderValues...); err != nil {
+	if _, err := db.ExecContext(ctx, query, placeholderValues...); err != nil {
 		fmt.Println("could not insert ingredients")
 		return err
 	}
@@ -401,7 +402,7 @@ func insertIngredients(recipe common.Recipe, db execer) error {
 // ("no unit, just a count") entry where needed, mirroring insertIngredients. Without this, a
 // unit that doesn't already exist (e.g. "bunch") leaves part.unit_id with nothing to reference,
 // which fails the recipe save outright since that column is NOT NULL.
-func insertUnits(recipe common.Recipe, db execer) error {
+func insertUnits(ctx context.Context, recipe common.Recipe, db execer) error {
 	if len(recipe.Ingredients) == 0 {
 		return nil
 	}
@@ -413,14 +414,14 @@ func insertUnits(recipe common.Recipe, db execer) error {
 	}
 	query := fmt.Sprintf("INSERT INTO unit (name) VALUES %s ON DUPLICATE KEY UPDATE id=id;", strings.Join(placeholders, ","))
 
-	if _, err := db.Exec(query, placeholderValues...); err != nil {
+	if _, err := db.ExecContext(ctx, query, placeholderValues...); err != nil {
 		fmt.Println("could not insert units")
 		return err
 	}
 	return nil
 }
 
-func insertParts(recipe common.Recipe, db execer) error {
+func insertParts(ctx context.Context, recipe common.Recipe, db execer) error {
 	if len(recipe.Ingredients) == 0 {
 		return nil
 	}
@@ -432,7 +433,7 @@ func insertParts(recipe common.Recipe, db execer) error {
 	}
 	query := fmt.Sprintf("INSERT INTO part (recipe_id, ingredient_id, unit_id, quantity) VALUES %s;", strings.Join(placeholders, ","))
 
-	if _, err := db.Exec(query, placeholderValues...); err != nil {
+	if _, err := db.ExecContext(ctx, query, placeholderValues...); err != nil {
 		fmt.Println("could not insert part")
 		return err
 	}
@@ -440,9 +441,9 @@ func insertParts(recipe common.Recipe, db execer) error {
 	return nil
 }
 
-func insertTags(recipe common.Recipe, db execer) error {
+func insertTags(ctx context.Context, recipe common.Recipe, db execer) error {
 	removeQuery := "DELETE FROM recipe_tag WHERE recipe_id = ?;"
-	_, err := db.Exec(removeQuery, recipe.ID)
+	_, err := db.ExecContext(ctx, removeQuery, recipe.ID)
 	if err != nil {
 		fmt.Println("could not remove tags")
 		return err
@@ -460,7 +461,7 @@ func insertTags(recipe common.Recipe, db execer) error {
 		placeholders = append(placeholders, "(?,?)")
 		placeholderValues = append(placeholderValues, recipe.ID, tag)
 	}
-	_, err = db.Exec(fmt.Sprintf(addQuery, strings.Join(placeholders, ",")), placeholderValues...)
+	_, err = db.ExecContext(ctx, fmt.Sprintf(addQuery, strings.Join(placeholders, ",")), placeholderValues...)
 	if err != nil {
 		fmt.Println("could not add tags")
 		fmt.Println(err)
@@ -503,16 +504,16 @@ func insertTags(recipe common.Recipe, db execer) error {
 // that structural rather than a rule each caller has to remember. A failed
 // statement does not abort a MySQL transaction, so the surrounding save is
 // unaffected.
-func classifyNewIngredients(recipe common.Recipe, db execer) {
+func classifyNewIngredients(ctx context.Context, recipe common.Recipe, db execer) {
 	for _, ingredient := range recipe.Ingredients {
 		if ingredient.BaseUnit != "" {
-			setIngredientUnitColumn(db, "base_unit_id", ingredient.BaseUnit, ingredient.Name)
+			setIngredientUnitColumn(ctx, db, "base_unit_id", ingredient.BaseUnit, ingredient.Name)
 		}
 		if ingredient.DisplayUnit != nil {
-			setIngredientUnitColumn(db, "display_unit_id", *ingredient.DisplayUnit, ingredient.Name)
+			setIngredientUnitColumn(ctx, db, "display_unit_id", *ingredient.DisplayUnit, ingredient.Name)
 		}
 		if ingredient.PantryStaple {
-			setPantryStaple(db, ingredient.Name)
+			setPantryStaple(ctx, db, ingredient.Name)
 		}
 
 		for unit, size := range ingredient.UnitSizes {
@@ -527,7 +528,7 @@ func classifyNewIngredients(recipe common.Recipe, db execer) {
 				SELECT i.id, u.id, ? FROM ingredient i, unit u
 				WHERE i.name = ? AND u.name = ? AND NOT i.curated
 				ON DUPLICATE KEY UPDATE ingredient_unit_size.ingredient_id = ingredient_unit_size.ingredient_id;`
-			if _, err := db.Exec(query, size, ingredient.Name, unit); err != nil {
+			if _, err := db.ExecContext(ctx, query, size, ingredient.Name, unit); err != nil {
 				log.Printf("could not set unit size %q for %q: %v", unit, ingredient.Name, err)
 			}
 		}
@@ -545,11 +546,11 @@ func classifyNewIngredients(recipe common.Recipe, db execer) {
 // not exist, so an invented Base Unit is inert rather than corrupting the
 // catalog. And `NOT curated` keeps it away from values a person chose - see
 // classifyNewIngredients for why "is the column still unset" is not sufficient.
-func setIngredientUnitColumn(db execer, column, unitName, ingredientName string) {
+func setIngredientUnitColumn(ctx context.Context, db execer, column, unitName, ingredientName string) {
 	query := fmt.Sprintf(`
 		UPDATE ingredient SET %s = (SELECT id FROM unit WHERE name = ?)
 		WHERE name = ? AND %s IS NULL AND NOT curated;`, column, column)
-	if _, err := db.Exec(query, unitName, ingredientName); err != nil {
+	if _, err := db.ExecContext(ctx, query, unitName, ingredientName); err != nil {
 		log.Printf("could not set %s for %q: %v", column, ingredientName, err)
 	}
 }
@@ -565,9 +566,9 @@ func setIngredientUnitColumn(db execer, column, unitName, ingredientName string)
 //
 // `NOT curated` still applies, so anyone who deliberately un-flags an Ingredient
 // by hand can mark it curated and have that stick.
-func setPantryStaple(db execer, ingredientName string) {
+func setPantryStaple(ctx context.Context, db execer, ingredientName string) {
 	query := `UPDATE ingredient SET pantry_staple = TRUE WHERE name = ? AND NOT curated;`
-	if _, err := db.Exec(query, ingredientName); err != nil {
+	if _, err := db.ExecContext(ctx, query, ingredientName); err != nil {
 		log.Printf("could not set pantry_staple for %q: %v", ingredientName, err)
 	}
 }

--- a/netlify-functions/recipes/internal/pkg/service/recipe_test.go
+++ b/netlify-functions/recipes/internal/pkg/service/recipe_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"strings"
@@ -18,7 +19,7 @@ type fakeExecer struct {
 	failOn  string
 }
 
-func (f *fakeExecer) Exec(query string, args ...interface{}) (sql.Result, error) {
+func (f *fakeExecer) ExecContext(_ context.Context, query string, args ...interface{}) (sql.Result, error) {
 	f.queries = append(f.queries, query)
 	if f.failOn != "" && strings.Contains(query, f.failOn) {
 		return nil, errors.New("fake exec failure")
@@ -39,7 +40,7 @@ func TestInsertIngredients(t *testing.T) {
 
 	t.Run("no ingredients issues no query", func(t *testing.T) {
 		fake := &fakeExecer{}
-		if err := insertIngredients(common.Recipe{}, fake); err != nil {
+		if err := insertIngredients(context.Background(), common.Recipe{}, fake); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(fake.queries) != 0 {
@@ -49,7 +50,7 @@ func TestInsertIngredients(t *testing.T) {
 
 	t.Run("batches every ingredient into one upsert", func(t *testing.T) {
 		fake := &fakeExecer{}
-		if err := insertIngredients(recipe, fake); err != nil {
+		if err := insertIngredients(context.Background(), recipe, fake); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(fake.queries) != 1 {
@@ -62,7 +63,7 @@ func TestInsertIngredients(t *testing.T) {
 
 	t.Run("propagates a failing Exec", func(t *testing.T) {
 		fake := &fakeExecer{failOn: "INSERT INTO ingredient"}
-		if err := insertIngredients(recipe, fake); err == nil {
+		if err := insertIngredients(context.Background(), recipe, fake); err == nil {
 			t.Fatal("expected an error, got nil")
 		}
 	})
@@ -76,7 +77,7 @@ func TestInsertUnits(t *testing.T) {
 
 	t.Run("batches every unit, including a blank one, into one upsert", func(t *testing.T) {
 		fake := &fakeExecer{}
-		if err := insertUnits(recipe, fake); err != nil {
+		if err := insertUnits(context.Background(), recipe, fake); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(fake.queries) != 1 {
@@ -89,7 +90,7 @@ func TestInsertUnits(t *testing.T) {
 
 	t.Run("propagates a failing Exec", func(t *testing.T) {
 		fake := &fakeExecer{failOn: "INSERT INTO unit"}
-		if err := insertUnits(recipe, fake); err == nil {
+		if err := insertUnits(context.Background(), recipe, fake); err == nil {
 			t.Fatal("expected an error, got nil")
 		}
 	})
@@ -105,7 +106,7 @@ func TestInsertParts(t *testing.T) {
 
 	t.Run("inserts one part row referencing the recipe", func(t *testing.T) {
 		fake := &fakeExecer{}
-		if err := insertParts(recipe, fake); err != nil {
+		if err := insertParts(context.Background(), recipe, fake); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(fake.queries) != 1 {
@@ -118,7 +119,7 @@ func TestInsertParts(t *testing.T) {
 
 	t.Run("propagates a failing Exec", func(t *testing.T) {
 		fake := &fakeExecer{failOn: "INSERT INTO part"}
-		if err := insertParts(recipe, fake); err == nil {
+		if err := insertParts(context.Background(), recipe, fake); err == nil {
 			t.Fatal("expected an error, got nil")
 		}
 	})
@@ -129,7 +130,7 @@ func TestInsertTags(t *testing.T) {
 
 	t.Run("always clears existing tags first, even with none to add", func(t *testing.T) {
 		fake := &fakeExecer{}
-		if err := insertTags(common.Recipe{ID: 42}, fake); err != nil {
+		if err := insertTags(context.Background(), common.Recipe{ID: 42}, fake); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(fake.queries) != 1 {
@@ -142,7 +143,7 @@ func TestInsertTags(t *testing.T) {
 
 	t.Run("clears then inserts every tag", func(t *testing.T) {
 		fake := &fakeExecer{}
-		if err := insertTags(recipe, fake); err != nil {
+		if err := insertTags(context.Background(), recipe, fake); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(fake.queries) != 2 {
@@ -155,7 +156,7 @@ func TestInsertTags(t *testing.T) {
 
 	t.Run("propagates a failing delete without attempting the insert", func(t *testing.T) {
 		fake := &fakeExecer{failOn: "DELETE FROM recipe_tag"}
-		if err := insertTags(recipe, fake); err == nil {
+		if err := insertTags(context.Background(), recipe, fake); err == nil {
 			t.Fatal("expected an error, got nil")
 		}
 		if len(fake.queries) != 1 {
@@ -165,7 +166,7 @@ func TestInsertTags(t *testing.T) {
 
 	t.Run("propagates a failing insert", func(t *testing.T) {
 		fake := &fakeExecer{failOn: "INSERT INTO recipe_tag"}
-		if err := insertTags(recipe, fake); err == nil {
+		if err := insertTags(context.Background(), recipe, fake); err == nil {
 			t.Fatal("expected an error, got nil")
 		}
 	})
@@ -175,7 +176,7 @@ func TestClassifyNewIngredients(t *testing.T) {
 	t.Run("an ingredient with no proposals issues no query", func(t *testing.T) {
 		fake := &fakeExecer{}
 		recipe := common.Recipe{Ingredients: []common.Ingredient{{Name: "flour", Quantity: "200", Unit: "gram"}}}
-		classifyNewIngredients(recipe, fake)
+		classifyNewIngredients(context.Background(), recipe, fake)
 		// Manual Entry and every edit of an existing Recipe land here.
 		if len(fake.queries) != 0 {
 			t.Errorf("expected no queries but got %v", fake.queries)
@@ -188,7 +189,7 @@ func TestClassifyNewIngredients(t *testing.T) {
 			Name: "sumac", Quantity: "2", Unit: "teaspoon",
 			BaseUnit: "gram", UnitSizes: map[string]float64{"millilitre": 0.5},
 		}}}
-		classifyNewIngredients(recipe, fake)
+		classifyNewIngredients(context.Background(), recipe, fake)
 
 		joined := strings.Join(fake.queries, "\n")
 		// This is the whole safety property of the phase: a value reviewed by a
@@ -221,7 +222,7 @@ func TestClassifyNewIngredients(t *testing.T) {
 		recipe := common.Recipe{Ingredients: []common.Ingredient{{
 			Name: "sumac", DisplayUnit: &count,
 		}}}
-		classifyNewIngredients(recipe, fake)
+		classifyNewIngredients(context.Background(), recipe, fake)
 		if !strings.Contains(strings.Join(fake.queries, "\n"), "display_unit_id IS NULL") {
 			t.Errorf("expected a conditional display unit write, got %v", fake.queries)
 		}
@@ -232,7 +233,7 @@ func TestClassifyNewIngredients(t *testing.T) {
 		recipe := common.Recipe{Ingredients: []common.Ingredient{{
 			Name: "sumac", UnitSizes: map[string]float64{"": 0, "millilitre": -1},
 		}}}
-		classifyNewIngredients(recipe, fake)
+		classifyNewIngredients(context.Background(), recipe, fake)
 		if len(fake.queries) != 0 {
 			t.Errorf("expected no queries but got %v", fake.queries)
 		}
@@ -248,7 +249,7 @@ func TestClassifyNewIngredients(t *testing.T) {
 			Name: "sumac", BaseUnit: "gram", UnitSizes: map[string]float64{"millilitre": 0.5},
 		}}}
 
-		classifyNewIngredients(recipe, fake)
+		classifyNewIngredients(context.Background(), recipe, fake)
 
 		if len(fake.queries) != 2 {
 			t.Errorf("expected the unit size write to still be attempted, got %v", fake.queries)

--- a/netlify-functions/recipes/internal/pkg/service/recipes.go
+++ b/netlify-functions/recipes/internal/pkg/service/recipes.go
@@ -19,11 +19,10 @@ type Recipe struct {
 //
 // Takes a context so its query can be attributed to the request that caused it:
 // otelsql emits a span only for a call whose context already carries one (see
-// main.go's SpanFilter), which is what stops the still-uninstrumented routes
-// from producing rootless spans. The rest of the service layer keeps the
-// context-free signature until Session 3 threads it through.
+// main.go's SpanFilter). Every function in this package now does the same; this
+// one was simply first.
 func GetAllRecipes(ctx context.Context, db *sql.DB, userID string) ([]Recipe, error) {
-	accountID, err := GetAccountID(db, userID)
+	accountID, err := GetAccountID(ctx, db, userID)
 
 	if err != nil {
 		log.Println("Error getting account ID")

--- a/netlify-functions/recipes/internal/pkg/service/recipes.go
+++ b/netlify-functions/recipes/internal/pkg/service/recipes.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 	"database/sql"
-	"log"
+	"fmt"
 
 	"recipes/internal/pkg/telemetry"
 )
@@ -25,8 +25,7 @@ func GetAllRecipes(ctx context.Context, db *sql.DB, userID string) ([]Recipe, er
 	accountID, err := GetAccountID(ctx, db, userID)
 
 	if err != nil {
-		log.Println("Error getting account ID")
-		return nil, err
+		return nil, fmt.Errorf("getting account ID: %w", err)
 	}
 
 	// Recorded here because here is where it becomes known - the handler is
@@ -43,8 +42,7 @@ func GetAllRecipes(ctx context.Context, db *sql.DB, userID string) ([]Recipe, er
 	results, err := db.QueryContext(ctx, recipesQuery, accountID)
 
 	if err != nil {
-		log.Println("Error querying recipes")
-		return nil, err
+		return nil, fmt.Errorf("querying recipes: %w", err)
 	}
 	defer results.Close()
 

--- a/netlify-functions/recipes/internal/pkg/service/tags.go
+++ b/netlify-functions/recipes/internal/pkg/service/tags.go
@@ -1,12 +1,13 @@
 package service
 
 import (
+	"context"
 	"database/sql"
 )
 
 // GetAllTags returns all tags
-func GetAllTags(db *sql.DB) ([]string, error) {
-	results, err := db.Query("SELECT name FROM tag order by lower(name);")
+func GetAllTags(ctx context.Context, db *sql.DB) ([]string, error) {
+	results, err := db.QueryContext(ctx, "SELECT name FROM tag order by lower(name);")
 
 	if err != nil {
 		return nil, err

--- a/netlify-functions/recipes/internal/pkg/service/units.go
+++ b/netlify-functions/recipes/internal/pkg/service/units.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"database/sql"
 )
 
@@ -79,8 +80,8 @@ func (c UnitCatalog) Get(name string) UnitInfo {
 // GetUnitCatalog loads every Unit's measurement metadata in one query, for
 // passing into CombineIngredients. The aggregation itself stays pure - it takes
 // this as an argument and never queries.
-func GetUnitCatalog(db *sql.DB) (UnitCatalog, error) {
-	results, err := db.Query("SELECT name, kind, factor, default_size FROM unit;")
+func GetUnitCatalog(ctx context.Context, db *sql.DB) (UnitCatalog, error) {
+	results, err := db.QueryContext(ctx, "SELECT name, kind, factor, default_size FROM unit;")
 	if err != nil {
 		return nil, err
 	}
@@ -117,8 +118,8 @@ func GetUnitCatalog(db *sql.DB) (UnitCatalog, error) {
 }
 
 // GetAllUnits returns all unit types
-func GetAllUnits(db *sql.DB) ([]Unit, error) {
-	results, err := db.Query("SELECT id, name FROM unit order by lower(name);")
+func GetAllUnits(ctx context.Context, db *sql.DB) ([]Unit, error) {
+	results, err := db.QueryContext(ctx, "SELECT id, name FROM unit order by lower(name);")
 
 	if err != nil {
 		return nil, err

--- a/netlify-functions/recipes/internal/pkg/service/user.go
+++ b/netlify-functions/recipes/internal/pkg/service/user.go
@@ -1,12 +1,13 @@
 package service
 
 import (
+	"context"
 	"database/sql"
 	"log"
 	"recipes/internal/pkg/common"
 )
 
-func AddUser(db *sql.DB, user common.User) error {
+func AddUser(ctx context.Context, db *sql.DB, user common.User) error {
 	userQuery := `
 		INSERT INTO user (id, name, email)
 			VALUES (?, ?, ?)
@@ -17,7 +18,7 @@ func AddUser(db *sql.DB, user common.User) error {
 				last_logged_in_at=CURRENT_TIMESTAMP
 			;
 	`
-	_, err := db.Exec(userQuery, user.ID, user.Name, user.Email, user.Name, user.Email)
+	_, err := db.ExecContext(ctx, userQuery, user.ID, user.Name, user.Email, user.Name, user.Email)
 	if err != nil {
 		log.Println("Error adding user")
 		log.Println(err)
@@ -26,7 +27,7 @@ func AddUser(db *sql.DB, user common.User) error {
 	return nil
 }
 
-func GetUser(db *sql.DB, userID string) (u *common.User, e error) {
+func GetUser(ctx context.Context, db *sql.DB, userID string) (u *common.User, e error) {
 	userQuery := `SELECT id, name, email, onboarded, show_pantry_staples FROM user WHERE id = ?`
 	user := &common.User{}
 
@@ -34,7 +35,7 @@ func GetUser(db *sql.DB, userID string) (u *common.User, e error) {
 	// on the way out - a read of this User always states the preference,
 	// including when it is false. See the field's comment in common/types.go.
 	var showPantryStaples bool
-	if err := db.QueryRow(userQuery, userID).Scan(&user.ID, &user.Name, &user.Email, &user.Onboarded, &showPantryStaples); err != nil {
+	if err := db.QueryRowContext(ctx, userQuery, userID).Scan(&user.ID, &user.Name, &user.Email, &user.Onboarded, &showPantryStaples); err != nil {
 		return nil, err
 	}
 	user.ShowPantryStaples = &showPantryStaples
@@ -47,9 +48,9 @@ func GetUser(db *sql.DB, userID string) (u *common.User, e error) {
 // Takes the value rather than only ever setting true, unlike SetOnboarded above:
 // onboarding happens once and never un-happens, while this is a preference the
 // same person flips back and forth.
-func SetShowPantryStaples(db *sql.DB, userID string, show bool) error {
+func SetShowPantryStaples(ctx context.Context, db *sql.DB, userID string, show bool) error {
 	query := `UPDATE user SET show_pantry_staples = ? WHERE id = ?`
-	_, err := db.Exec(query, show, userID)
+	_, err := db.ExecContext(ctx, query, show, userID)
 	if err != nil {
 		log.Println("Error setting user show_pantry_staples")
 		log.Println(err)
@@ -59,9 +60,9 @@ func SetShowPantryStaples(db *sql.DB, userID string, show bool) error {
 }
 
 // SetOnboarded marks a user as having completed the onboarding screen.
-func SetOnboarded(db *sql.DB, userID string) error {
+func SetOnboarded(ctx context.Context, db *sql.DB, userID string) error {
 	query := `UPDATE user SET onboarded = true WHERE id = ?`
-	_, err := db.Exec(query, userID)
+	_, err := db.ExecContext(ctx, query, userID)
 	if err != nil {
 		log.Println("Error setting user onboarded")
 		log.Println(err)

--- a/netlify-functions/recipes/internal/pkg/service/user.go
+++ b/netlify-functions/recipes/internal/pkg/service/user.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 	"database/sql"
-	"log"
+	"fmt"
 	"recipes/internal/pkg/common"
 )
 
@@ -20,9 +20,7 @@ func AddUser(ctx context.Context, db *sql.DB, user common.User) error {
 	`
 	_, err := db.ExecContext(ctx, userQuery, user.ID, user.Name, user.Email, user.Name, user.Email)
 	if err != nil {
-		log.Println("Error adding user")
-		log.Println(err)
-		return err
+		return fmt.Errorf("adding user: %w", err)
 	}
 	return nil
 }
@@ -52,9 +50,7 @@ func SetShowPantryStaples(ctx context.Context, db *sql.DB, userID string, show b
 	query := `UPDATE user SET show_pantry_staples = ? WHERE id = ?`
 	_, err := db.ExecContext(ctx, query, show, userID)
 	if err != nil {
-		log.Println("Error setting user show_pantry_staples")
-		log.Println(err)
-		return err
+		return fmt.Errorf("setting user show_pantry_staples: %w", err)
 	}
 	return nil
 }
@@ -64,9 +60,7 @@ func SetOnboarded(ctx context.Context, db *sql.DB, userID string) error {
 	query := `UPDATE user SET onboarded = true WHERE id = ?`
 	_, err := db.ExecContext(ctx, query, userID)
 	if err != nil {
-		log.Println("Error setting user onboarded")
-		log.Println(err)
-		return err
+		return fmt.Errorf("setting user onboarded: %w", err)
 	}
 	return nil
 }

--- a/netlify-functions/recipes/internal/pkg/telemetry/http.go
+++ b/netlify-functions/recipes/internal/pkg/telemetry/http.go
@@ -7,28 +7,29 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
-// phase1Routes is the allow-list of operations that produce a server span.
+// healthRoute is the one path deliberately left untraced.
 //
-// specs/observability.md's Phase 1 is deliberately *one* route end to end
-// rather than everything at once, so that the first thing proved is that the
-// pipeline works - trace, its logs and its metric, correlated - on a surface
-// small enough to reason about. Phase 3 (Session 3) widens this to every route,
-// at which point this filter and Middleware's use of it both go away.
+// Phase 1's allow-list of a single route is gone: every route is instrumented
+// now, which is what Phase 3 asks for. What replaces it is a single exclusion,
+// because /health is polled rather than requested. Fly checks it every 30s on
+// every machine, and Session 7 adds a Grafana synthetic check at roughly 1/min
+// on top - several thousand spans a day, all identical, none of which anyone
+// will ever read. Left in, they would also dominate the duration histogram and
+// make the p99 of "a Big Shop request" mean nothing.
 //
-// Keyed by method and route together, and compared against route() rather than
-// the raw path, so the entries here are the same route templates that appear on
-// spans and metric labels rather than a second, subtly different spelling of
-// them. (A suffix match on the raw path would also work today - no other route
-// ends in "/recipes" - but only by luck: "/recipe" and "/recipes" are one
-// character apart and both exist.)
-//
-// Including the method is what makes this honestly "one route": keyed by path
-// alone, a POST or PUT to the same path would be traced too, which is one more
-// route than Phase 1 says it is instrumenting.
-var phase1Routes = map[string]bool{"GET /recipes": true}
+// Compared against route() rather than the raw path, so it is the same route
+// template that appears on spans and metric labels rather than a second,
+// subtly different spelling of it.
+const healthRoute = "/health"
+
+// unmatchedRoute is the single bucket every unrecognised path collapses into,
+// so that traffic nobody registered - 404s, vulnerability scanners, a typo -
+// cannot add label values to the metrics from outside.
+const unmatchedRoute = "unmatched"
 
 // Handler wraps the whole HTTP stack in OpenTelemetry instrumentation: one
 // server span per request, plus the http.server.request.duration histogram that
@@ -40,13 +41,13 @@ var phase1Routes = map[string]bool{"GET /recipes": true}
 // as well as the handler - if auth or CORS is what is slow, the span should say
 // so. The consequence is that the span starts before the user is known, which
 // is why the identifying attributes are added later, by Middleware.
-func Handler(next http.Handler, basePath string) http.Handler {
+func Handler(next http.Handler, basePath string, templates []string) http.Handler {
 	return otelhttp.NewHandler(next, "",
 		otelhttp.WithFilter(func(r *http.Request) bool {
-			return isTracedRoute(basePath, r.Method, r.URL.Path)
+			return isTracedRoute(basePath, templates, r.URL.Path)
 		}),
 		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
-			return r.Method + " " + route(basePath, r.URL.Path)
+			return r.Method + " " + route(basePath, templates, r.URL.Path)
 		}),
 		// otelhttp does not put http.route on its metrics unless told: it only
 		// knows the concrete URL, and guessing a template from it is the
@@ -60,7 +61,7 @@ func Handler(next http.Handler, basePath string) http.Handler {
 		// is bounded by the number of registered routes, not by the size of the
 		// recipe table.
 		otelhttp.WithMetricAttributesFn(func(r *http.Request) []attribute.KeyValue {
-			return []attribute.KeyValue{attribute.String("http.route", route(basePath, r.URL.Path))}
+			return []attribute.KeyValue{attribute.String("http.route", route(basePath, templates, r.URL.Path))}
 		}),
 	)
 }
@@ -86,12 +87,12 @@ func Handler(next http.Handler, basePath string) http.Handler {
 // The returned middleware is a no-op when the request was filtered out of
 // tracing - SpanFromContext gives back a non-recording span and every
 // SetAttributes call on it is discarded, so it needs no guard of its own.
-func Middleware(basePath string, userSub func(*http.Request) string) func(http.ResponseWriter, *http.Request, http.HandlerFunc) {
+func Middleware(basePath string, templates []string, userSub func(*http.Request) string) func(http.ResponseWriter, *http.Request, http.HandlerFunc) {
 	return func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		span := trace.SpanFromContext(r.Context())
 
 		attrs := []attribute.KeyValue{
-			attribute.String("http.route", route(basePath, r.URL.Path)),
+			attribute.String("http.route", route(basePath, templates, r.URL.Path)),
 		}
 
 		if sub := userSub(r); sub != "" {
@@ -125,47 +126,83 @@ func SetAccountID(ctx context.Context, accountID int) {
 	trace.SpanFromContext(ctx).SetAttributes(attribute.Int("account.id", accountID))
 }
 
-// isTracedRoute reports whether a method and path are in the Phase 1 allow-list.
-func isTracedRoute(basePath, method, path string) bool {
-	return phase1Routes[method+" "+route(basePath, path)]
+// isTracedRoute reports whether a request should produce a server span. Every
+// route does, except the health check - see healthRoute.
+//
+// One test covers both paths app.go answers the check on. `base + "/health"`
+// has its prefix stripped by route(); a bare "/health" does not match the
+// prefix and passes through unchanged. Both arrive here as "/health".
+func isTracedRoute(basePath string, templates []string, path string) bool {
+	return route(basePath, templates, path) != healthRoute
 }
 
 // route reduces a request path to the low-cardinality template that belongs on
-// a span and, more importantly, on the duration histogram's labels.
+// a span name and, more importantly, on the duration histogram's labels.
 //
-// Without this, "/recipe/41" and "/recipe/42" are different label values and the
-// series count grows with the Recipe table - the unbounded-label failure
-// ADR-0008 §2 is about.
+// Matched against the templates the router actually registered, rather than
+// inferred from the shape of the path. Inferring was the first implementation
+// and it was wrong in a way that mattered: it replaced any *numeric* segment
+// with {id}, which is fine for "/recipe/41" and useless for "/recipe/katsu-
+// curry" - `GET /recipe/{id}` accepts a slug too (app/recipe.go tries
+// strconv.Atoi and falls back to a slug lookup). That put a **recipe name**
+// into the span name and into an `http.route` metric label: content on a span,
+// which ADR-0008 §1 forbids, and an unbounded label, which §2 forbids and
+// which grows the series count with the size of the recipe table.
 //
-// basePath is passed in rather than hardcoded because main.go already owns that
-// value and it is genuinely two different strings at runtime - "/api/bigshop"
-// for the server, "/.netlify/functions/recipes" for the Lambda. A copy of the
-// literal here would go stale silently: routes would keep their prefix, every
-// label would change, and nothing would fail.
-func route(basePath, path string) string {
+// Anything not matching a registered template collapses to "unmatched" - one
+// bucket for 404s, scanners and probes, which are otherwise the easiest way for
+// a stranger to add label values to your metrics from the outside.
+func route(basePath string, templates []string, path string) string {
 	if basePath != "" && strings.HasPrefix(path, basePath) {
 		path = path[len(basePath):]
 	}
-	if path == "" {
-		return "/"
+	if path == healthRoute {
+		return healthRoute
 	}
 	segments := strings.Split(path, "/")
-	for i, s := range segments {
-		if isNumeric(s) {
-			segments[i] = "{id}"
+	for _, t := range templates {
+		if matchTemplate(strings.Split(t, "/"), segments) {
+			return t
 		}
 	}
-	return strings.Join(segments, "/")
+	return unmatchedRoute
 }
 
-func isNumeric(s string) bool {
-	if s == "" {
+// matchTemplate reports whether a concrete path matches a route template,
+// treating any {placeholder} segment as a wildcard.
+func matchTemplate(tmpl, segments []string) bool {
+	if len(tmpl) != len(segments) {
 		return false
 	}
-	for _, c := range s {
-		if c < '0' || c > '9' {
+	for i, t := range tmpl {
+		if strings.HasPrefix(t, "{") && strings.HasSuffix(t, "}") {
+			if segments[i] == "" {
+				return false
+			}
+			continue
+		}
+		if t != segments[i] {
 			return false
 		}
 	}
 	return true
+}
+
+// RecordHandlerError attaches a failed handler's error to the request's span.
+//
+// Split by status deliberately. The error is always *recorded*, so the cause is
+// there to read whatever happened - but only 5xx sets the span's status to
+// Error. A 404 for a Recipe that does not exist, or a 422 for a malformed body,
+// is the API working correctly; marking those spans failed would make "show me
+// the errors" mean "show me the traffic", which is the fastest way to make an
+// error rate worthless.
+//
+// A no-op on an untraced request: SpanFromContext returns a non-recording span
+// and discards both calls.
+func RecordHandlerError(ctx context.Context, err error, status int) {
+	span := trace.SpanFromContext(ctx)
+	span.RecordError(err)
+	if status >= http.StatusInternalServerError {
+		span.SetStatus(codes.Error, err.Error())
+	}
 }

--- a/netlify-functions/recipes/internal/pkg/telemetry/http.go
+++ b/netlify-functions/recipes/internal/pkg/telemetry/http.go
@@ -206,3 +206,32 @@ func RecordHandlerError(ctx context.Context, err error, status int) {
 		span.SetStatus(codes.Error, err.Error())
 	}
 }
+
+// RecordWarning notes a non-fatal problem on the request's span.
+//
+// For the failures a caller deliberately ignores - best-effort catalog
+// enrichment, a shopping-list history row that did not get written - where
+// there is no error to return and wrapping is therefore not available. A span
+// event keeps the service layer free of logging (ADR-0008 §3) while leaving the
+// fact somewhere it can be found, attached to the request that caused it.
+//
+// `what` names the operation and is expected to be a short fixed string, not a
+// formatted detail: the lines this replaced named the ingredient ("could not
+// set unit size %q for %q"), and ingredient text is what ADR-0008 §1 says
+// telemetry does not carry. That is a real loss of resolution, and it is the
+// trade the ADR already makes explicit - the identifiers narrow it to one
+// request and one Account, and the rest is reproducible locally.
+//
+// It is a convention rather than a guarantee, and worth being honest about:
+// err.Error() is passed through, and some driver errors embed the offending
+// value (MySQL 1062 reads `Duplicate entry 'chicken thighs' for key ...`). The
+// same is true of any error reaching a span through fail(). Sanitising driver
+// text was considered and rejected as the kind of filter that is wrong in both
+// directions; the containment is that these are Grafana Cloud, not a public
+// surface.
+func RecordWarning(ctx context.Context, what string, err error) {
+	trace.SpanFromContext(ctx).AddEvent("warning", trace.WithAttributes(
+		attribute.String("warning.operation", what),
+		attribute.String("warning.error", err.Error()),
+	))
+}

--- a/netlify-functions/recipes/internal/pkg/telemetry/http_test.go
+++ b/netlify-functions/recipes/internal/pkg/telemetry/http_test.go
@@ -1,0 +1,86 @@
+package telemetry
+
+import "testing"
+
+// templates stands in for what app.RouteTemplates returns from the live router.
+var templates = []string{
+	"/account",
+	"/recipe",
+	"/recipe/{id}",
+	"/recipes",
+	"/shopping-list",
+	"/shopping-list/buy",
+	"/user/preferences",
+}
+
+// TestRouteIsBoundedAndCarriesNoContent is the guard on ADR-0008's two rules
+// that this function alone enforces: no unbounded metric labels (§2), and no
+// content on spans (§1).
+//
+// The slug case is the one that matters and the one an earlier implementation
+// got wrong. `GET /recipe/{id}` accepts a slug as well as a numeric id, so a
+// route derived by "replace digits with {id}" let a **recipe name** through
+// into the span name and into an http.route label - content, and a label whose
+// value set grows with the recipe table.
+func TestRouteIsBoundedAndCarriesNoContent(t *testing.T) {
+	const base = "/api/bigshop"
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"numeric id collapses", base + "/recipe/41", "/recipe/{id}"},
+		{"slug collapses too, and does not leak the recipe name", base + "/recipe/katsu-curry", "/recipe/{id}"},
+		{"a slug that looks like a sentence", base + "/recipe/mums-sunday-roast-2", "/recipe/{id}"},
+		{"static route is itself", base + "/recipes", "/recipes"},
+		{"nested static route", base + "/shopping-list/buy", "/shopping-list/buy"},
+		{"sibling of a templated route stays distinct", base + "/recipe", "/recipe"},
+		{"unregistered path is one bucket", base + "/wp-admin.php", unmatchedRoute},
+		{"deep unregistered path is the same bucket", base + "/a/b/c/d", unmatchedRoute},
+		{"empty id does not match the template", base + "/recipe/", unmatchedRoute},
+		{"health keeps its own name", base + "/health", healthRoute},
+		{"bare health, without the base prefix", "/health", healthRoute},
+		{"the bare base path, which nothing registers", base, unmatchedRoute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := route(base, templates, tt.path); got != tt.want {
+				t.Errorf("route(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestOnlyHealthIsUntraced pins the single carve-out from "instrument every
+// route". Fly polls /health every 30s per machine and a Grafana synthetic check
+// adds more, so tracing it would bury real traffic and skew the duration
+// histogram; everything else, including traffic nobody registered, is traced.
+func TestOnlyHealthIsUntraced(t *testing.T) {
+	const base = "/api/bigshop"
+
+	untraced := []string{base + "/health", "/health"}
+	for _, p := range untraced {
+		if isTracedRoute(base, templates, p) {
+			t.Errorf("expected %q to be untraced", p)
+		}
+	}
+
+	traced := []string{base + "/recipes", base + "/recipe/41", base + "/wp-admin.php"}
+	for _, p := range traced {
+		if !isTracedRoute(base, templates, p) {
+			t.Errorf("expected %q to be traced", p)
+		}
+	}
+}
+
+// TestRouteHandlesTheLambdaBasePath guards the reason basePath is a parameter
+// rather than a constant: it is genuinely two different strings at runtime, and
+// a hardcoded copy would silently stop stripping.
+func TestRouteHandlesTheLambdaBasePath(t *testing.T) {
+	const lambdaBase = "/.netlify/functions/recipes"
+	if got := route(lambdaBase, templates, lambdaBase+"/recipe/41"); got != "/recipe/{id}" {
+		t.Errorf("route under the Lambda base = %q, want %q", got, "/recipe/{id}")
+	}
+}

--- a/netlify-functions/recipes/main.go
+++ b/netlify-functions/recipes/main.go
@@ -35,6 +35,11 @@ var openapiAPI huma.API
 // the App actually built, not a second guess at it.
 var purgeConfigured bool
 
+// routeTemplates is the set of path templates the router registered, used to
+// keep span names and metric labels bounded. Captured at startup because it is
+// fixed for the life of the process.
+var routeTemplates []string
+
 // shutdownTelemetry flushes the three OTel providers at exit. Replaced by
 // init() with the real one; telemetry.Setup always returns a callable shutdown
 // even when telemetry is disabled or setup failed.
@@ -138,17 +143,17 @@ func init() {
 		otelsql.WithAttributes(semconv.DBSystemNameMySQL),
 		otelsql.WithSpanOptions(otelsql.SpanOptions{
 			// Emit a query span only when the caller passed a context that
-			// already carries one. Almost all of the service layer still calls
-			// db.Query/Exec/QueryRow rather than the *Context variants - 57 such
-			// call sites against a single Context one, the GetAllRecipes query
-			// this session threaded - and those resolve to context.Background(),
-			// which otelsql would otherwise turn into a *root* span, flooding
-			// Tempo with rootless single-span traces that mean nothing.
+			// already carries one.
 			//
-			// This makes the incremental rollout self-managing rather than
-			// hazardous: a query lights up the moment its route is threaded
-			// with a context, and stays silent until then, with no further
-			// configuration. Session 3 threads the rest.
+			// Session 3 threaded ctx through the whole service layer, so there
+			// are now no context-free DB calls left and this filter rejects
+			// nothing in normal operation. It stays as a guard rather than
+			// housekeeping: any future query written with db.Query instead of
+			// db.QueryContext - or any code path reaching the database outside
+			// a request, such as a future migration or cron - would otherwise
+			// produce a *root* span, and Tempo would fill with rootless
+			// single-span traces that mean nothing. Cheap insurance against a
+			// mistake that is silent in every other way.
 			SpanFilter: func(ctx context.Context, _ otelsql.Method, _ string, _ []driver.NamedValue) bool {
 				return trace.SpanContextFromContext(ctx).IsValid()
 			},
@@ -188,11 +193,14 @@ func init() {
 	}
 	purgeConfigured = application.PurgeConfigured()
 
-	router, _, err = application.GetRouter(routerBasePath())
+	var api huma.API
+	router, api, err = application.GetRouter(routerBasePath())
 	if err != nil {
 		fmt.Println("Failed to get application router")
 		fmt.Println(err)
 	}
+
+	routeTemplates = app.RouteTemplates(api)
 
 	negroniLambda = negroniadapter.New(router)
 }
@@ -245,7 +253,7 @@ func main() {
 			// wrapped: the Lambda below is the rollback target from ADR-0006 and
 			// is left exactly as it was, which is also why it needs no telemetry
 			// of its own - it serves no traffic unless the migration is undone.
-			Handler: telemetry.Handler(router, basePath),
+			Handler: telemetry.Handler(router, basePath, routeTemplates),
 		}
 		// Fatal rather than ignored: a bind failure used to exit 0 silently,
 		// which on Fly would be a restart loop with no reason recorded.

--- a/specs/observability.state.md
+++ b/specs/observability.state.md
@@ -270,8 +270,20 @@ middleware at the Huma boundary (`span.RecordError` + `span.SetStatus`);
 spans every query rather than only `/recipes`. **`/health` is deliberately not changed** — see
 correction 6.
 Depends on: Session 2
-Commit:
-Notes:
+Commit: ce2549e
+Notes: Verified against local LGTM by reading traces back, not by assuming export worked.
+Every route now carries DB child spans where before only `/recipes` did, and only one of its
+two queries: `/shopping-list` 30 sql spans, `/recipe/{id}` 12, `/account` 8, `/user` 4,
+`/tags`/`/units`/`/ingredients` 2 each. `/health` produces none. `http_route` label values are
+exactly the registered templates plus `unmatched`.
+
+Test gate: `scripts/build-local.sh` green (four Go packages, both drift checks);
+`npm run test:e2e` 27/27.
+Review gate: two real defects caught and fixed before commit, both of which had gone live the
+moment the allow-list came off — an unbounded/content-carrying `http.route` (slugs and
+unregistered paths), and `huma.Error500InternalServerError(msg, err)` serialising the cause to
+the client while *not* recording it on the span. Also fixed: three comments that had become
+false, `db.Begin` → `BeginTx`, and a bare `500`.
 
 ## Session 4: Phase 3b — the log cleanup
 Status: pending

--- a/specs/observability.state.md
+++ b/specs/observability.state.md
@@ -113,14 +113,35 @@ present and is wrong:
   declared in the telemetry package, and Go compares context keys by type as well as value.
 
 ## Session 2: Phase 2 — production, and the checkpoint
-Status: in-progress
+Status: in-progress (deployed; exit criteria not yet met)
 Scope: OTel Collector as a sidecar in the Fly app; Go exports to `localhost:4318`; Grafana
 credentials in collector config only. The three exit criteria: production trace + correlated
 logs + metric; latency statistically unchanged; blackhole failure injection proving a dead
 collector is a silent drop.
 Depends on: Session 1
-Commit:
-Notes: **BLOCKED on the user.** Needs, before any of this session can run:
+Commit: 5f94c8f (PR #93)
+
+**Deployed 2026-08-11. Not verified.** Both machines run `['api', 'otelcol']`, 1/1, health
+200; the collector started cleanly on both with no export errors (a bad credential would show
+as a 401/403, and the config logs at `warn`, so failures are not being swallowed). The stray
+probe container from the investigation is gone — this deploy cleared it by declaring
+`containers` explicitly, which is the only thing that can.
+
+**The three exit criteria remain open, and one cannot be checked from here:**
+1. *Trace in Tempo + logs in Loki + metric in Mimir.* Requires querying Grafana Cloud, whose
+   credentials are Fly secrets scoped to the collector container and deliberately never seen by
+   anyone working on the Go side. Needs a human with Grafana access, and an **authenticated**
+   `GET /recipes` — unauthenticated 401s do produce spans (otelhttp wraps outside the auth
+   middleware) but carry no `account.id`/`user.sub`, so they prove the pipeline and not the
+   attributes. **Check `service.version` first**: a 7-char sha means the `--build-arg` wiring
+   works, `unknown` means it silently didn't.
+2. *Latency unchanged.* Preliminary only: `/recipes` 401s at 48–89ms against `/health` at
+   44–60ms, both dominated by the network hop to Frankfurt. No new per-request cost visible,
+   but this is weak evidence, not a measurement.
+3. *Blackhole failure injection.* **Not done.** Proven locally; the spec asks for it in
+   production, which means deliberately misconfiguring a working export and a deploy cycle.
+
+Original blocking notes, kept for the record: **BLOCKED on the user.** Needs, before any of this session can run:
 1. A Grafana Cloud Free stack (region is permanent — ADR-0007 picks eu-central-1/Frankfurt).
 2. Its OTLP endpoint, instance ID and token, to be set with `fly secrets set` — never committed.
    **Use the names Grafana's own OpenTelemetry tile emits**, so its snippets and docs line up

--- a/specs/observability.state.md
+++ b/specs/observability.state.md
@@ -285,9 +285,40 @@ unregistered paths), and `huma.Error500InternalServerError(msg, err)` serialisin
 the client while *not* recording it on the span. Also fixed: three comments that had become
 false, `db.Begin` → `BeginTx`, and a bare `500`.
 
+### Correction 8 — where the removed logging actually went
+
+The spec says "Convert only those carrying genuine extra context to `slog`". Nothing was
+converted to slog. Two substitutions were made instead:
+
+- **Span events, not slog, for the four best-effort failures** (catalog enrichment, shopping-
+  list history). Their callers deliberately ignore the error, so there is nothing to wrap and
+  return; `telemetry.RecordWarning` attaches the fact to the request's span. This keeps the
+  service layer free of logging entirely, which ADR-0008 §3 asks for and slog would not have.
+- **`main.go` and `internal/pkg/purge/purge.go` keep stdlib `log`** — 11 lines. Startup and
+  fatal messages happen before any request exists, and the purger is a detached fire-and-forget
+  goroutine with no request context, so in both cases there is no span to attach to and no
+  trace_id to correlate by. The consequence, worth stating: those lines reach Fly's log stream
+  and never Loki. A purge that silently stops working is therefore still invisible in Grafana —
+  a real gap, and a candidate for `follow-ups.md` rather than for widening this session.
+
+### Correction 9 — the spec's log counts were measured with the wrong instrument
+
+The spec says "70 `log.*` calls ... 26 of them a bare `log.Println(err)`", and earlier notes
+here corrected that to 87/27. All three counts only ever matched `log.*`. The service layer
+also had **21 `fmt.Print*` calls**, including — on the invite path —
+
+```go
+fmt.Println(email)
+fmt.Println(token)
+```
+
+An email address is named in ADR-0008 §1 as excluded by rule, and an invite token is a bearer
+credential; both were being written to stdout, which on Fly is the log stream. Found by review,
+not by the counting. Session 4 removes all 21.
+
 ## Session 4: Phase 3b — the log cleanup
-Status: pending
-Scope: delete the 27 bare `log.Println(err)` calls and everything else the span makes redundant;
+Status: done
+Scope: delete the bare `log.Println(err)` calls and everything else the span makes redundant;
 service layer stops logging and wraps errors per ADR-0008 §3; convert only genuinely-extra-
 context lines to `slog`. Net fewer lines than we started with.
 Depends on: Session 3

--- a/specs/observability.state.md
+++ b/specs/observability.state.md
@@ -322,8 +322,24 @@ Scope: delete the bare `log.Println(err)` calls and everything else the span mak
 service layer stops logging and wraps errors per ADR-0008 §3; convert only genuinely-extra-
 context lines to `slog`. Net fewer lines than we started with.
 Depends on: Session 3
-Commit:
-Notes: Split from Session 3 on purpose — 17 files, far easier to review once the spans that
+Commit: 89cbb1c
+Notes: Verified end to end against local LGTM by stopping the database and reading the trace
+back: root `GET /recipes` with `STATUS_CODE_ERROR` and two exception events — the wrapped cause
+(`getting account ID: dial tcp: lookup db ... no such host`) and what the client was told
+(`Failed to get recipes from db`) — while the HTTP body carried only the opaque message.
+
+Final state: 0 log/print calls in `internal/pkg/service`, 0 `fmt.Print*` anywhere in
+`internal/`, 11 stdlib `log` calls left in `main.go` and `purge.go` (correction 8). Net −31
+lines across the session.
+
+Test gate: `scripts/build-local.sh` green; `npm run test:e2e` 27/27.
+Review gate: both axes blocked on the same finding — 21 `fmt.Print*` calls the `log.*` count
+could not see, two of them writing an invite email and token to stdout (correction 9). Also
+fixed: `fail()` classifying span errors by client status rather than cause, a wrapped
+`sql.ErrNoRows` plus the `==` comparison that would have broken on it, four wrap-text defects,
+and ten `%v` formats in `history.go` that never wrapped.
+
+Split from Session 3 on purpose — 17 files, far easier to review once the spans that
 justify each deletion already exist. Spec's counts (70/26) were stale; actual is 87/27.
 
 ## Session 5: Phase 4 — Next.js functions and propagation

--- a/specs/observability.state.md
+++ b/specs/observability.state.md
@@ -10,8 +10,8 @@ and [ADR-0008](../docs/adr/0008-what-telemetry-does-not-carry.md). Sessions 1–
 spec's Phases 1–6, with Phase 3 split across two Sessions and a preparatory Session 0 the spec
 does not contain.
 
-Four corrections to the spec, agreed at planning time and applied by the Sessions below rather
-than by editing the spec:
+Corrections to the spec, applied by the Sessions below rather than by editing the spec. The
+first four were agreed at planning time; the rest were forced by what the work turned up.
 
 1. `go.opentelemetry.io/otel` v1.45.0 declares `go 1.25.0`; the module is on `go 1.23.0`. Hence
    Session 0. (User chose the bump over pinning otel to a ~18-month-old v1.35.x.)
@@ -229,11 +229,46 @@ Researched while blocked:
 - **`DEPLOY_ENV=production`** needs setting in `fly.toml`'s `[env]`, or production telemetry
   arrives labelled `development` and is indistinguishable from a laptop's in the same Tempo.
 
+### Correction 6 — `/health` stays as it is
+
+The spec's Phase 3 says **"Fix `/health` to `SELECT 1`"**, and its "Current state" calls the
+present check "a health check that checks nothing". Ian decided against it on 2026-08-11:
+`/health` should answer only "is this machine up and the Go process serving", and database
+connectivity should be observed through telemetry rather than through a health check.
+
+**Why this is the better answer, now:** `/health` backs a *Fly health check*. Making it depend
+on TiDB means a database outage causes Fly to fail health checks and start cycling machines
+that are themselves perfectly healthy — turning a degraded dependency into a restart storm, and
+removing the one thing still able to serve cached or non-DB responses. The spec's complaint was
+that a warm container with a dead database looks fine; the answer to that is a metric and an
+alert, which is what the rest of this spec builds.
+
+Also worth recording, because it makes the check less empty than the spec implies: `main.go`
+`log.Fatalf`s on a failed DB ping during init, so a process that is serving at all did reach
+the database at startup. What is missing is only the *continuous* signal — and that is
+telemetry's job.
+
+### Correction 7 — two carve-outs in Session 3, both deliberate
+
+- **`/health` is not traced.** The spec says "instrument every route via middleware". Every
+  route is, bar this one: Fly polls it every 30s per machine and Session 7 adds a Grafana
+  synthetic check at ~1/min, so tracing it would add thousands of identical spans a day and
+  drag the duration histogram's p99 towards the cost of a health check rather than of a
+  request.
+- **`span.SetStatus` fires only on 5xx**, though `span.RecordError` fires on every returned
+  error. The spec says "`span.RecordError` + `span.SetStatus` on any returned error". A 404 for
+  a Recipe that does not exist is the API working; marking those spans failed would make "show
+  me the errors" mean "show me the traffic". The cause is still recorded and readable — only
+  the red flag is withheld.
+
 ## Session 3: Phase 3a — widen the Go API
-Status: pending
+Status: done
 Scope: every route instrumented via middleware rather than per-handler code; error-recording
-middleware at the Huma boundary (`span.RecordError` + `span.SetStatus`); `/health` becomes a
-real `SELECT 1`; `internal/pkg/app/account.go:41` stops discarding the real error.
+middleware at the Huma boundary (`span.RecordError` + `span.SetStatus`);
+`internal/pkg/app/account.go` stops discarding the real error at **both** sites (`:41` and
+`:69` — the spec names only one); and `ctx` threaded through the service layer so `otelsql`
+spans every query rather than only `/recipes`. **`/health` is deliberately not changed** — see
+correction 6.
 Depends on: Session 2
 Commit:
 Notes:

--- a/specs/observability.state.md
+++ b/specs/observability.state.md
@@ -113,7 +113,7 @@ present and is wrong:
   declared in the telemetry package, and Go compares context keys by type as well as value.
 
 ## Session 2: Phase 2 — production, and the checkpoint
-Status: in-progress (deployed; exit criteria not yet met)
+Status: done
 Scope: OTel Collector as a sidecar in the Fly app; Go exports to `localhost:4318`; Grafana
 credentials in collector config only. The three exit criteria: production trace + correlated
 logs + metric; latency statistically unchanged; blackhole failure injection proving a dead
@@ -127,7 +127,23 @@ as a 401/403, and the config logs at `warn`, so failures are not being swallowed
 probe container from the investigation is gone — this deploy cleared it by declaring
 `containers` explicitly, which is the only thing that can.
 
-**The three exit criteria remain open, and one cannot be checked from here:**
+**Exit criteria, as actually resolved:**
+1. **Met.** A production trace was read back in Tempo: root `bigshop/bigshop-api GET /recipes`
+   (77.65ms) with `sql.conn.query` and `sql.rows` beneath it, `Route /recipes`, 200. Confirmed
+   by Ian, who has the Grafana access this side deliberately does not.
+2. **Preliminary only.** No new per-request cost visible, but the measurement is weak (see
+   below); not a controlled before/after.
+3. **Not run.** Waived by Ian in favour of moving to Phase 3. Proven locally — the collector
+   starts, stays up and logs nothing against a blackholed endpoint — but never demonstrated in
+   production, which is what the spec asked for. Recorded as skipped rather than passed.
+
+While diagnosing, one thing worth keeping: Tempo's search table can show
+`<root span not yet received>` for a perfectly good trace. A span is exported when it *ends*,
+and the root ends last, so children reach the index in an earlier batch than their parent. It
+resolves itself. Single-span traces (e.g. a 401 that never touches the DB) never show it, which
+makes it look like a pattern with meaning when it has none.
+
+**Original notes, kept because they explain the shape of the work:**
 1. *Trace in Tempo + logs in Loki + metric in Mimir.* Requires querying Grafana Cloud, whose
    credentials are Fly secrets scoped to the collector container and deliberately never seen by
    anyone working on the Go side. Needs a human with Grafana access, and an **authenticated**


### PR DESCRIPTION
Phase 3 of [`specs/observability.md`](specs/observability.md), split across two sessions: widen
instrumentation across the whole Go API, then delete the logging it makes redundant.

Backend only — no user-visible surface, so no screenshots. Evidence is trace data, read back
from a local LGTM stack rather than inferred from export succeeding.

## Session 3 — every route instrumented

**`ctx` threaded through ~45 service functions**, every call site, both the `execer`/`dbConn`
interfaces and the test double. Every DB call is a `*Context` variant; the three write
transactions use `BeginTx`. This is what makes `otelsql`'s `SpanFilter` fire — before it, only
`GET /recipes` produced spans, and only one of its two queries.

| Route | spans | of which SQL |
|---|---|---|
| `GET /shopping-list` | 31 | 30 |
| `GET /recipe/{id}` | 13 | 12 |
| `GET /recipes`, `/account` | 9 | 8 |
| `GET /user` | 5 | 4 |
| `/tags`, `/units`, `/ingredients` | 3 | 2 |
| `GET /health` | 0 | — |

`GET /shopping-list` issuing 30 database operations in one request is exactly the sort of thing
this spec exists to make visible.

**Errors recorded at the Huma boundary** by wrapping `huma.Register`. A `huma.UseMiddleware`
middleware cannot do it — middleware sees `huma.Context`, which exposes `Status()` but never
the returned error — so it would record that *something* failed and lose the cause, which is
now the only copy. `RecordError` fires on every returned error; `SetStatus` only when the cause
is unexpected, so a 404 for a missing Recipe does not turn "show me the errors" into "show me
the traffic".

**`app/account.go` stops discarding the real error** at both sites, not the one the spec names.

## Session 4 — the service layer stops logging

ADR-0008 §3 has described this as already true since it was written. It now is: zero log or
print calls in `internal/pkg/service`. Errors are wrapped with what was being attempted;
best-effort failures whose callers ignore them became span events.

Verified by stopping the database and reading the trace back:

```
ROOT: GET /recipes | status: STATUS_CODE_ERROR
  event: exception -> getting account ID: dial tcp: lookup db ... no such host   ← the cause
  event: exception -> Failed to get recipes from db                             ← the client's message
```

…while the HTTP response body carried **only** `{"detail":"Failed to get recipes from db"}`.

## What review caught, and why it matters

Four of these were live defects in code I had written and described as correct.

1. **`route()` collapsed only numeric segments**, but `GET /recipe/{id}` also takes a slug. A
   recipe name reached the span name and the `http.route` metric label — content (ADR-0008 §1)
   and an unbounded label (§2). Any unregistered path did the same, letting a stranger add
   label values from outside. Routes now match against the templates the router registered,
   read from the Huma API so they cannot drift, with one `unmatched` bucket. The telemetry
   package gets its first tests.
2. **`huma.Error500InternalServerError(msg, err)` serialises the cause to the client** via
   `ErrorModel.Errors` — so "preserve the real error" would have put raw TiDB strings in HTTP
   responses, *and* still not reached the span, since `ErrorModel.Error()` returns only
   `Detail`.
3. **21 `fmt.Print*` calls in the service layer**, invisible to the `log.*` count that reported
   the cleanup as finished. Two wrote an invite **email address and token** to stdout. ADR-0008
   §1 names email as excluded by rule; a token is a bearer credential.
4. **`fail()` classified span errors by client status**, and several handlers answer a failed DB
   call with a 400 or 404 — so a TiDB outage would have vanished from the error rate.

Also: a wrapped `sql.ErrNoRows` plus the `==` comparison it would eventually break (now
`errors.Is`), four wrap-text defects, and ten `%v` formats in `history.go` that never wrapped.

## Deviations, recorded in the state file

- **Correction 7** — `/health` is not traced (Fly polls it every 30s per machine); `SetStatus`
  fires only on unexpected causes.
- **Correction 8** — the four best-effort lines became span events rather than `slog`, and
  `main.go`/`purge.go` keep stdlib `log` (11 lines, no span to attach to). Consequence stated:
  those reach Fly's logs and never Loki, so a silently-failing cache purge is still invisible in
  Grafana — a real gap, flagged rather than widened into.
- **Correction 9** — the spec's log counts (70/26, later 87/27) only ever matched `log.*`.

## Testing

`scripts/build-local.sh` green (four Go packages, both drift checks); `npm run test:e2e` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
