### PR TITLE
Add follow-up #58: the marketing page flashes before auth resolves

### DIFF
--- a/follow-ups.md
+++ b/follow-ups.md
@@ -581,3 +581,57 @@ Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are r
     JWKS, explicitly to prevent SSRF. On v2 a token carrying an attacker-chosen `iss`
     reaches the key fetch first, which is the shape #54 flagged as "unauthenticated work"
     in the first place.
+
+58. **A logged-in user sees the marketing page flash before the homepage realises who they
+    are.** Going to `/` while already logged in renders the full pitch — hero, list preview,
+    the lot — then blanks, then lands on `/list`. Three states where there should be one,
+    and the first of them is the page that exists to sell the product to someone who does
+    not have it.
+
+    The guard is already there and covers the wrong half of the window.
+    `pages/index.tsx:198` reads
+
+    ```ts
+    const resolvingLoggedInUser = isAuthenticated && status !== 'onboarding';
+    ```
+
+    which blanks the page once Auth0 has confirmed a session but the `POST /user` behind
+    `status` has not come back yet. What it does not cover is *before* that: while the SDK
+    is still checking, `isLoading` is true and `isAuthenticated` is **false**, which is
+    indistinguishable from logged-out as far as that line is concerned, so the marketing
+    page renders in full. The comment above it already states the intent ("kept blank
+    rather than flashing the marketing copy at an already-onboarded user") — the condition
+    just does not implement it.
+
+    So the sequence is: marketing page (Auth0 loading) → blank (`isAuthenticated`, awaiting
+    `POST /user`) → `router.replace('/list')` at `pages/index.tsx:180`. The header shows
+    the same seam on its own, without any redirect: `pages/index.tsx:228` swaps "Log in"
+    for "Your shopping list" when `isAuthenticated` flips, so a returning user watches the
+    button change under the cursor.
+
+    **`isLoading || isAuthenticated` is the obvious fix and it is not free**, which is why
+    this is written down rather than done. That blanks the homepage for *every* first-time
+    anonymous visitor for as long as the Auth0 check takes — and they are the entire
+    audience for that page. `_app.tsx` configures `cacheLocation="localstorage"` with
+    `useRefreshTokens={true}`, so the check can involve a token refresh over the network,
+    not just a synchronous read. Trading a flash seen by returning users for a blank screen
+    seen by new ones is the wrong way round; #42 is about exactly how fragile that first
+    visit is.
+
+    Two directions worth costing before picking one:
+
+    - **Decide synchronously from the SDK's own cache.** With `cacheLocation="localstorage"`
+      the client writes a key prefixed `@@auth0spajs@@::<clientId>::…`, readable on first
+      render before any network call. Its presence is a good-enough hint of "there was a
+      session here" to choose between blanking and rendering, with the real answer still
+      arriving normally. Needs checking against the SDK version actually installed rather
+      than assumed — the key format is internal and has changed before.
+    - **Stop making `/` do two jobs.** The redirect exists because the marketing page and
+      the logged-in entry point share a route. A logged-in user could be sent to `/list`
+      before the page renders at all, which is a Next.js middleware or a server-side
+      session question, and would settle #42's "land in an account holding nothing" problem
+      in the same move rather than layering another client-side guard on top.
+
+    Not urgent — it is cosmetic, and only on a route a logged-in user reaches by typing the
+    bare domain. But it reads as broken to the one audience that already trusts the
+    product, and the fix is cheap in one of the two directions above.


### PR DESCRIPTION
Adds one item to `follow-ups.md`. Documentation only — no code change.

Going to `/` while already logged in renders the full marketing page, then blanks, then lands on `/list`.

### What's actually happening

The guard is already there and covers the wrong half of the window. `pages/index.tsx:198`:

```ts
const resolvingLoggedInUser = isAuthenticated && status !== 'onboarding';
```

That blanks the page once Auth0 has confirmed a session but the `POST /user` behind `status` hasn't returned. It does not cover the window *before* that: while the SDK is still checking, `isLoading` is true and `isAuthenticated` is **false**, which is indistinguishable from logged-out as far as that line is concerned. The comment directly above it already states the intent — the condition just doesn't implement it.

The header shows the same seam without any redirect: `pages/index.tsx:228` swaps "Log in" for "Your shopping list" when `isAuthenticated` flips.

### Why it's a follow-up and not a fix

`isLoading || isAuthenticated` is the obvious one-line change and it isn't free — it blanks the homepage for every first-time anonymous visitor for as long as the Auth0 check takes, and they're the entire audience for that page. `_app.tsx` uses `cacheLocation="localstorage"` with `useRefreshTokens={true}`, so that check can involve a network round trip. Trading a flash seen by returning users for a blank screen seen by new ones is the wrong way round.

The entry costs two directions instead: reading the SDK's own localStorage cache synchronously to decide before first paint, or taking the redirect off the client entirely so `/` stops doing two jobs — which would also bear on #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)