### PR TITLE
Deleting a Recipe that is not there answers 404, not 500 (#56)

### DIFF
--- a/e2e/api.ts
+++ b/e2e/api.ts
@@ -49,7 +49,16 @@ export async function deleteRecipeById(request: APIRequestContext, id: number): 
   // Asserted, deliberately. This silently swallowed failures for months: every
   // Recipe that reached a Shopping List failed to delete (follow-ups.md #24)
   // and the suite never noticed, because teardown ignored the status.
+  //
+  // 404 is the one exception, and only because the API now distinguishes it.
+  // Teardown deletes by id, spec *files* run in parallel against one shared
+  // Account, and a Recipe can be gone before its own teardown runs - so
+  // "already gone" is a successful teardown, not a failed one. Until the API
+  // grew this branch that case arrived as a 500, indistinguishable from a real
+  // server failure, and it failed tests that had already passed
+  // (follow-ups.md #56). Everything else still throws, so #24 stays caught.
   const res = await request.delete(`${API_HOST}/recipe`, { data: { id } });
+  if (res.status() === 404) return;
   if (!res.ok()) {
     throw new Error(`Failed to delete recipe ${id}: ${res.status()} ${await res.text()}`);
   }

--- a/e2e/recipe.spec.ts
+++ b/e2e/recipe.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from './fixtures';
 import { createRecipe, deleteRecipeByName, findRecipeIdByName } from './api';
+import { API_HOST } from './env';
 
 // Each test creates its own uniquely-named, throwaway Recipe and cleans up
 // after itself via a direct API call (not through the UI, so cleanup doesn't
@@ -69,5 +70,16 @@ test.describe('recipe management', () => {
     await expect(page.getByRole('checkbox', { name: recipeName })).toHaveCount(0);
 
     recipeName = undefined; // deletion under test already cleaned this up
+  });
+
+  // Deliberately at this level rather than in Go: reaching the handler's
+  // sql.ErrNoRows branch needs a real database, and the API has no DB-backed
+  // test harness (follow-ups.md #52). This is the cheapest thing that actually
+  // exercises the branch, and the status code is the whole contract - a 500
+  // here told every client "the server is broken" for a Recipe that was simply
+  // not there, and made teardown flaky (follow-ups.md #56).
+  test('deleting a recipe that is not there is a 404, not a 500', async ({ request }) => {
+    const res = await request.delete(`${API_HOST}/recipe`, { data: { id: 2_000_000_000 } });
+    expect(res.status()).toBe(404);
   });
 });

--- a/e2e/shopping-list.spec.ts
+++ b/e2e/shopping-list.spec.ts
@@ -172,9 +172,6 @@ test.describe('shopping list unit combining', () => {
 
   test.afterAll(async ({ request }) => {
     await clearShoppingList(request);
-    // Note: these deletes currently fail silently for any recipe that reached
-    // the shopping list - see follow-ups.md #24. Harmless here because the e2e
-    // database is recreated per run, and deleteRecipeById doesn't assert.
     await deleteRecipeById(request, spoonsRecipeId);
     await deleteRecipeById(request, gramsRecipeId);
   });

--- a/follow-ups-resolved.md
+++ b/follow-ups-resolved.md
@@ -378,3 +378,30 @@ cross-references between entries (e.g. #9 references #16).
     a Recipe save and nowhere else. And 5b's cache is the reason, which is the spec's own
     point that "parallelising four round trips saves less than not making eleven of them"
     arriving one phase earlier than expected.
+
+56. ~~Deleting an already-deleted Recipe returns 500, and it makes the e2e suite flaky.~~
+    **Resolved** — `app/recipe.go`'s `deleteRecipe` now has the `errors.Is(err, sql.ErrNoRows)`
+    branch the service layer was already written for: `service/recipe.go` returns that sentinel
+    deliberately unwrapped, with a comment about not breaking "any caller comparing against it",
+    and the one caller finally does. A Recipe that is not on the Account answers **404 Recipe not
+    found**; everything else still answers 500.
+
+    Both branches now go through `fail(ctx, clientErr, cause)` rather than returning the client
+    error bare, which is what the rest of the package does. That has two consequences worth
+    stating: a 500 from a delete now records its *cause* on the span instead of only the generic
+    message the client saw, and the 404 is deliberately **not** flagged as a server error —
+    `fail` treats `sql.ErrNoRows` as the one expected cause, so a missing Recipe cannot inflate
+    the error rate the dashboards read.
+
+    **The flake needed the e2e side too, and that is the half the item did not spell out.**
+    `deleteRecipeById` asserts on the response status (added by #24, deliberately), so a 404 was
+    still a failed teardown — it only stopped being a *lie* about why. It now returns early on
+    404 and throws on everything else: teardown deletes by id, spec files run in parallel against
+    one shared Account under `DISABLE_AUTH`, and a Recipe can be gone before its own teardown
+    runs, so "already gone" is a successful teardown. #24's protection is untouched — the 500 that
+    went unnoticed for months would still fail the suite today.
+
+    Covered by an e2e test (`recipe.spec.ts`, "deleting a recipe that is not there is a 404, not
+    a 500") rather than a Go one, because reaching the branch needs a real database and #52 is
+    still open. Also deleted a stale comment in `shopping-list.spec.ts` claiming those teardown
+    deletes silently fail and that `deleteRecipeById` does not assert — both untrue since #24.

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -2,7 +2,7 @@
 
 Small defects and doc-drift found while building `CONTEXT.md` from the codebase (2026-07-13). Not designed here — just flagged for later action.
 
-Items 1–30, 32, 33, 36, 39, 40, 44, 48 and 49 have all been resolved — see [`follow-ups-resolved.md`](./follow-ups-resolved.md) for the full history (numbering preserved for cross-references between entries).
+Items 1–30, 32, 33, 36, 39, 40, 44, 48, 49, 53 and 56 have all been resolved — see [`follow-ups-resolved.md`](./follow-ups-resolved.md) for the full history (numbering preserved for cross-references between entries).
 
 Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are real but deliberately not being fixed, so they are not queued work.
 
@@ -510,35 +510,6 @@ Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are r
     request — not a change to how it is observed. **The counter going flat while Photo
     Import appears to work is the signal to come back here**, which is a better position
     than the one before Phase 4, where there was no signal at all.
-
-56. **Deleting an already-deleted Recipe returns 500, and it makes the e2e suite flaky.**
-    `service.DeleteRecipe` checks the Recipe exists for the Account and returns `sql.ErrNoRows`
-    when it does not. `app/recipe.go:132` turns *any* error from it into
-    `huma.Error500InternalServerError("could not delete recipe")`, so "this Recipe is not there"
-    is reported as "this server is broken".
-
-    The intent to do better is already written down and unfinished: `service/recipe.go:329-332`
-    returns the sentinel deliberately unwrapped, with a comment explaining that wrapping it would
-    "break any caller comparing against it" — and then the only caller does not compare against
-    it. An `errors.Is(err, sql.ErrNoRows)` branch returning 404 is the whole fix.
-
-    **Found while investigating an e2e failure during Phase 6** (`specs/observability.md`), and
-    measured rather than assumed: six runs on `master` produced one failure, five runs on the
-    Phase 6 branch produced three, always the same signature and always in teardown —
-
-    ```
-    Failed to delete recipe 22: 500 {"detail":"could not delete recipe"}
-      at deleteRecipeById (e2e/api.ts:54)
-    ```
-
-    Different test each time, on Go code neither branch had touched. Playwright runs spec *files*
-    in parallel and teardown deletes by id, so a Recipe can be gone before its own teardown runs;
-    the 500 then fails a test that had already passed.
-
-    Two reasons it is worth fixing beyond the flake. A flaky suite is one that gets re-run instead
-    of read, which is exactly what CLAUDE.md's "a flaky-looking e2e failure gets investigated, not
-    re-run-until-green" exists to prevent. And a 500 here is a lie to any client: the browser's
-    delete button cannot tell "already gone, refresh your list" from "the API is down".
 
 57. **Upgrade `go-jwt-middleware` to v3.** Split off while removing the Go 1.23 version
     pins (see #54 and `specs/completed/request-model-optimisations.md`). Once #91 moved the repo to

--- a/netlify-functions/recipes/internal/pkg/app/recipe.go
+++ b/netlify-functions/recipes/internal/pkg/app/recipe.go
@@ -140,7 +140,21 @@ func (a *App) deleteRecipe(ctx context.Context, input *DeleteRecipeInput) (*Stat
 	}
 
 	if err := service.DeleteRecipe(ctx, common.Recipe{ID: input.Body.ID}, caller, a.db); err != nil {
-		return nil, huma.Error500InternalServerError("could not delete recipe")
+		// "There is no such Recipe on this Account" is the API working, not the
+		// API broken, and the two are not interchangeable to a caller: a delete
+		// button that gets a 500 cannot tell "already gone, refresh your list"
+		// from "the server is down", and answers the second. It also made the
+		// e2e suite flaky - teardown deletes by id, and a Recipe can be gone
+		// before its own teardown runs (follow-ups.md #56).
+		//
+		// errors.Is rather than ==, for the reason getRecipe gives above: the
+		// service layer wraps, and DeleteRecipe returns this one unwrapped
+		// precisely so a caller can compare against it - which, until now, no
+		// caller did.
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fail(ctx, huma.Error404NotFound("Recipe not found"), err)
+		}
+		return nil, fail(ctx, huma.Error500InternalServerError("could not delete recipe"), err)
 	}
 
 	return &StatusOutput{Body: common.SimpleResponse{Status: "ok"}}, nil


### PR DESCRIPTION
Closes follow-ups.md #56.

`service.DeleteRecipe` has always returned `sql.ErrNoRows` unwrapped, with a comment explaining that wrapping it would "break any caller comparing against it". The only caller did not compare against it — `app/recipe.go:132` turned *any* error into `huma.Error500InternalServerError("could not delete recipe")`, so "this Recipe is not on your Account" was reported as "this server is broken".

## What changed

**`internal/pkg/app/recipe.go`** — the `errors.Is(err, sql.ErrNoRows)` branch the service layer was already written for. A Recipe that is not on the Account answers **404 Recipe not found**; everything else still answers 500.

Both branches now go through `fail(ctx, clientErr, cause)`, as the rest of the package does. Two consequences worth calling out:

- a 500 from a delete now records its **cause** on the span, rather than only the generic message the client saw;
- the 404 is deliberately **not** flagged as a server error — `fail` treats `sql.ErrNoRows` as the one routinely-expected cause, so a missing Recipe cannot inflate the error rate the Phase 6 dashboards read.

**`e2e/api.ts`** — the half the follow-up did not spell out. `deleteRecipeById` asserts on the response status (added by #24, deliberately), so a 404 was still a *failed* teardown; it had only stopped being a lie about why. It now returns early on 404 and throws on everything else. Teardown deletes by id, spec files run in parallel against one shared Account under `DISABLE_AUTH`, and a Recipe can be gone before its own teardown runs — so "already gone" is a successful teardown. #24's protection is untouched: the 500 that went unnoticed for five months would still fail the suite today.

**`e2e/recipe.spec.ts`** — a test pinning the status code. Deliberately at this level rather than in Go: reaching the handler branch needs a real database, and the API still has no DB-backed test harness (#52).

Also deleted a stale comment in `shopping-list.spec.ts` claiming those teardown deletes silently fail and that `deleteRecipeById` does not assert — both untrue since #24.

## Verification

- `gofmt -l` clean, `go vet ./...` clean, `go test ./... -race` — all packages pass.
- `docs/openapi.yaml` unchanged (Huma derives the spec from route registration, not from handler error branches), so `types/api.d.ts` is unchanged too.
- `npm run lint`, `npm run typecheck` — clean.
- `npm run test:e2e` — **28 passed**, including the new `deleting a recipe that is not there is a 404, not a 500`.

No visible surface: this is a status code on a route the UI already treats as pass/fail, and no frontend behaviour changed here. Making the delete button *use* the distinction is a separate question and is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)