### PR TITLE
Recipe Import reads the catalogs through the edge (#51)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -511,6 +511,9 @@ paths:
             Cache-Control:
               schema:
                 type: string
+            Netlify-Cache-Tag:
+              schema:
+                type: string
         default:
           content:
             application/problem+json:

--- a/follow-ups-resolved.md
+++ b/follow-ups-resolved.md
@@ -182,7 +182,7 @@ cross-references between entries (e.g. #9 references #16).
     the broken code it exists to catch. Verified end to end against the live URL with
     a real extraction call, which now returns all six ingredients and the method.
 
-44. ~~Audit `Cache-Control` across the Go API.~~ **Resolved** — see [ADR-0009](./docs/adr/0009-edge-caching-the-global-catalogs.md) and `specs/completed/cache-control-audit.md`. Every response now carries a policy: a `private, no-store` default stamped by middleware in `internal/pkg/app/app.go`, first in the negroni stack so it covers `/health` and the JWT middleware's own 401s, not just handler successes. Three routes override it, each as the audit concluded — `GET /tags` `public, max-age=0, s-maxage=86400` (no purge; `tag` is seeded by migration and never written to), `GET /units` `public, max-age=0, s-maxage=300` plus `Netlify-Cache-Tag: units`, purged on Recipe create/edit, and `GET /ingredients` `no-store` (it is read server-side via `API_HOST_INTERNAL` and never crosses the edge, so caching buys it nothing). The purge lives in a new `internal/pkg/purge` package: asynchronous, best-effort, and coalescing — one call goes immediately and a burst collapses into one trailing call per 5s window, because Netlify 429s a tag purged more than twice in five seconds. It is a no-op with `NETLIFY_PURGE_TOKEN`/`NETLIFY_SITE_ID` unset, which is what local dev, e2e and CI run as; the `s-maxage` is what makes a missed purge self-heal. **One correction to this item as filed:** it counted 22 routes with nineteen account-scoped. There are 25, of which 22 are account-scoped — three were added after it was written. None of its conclusions change; the three unscoped routes are the same three. **A second correction:** this item named an in-process cache in `lib/recipe-import/known-names.ts` as "the real win" for `/ingredients`. That was too quick — tracing the callers afterwards showed the round trip is Ohio to Frankfurt and back, on every import, for an unbounded catalog, and that routing the call through `www.bigshop.life` would make it edge-cacheable after all. Reopened as item 51 in [`follow-ups.md`](./follow-ups.md), which frames the choice rather than presuming it.
+44. ~~Audit `Cache-Control` across the Go API.~~ **Resolved** — see [ADR-0009](./docs/adr/0009-edge-caching-the-global-catalogs.md) and `specs/completed/cache-control-audit.md`. Every response now carries a policy: a `private, no-store` default stamped by middleware in `internal/pkg/app/app.go`, first in the negroni stack so it covers `/health` and the JWT middleware's own 401s, not just handler successes. Three routes override it, each as the audit concluded — `GET /tags` `public, max-age=0, s-maxage=86400` (no purge; `tag` is seeded by migration and never written to), `GET /units` `public, max-age=0, s-maxage=300` plus `Netlify-Cache-Tag: units`, purged on Recipe create/edit, and `GET /ingredients` `no-store` (it is read server-side via `API_HOST_INTERNAL` and never crosses the edge, so caching buys it nothing). The purge lives in a new `internal/pkg/purge` package: asynchronous, best-effort, and coalescing — one call goes immediately and a burst collapses into one trailing call per 5s window, because Netlify 429s a tag purged more than twice in five seconds. It is a no-op with `NETLIFY_PURGE_TOKEN`/`NETLIFY_SITE_ID` unset, which is what local dev, e2e and CI run as; the `s-maxage` is what makes a missed purge self-heal. **One correction to this item as filed:** it counted 22 routes with nineteen account-scoped. There are 25, of which 22 are account-scoped — three were added after it was written. None of its conclusions change; the three unscoped routes are the same three. **A second correction:** this item named an in-process cache in `lib/recipe-import/known-names.ts` as "the real win" for `/ingredients`. That was too quick — tracing the callers afterwards showed the round trip is Ohio to Frankfurt and back, on every import, for an unbounded catalog, and that routing the call through `www.bigshop.life` would make it edge-cacheable after all. Reopened as item 51, which framed the choice rather than presuming it, and is now resolved below — by the first option, not the in-process cache. That also overturns this item's `/ingredients` decision: it is no longer `no-store` but `public, max-age=0, s-maxage=300` with a purged tag, because the premise that its only reader never crosses Netlify's edge stopped being true.
 
 48. ~~You cannot log in on a deploy preview, so branch deploys cannot be tested.~~
     **Resolved** — verified end to end by completing a real login, and a real logout, on a
@@ -472,3 +472,70 @@ cross-references between entries (e.g. #9 references #16).
     visitor into an account they do not have), and the `@@auth0spajs@@` prefix asserted against
     auth0-spa-js's own public `CacheKey`, so an SDK upgrade that moves the storage fails a test
     rather than silently turning the hint into a no-op.
+
+51. ~~Every Recipe Import fetches the whole Ingredient catalog across the Atlantic.~~
+    **Resolved** — by the first of the three options the item frames, with the measurement it
+    asks for built first rather than skipped.
+
+    **Why the measurement did not already exist**, which is the part worth recording: nobody had
+    obeyed "measure before building" because the number was not obtainable.
+    `lib/telemetry/setup.ts` registers manual providers only, with no auto-instrumentation, so an
+    outbound `fetch` produces no client span. The Go API's own server span *does* hang under the
+    import's trace via the propagated `traceparent` — but it measures Go's handling and nothing
+    else. The crossing, the TLS handshake on a cold container and the edge lookup all happen
+    outside it, and they are the cost. Reading it off the gap between the two spans instead would
+    be measuring clock skew between Netlify and Fly as much as latency.
+
+    So `fetchKnownNames` now runs inside a `bigshop.known_names` span, the same way and for the
+    same reason `lib/telemetry/tool-span.ts` wraps the identical Netlify → Fly hop for Dave. It
+    carries the two list lengths — the item's other half, since `GetAllIngredients` is
+    unpaginated and grows monotonically — and whether the edge was used. No names: ADR-0008 §1.
+    The frequency half was already answered by `bigshop.import.outcome`.
+
+    **The fix**: the call goes to the site's own hostname rather than the Fly origin, so it meets
+    a Netlify PoP near the function; `/ingredients` answers `public, max-age=0, s-maxage=300`
+    with a cache tag purged on every Recipe write, the same shape `/units` has had since #44. A
+    miss is marginally *slower* than going direct — the same trip with a PoP in front — while a
+    hit saves the whole crossing, and that asymmetry is what makes it pay at a low hit rate.
+
+    **What the item did not anticipate, and what it cost.** Every route except `/health` sat
+    behind the JWT gate, `/units` and `/tags` included — so ADR-0009's "`public` makes this
+    readable by an unauthenticated caller" described the response's *cacheability*, not the
+    route's *reachability*. A shared CDN will not reliably store a response to a request carrying
+    `Authorization`, and `known-names.ts` forwarded the browser's token, so the cache headers on
+    all three catalogs were decoration. The three are now carved out of the auth middleware the
+    way `/health` is, which makes ADR-0009's position true rather than aspirational: **a gate a
+    CDN is licensed to serve around is not a gate.** What is exposed is exactly what ADR-0001
+    defines as global and non-personal, and `TestGlobalCatalogsAnswerWithoutAToken` pins both
+    halves — the three answer without a token, and `GET /recipes` still does not.
+
+    **The one assumption, and how to close it.** The item flagged "that Netlify's CDN caches a
+    response fetched by one of its own functions" as unverified and the thing to test first. It
+    could not be closed on the deploy preview, because `netlify.toml` rewrites `/api/bigshop/*`
+    to *production's* Fly app and the API deploys only from `master` — so a preview always runs
+    new frontend against old API. What the preview did establish is that Netlify Edge is in the
+    path for that rewrite, evaluates the proxied response, honours its directives (it declined to
+    store a `private, no-store` 401), and reports the outcome in `cache-status`, where a stored
+    response carries an explicit `stored` token. So the remaining step is one command, not an
+    experiment:
+
+    ```bash
+    curl -sI https://www.bigshop.life/api/bigshop/ingredients | grep -i cache-status
+    # want: ...; fwd=miss; fwd-status=200; stored   (first request)
+    # then: ...; hit                                 (second, within 300s)
+    ```
+
+    If it says neither, the change is inert rather than harmful — imports pay one extra hop, the
+    new span shows it, and the revert is the host choice in `known-names.ts`. Also confirmed
+    rather than assumed on the way past: `netlify-vary: query`, so `Authorization` is genuinely
+    not part of Netlify's cache key.
+
+    **Deployment ordering.** The frontend (Netlify) and the API (Fly) deploy independently and
+    nothing sequences them. If the frontend lands first it sends no token to an API that still
+    requires one, and `fetchKnownNames` degrades to empty lists — imports keep working and lose
+    canonicalisation for a few minutes. Graceful, and exactly what that function is written to
+    absorb, but worth knowing rather than discovering.
+
+    Options 2 and 3 are not taken and not queued. The in-process cache is subsumed. Moving Recipe
+    Import extraction into the Go API remains the structurally correct destination, and remains
+    its own spec if it is ever wanted; the span added here is what would justify it.

--- a/follow-ups.md
+++ b/follow-ups.md
@@ -2,7 +2,7 @@
 
 Small defects and doc-drift found while building `CONTEXT.md` from the codebase (2026-07-13). Not designed here — just flagged for later action.
 
-Items 1–30, 32, 33, 36, 39, 40, 44, 48, 49, 53, 56 and 58 have all been resolved — see [`follow-ups-resolved.md`](./follow-ups-resolved.md) for the full history (numbering preserved for cross-references between entries).
+Items 1–30, 32, 33, 36, 39, 40, 44, 48, 49, 51, 53, 56 and 58 have all been resolved — see [`follow-ups-resolved.md`](./follow-ups-resolved.md) for the full history (numbering preserved for cross-references between entries).
 
 Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are real but deliberately not being fixed, so they are not queued work.
 
@@ -343,68 +343,6 @@ Items 34 and 35 have moved to [`known-issues.md`](./known-issues.md): they are r
     - **#42 is the reason the lifecycle emails would work or not.** A retention email
       pointing someone back into an empty Account is the same wound from a different
       angle — sequencing matters more than content here.
-
-51. **Every Recipe Import fetches the whole Ingredient catalog across the Atlantic.**
-    Opened by the `Cache-Control` audit (#44, resolved), which concluded that `/ingredients`
-    is the one global catalog edge caching cannot help and named an in-process cache as
-    "the real win". That conclusion was too quick, and this item deliberately reopens the
-    question rather than inheriting it: the round trip is real, but an in-process cache is
-    only one of three ways to remove it, and probably not the best.
-
-    **What was actually verified**, by tracing every caller rather than by reading #44:
-
-    - **`/ingredients` has exactly one consumer**: `fetchKnownNames` in
-      `lib/recipe-import/known-names.ts`. The two browser hooks that used to read it
-      (`use-ingredient-names`, `use-ingredient-metadata`) no longer exist — they went when
-      the fetch moved server-side so the model would stop coining near-duplicates of names
-      created moments earlier. Dave does not touch it.
-    - **It runs on every ingredient-bearing import** — `/api/parse-recipe-url`,
-      `/api/parse-recipe-text` and `/api/recipe-image`, skipped only for a method-only
-      import.
-    - **The path is transatlantic.** Those are Next.js API routes, so they run as Netlify
-      functions, which [ADR-0006](./docs/adr/0006-go-api-leaves-netlify-functions.md)
-      records as defaulting to `cmh` (US East, Ohio) with region selection paywalled. They
-      call `API_HOST_INTERNAL` — the Fly origin in Frankfurt — *directly*, not through
-      `www.bigshop.life`. So the hop is Ohio → Frankfurt → TiDB and back, which is the
-      exact cost ADR-0006 moved the API to remove, reintroduced from the other side.
-    - **The payload has no ceiling.** `GetAllIngredients` is `SELECT name FROM ingredient`
-      — the entire global catalog, unscoped, unpaginated, growing monotonically as people
-      import recipes ([ADR-0001](./docs/adr/0001-global-ingredient-catalog.md)).
-
-    So the endpoint is not irrelevant — the data is what stops catalog fragmentation, which
-    migration 029 exists to undo — but its shape is an artifact of the extractor living in
-    a Netlify function while the catalog lives in Frankfurt.
-
-    **Three fixes, in increasing order of how much they actually solve.** Pick one
-    deliberately; they are alternatives, not stages.
-
-    - **Route the call through `www.bigshop.life` instead of the Fly origin.** Then it
-      crosses Netlify's edge like everything else and caches exactly like `/units` — and a
-      hit is served from the Ohio PoP rather than Frankfurt, which is the whole latency
-      problem gone. Cheapest by far: a host change plus the `public`/`s-maxage` header and
-      a cache tag, and `internal/pkg/purge` already exists to invalidate it. Costs: a hop
-      back through the platform the migration routed around; the catalog becomes publicly
-      readable (the same trade already accepted for `/tags` and `/units`, fine under
-      ADR-0001); and it needs purging on **every** Recipe save, since saves coin
-      ingredients far more often than units. **Unverified assumption, and the thing to test
-      first: that Netlify's CDN caches a response fetched by one of its own functions.**
-    - **Cache in-process in `known-names.ts`** — what #44 proposed. Works, but the ceiling
-      is lower than it looks: a module-level variable is only long-lived on a long-lived
-      process, and this runs in a Netlify function, where a cold start starts empty and
-      concurrent invocations do not share one. A short TTL is enough on correctness
-      grounds — a stale list costs a near-duplicate name, not a broken import, and
-      `extract.js` degrades honestly on an empty one.
-    - **Move Recipe Import extraction into the Go API.** The structurally correct answer:
-      co-located with the database, `fetchKnownNames` becomes a local query and
-      `/ingredients` can be deleted outright. Much the largest change — the LLM calls,
-      `OPENAI_API_KEY`, image upload and `formidable` all move — so it wants its own spec,
-      and it is worth noting as the destination even if the first option is what ships.
-
-    **Measure before building any of them.** Two numbers decide it: how long
-    `fetchKnownNames` actually takes in production, and how often imports happen. If
-    imports are rare, this is a round trip nobody is waiting on and the right answer is to
-    do nothing. `observability.md`'s tracing would answer both directly — as with #49, the
-    cheapest move may be to wait for it rather than to guess now.
 
 52. **The Go API has no DB-backed test harness, so no handler and no query is tested.**
     Surfaced by the `Cache-Control` audit (#44), which wanted to assert that a Recipe write

--- a/lib/api-host.ts
+++ b/lib/api-host.ts
@@ -52,3 +52,48 @@ export function serverApiHost(): string | undefined {
 
   return host;
 }
+
+// Where server-side code reaches the API *through Netlify's edge*, for the
+// handful of routes where that is faster than going direct.
+//
+// The opposite trade to serverApiHost above, and only worth making for the
+// global catalogs. Those functions run in us-east-2 and the origin is in
+// Frankfurt, so a direct call is a transatlantic round trip on every Recipe
+// Import - the exact cost ADR-0006 moved the API to remove, reintroduced from
+// the other side (follow-ups.md #51). Going through the site's own hostname
+// instead means the request meets a Netlify PoP near the function, and
+// `s-maxage` on /ingredients and /units means a hit is answered there rather
+// than in Frankfurt.
+//
+// **A miss is slightly slower than going direct** - it is the same trip with a
+// PoP in front of it - and that is the trade, made deliberately: a miss costs
+// single-digit milliseconds while a hit saves the whole crossing, so the
+// asymmetry pays for a low hit rate. The purge on Recipe write is what keeps
+// the cached copy honest; see IngredientsCacheTag on the Go side.
+//
+// **Only for routes that answer `public`.** Sending an account-scoped route
+// through here would put a personal response in front of a shared cache. The
+// three catalogs are exempt from the API's auth gate precisely so that no
+// Authorization header is involved (see GetRouter), which is also what makes
+// the response cacheable at all - a shared CDN will not reliably store a
+// response to an authenticated request.
+//
+// Returns undefined when there is no edge to use, which is the honest answer
+// locally: `next dev` has no proxy in front of it, so scripts/dev-full.sh sets
+// an absolute NEXT_PUBLIC_API_HOST and callers fall back to the direct host. A
+// relative value is therefore the signal that Netlify *is* in front, and is
+// what this reads rather than a separate flag that could disagree with it.
+export function edgeApiHost(): string | undefined {
+  const path = process.env.NEXT_PUBLIC_API_HOST;
+  if (!path || !path.startsWith('/')) return undefined;
+
+  // DEPLOY_URL first so a deploy preview reads its own edge rather than
+  // production's - NEXT_PUBLIC_HOST is inlined at build time and points at
+  // www.bigshop.life on every deploy, which is the same trap docs/deploy-
+  // previews.md describes for Auth0 redirects. Both are Netlify's own runtime
+  // variables; the last fallback is for a server-side render outside Netlify.
+  const origin = process.env.DEPLOY_URL || process.env.URL || process.env.NEXT_PUBLIC_HOST;
+  if (!origin) return undefined;
+
+  return `${origin.replace(/\/$/, '')}${path}`;
+}

--- a/lib/recipe-import/known-names.test.ts
+++ b/lib/recipe-import/known-names.test.ts
@@ -1,18 +1,15 @@
-import type { NextApiRequest } from 'next';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fetchKnownNames } from './known-names';
-
-const req = (headers: Record<string, string> = {}) => ({ headers }) as unknown as NextApiRequest;
 
 const ok = (rows: { name: string }[]) => ({ ok: true, json: async () => rows });
 
 beforeEach(() => {
-  // API_HOST_INTERNAL is what this reads in production - see lib/api-host.ts.
-  // NEXT_PUBLIC_API_HOST is stubbed to a relative path alongside it, matching
-  // the production shape, so a regression that reads the wrong one produces a
-  // relative URL rather than quietly passing.
+  // The direct path: an absolute NEXT_PUBLIC_API_HOST is what dev-full.sh sets
+  // and is the signal that there is no Netlify edge in front (lib/api-host.ts),
+  // so edgeApiHost declines and serverApiHost answers. The edge path has its own
+  // group below.
   vi.stubEnv('API_HOST_INTERNAL', 'http://api.test');
-  vi.stubEnv('NEXT_PUBLIC_API_HOST', '/api/bigshop');
+  vi.stubEnv('NEXT_PUBLIC_API_HOST', 'http://api.test');
   vi.spyOn(console, 'error').mockImplementation(() => {});
 });
 
@@ -28,30 +25,34 @@ describe('fetchKnownNames', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(fetchKnownNames(req())).resolves.toEqual({
+    await expect(fetchKnownNames()).resolves.toEqual({
       knownIngredients: ['egg', 'thyme'],
       knownUnits: ['gram']
     });
 
-    // Asserted as whole URLs, not suffixes. The host half is the point: this
-    // runs server-side, so reading NEXT_PUBLIC_API_HOST instead of
-    // API_HOST_INTERNAL would build a relative URL here. A suffix assertion
-    // (which is what this test used to make) is satisfied by both and so
-    // cannot tell the regression apart from correct behaviour.
+    // Asserted as whole URLs, not suffixes. The host half is the point: a
+    // regression that picked the wrong host would build a different URL here,
+    // and a suffix assertion is satisfied by both.
     expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
       'http://api.test/ingredients',
       'http://api.test/units'
     ]);
   });
 
-  it('forwards the caller Authorization header to the Go API', async () => {
+  // Was "forwards the caller Authorization header", and the reversal is the
+  // point of follow-ups.md #51 rather than a loosening. Both routes are now
+  // exempt from the API's auth gate, and a shared CDN will not reliably store a
+  // response to a request carrying Authorization - so a token here would turn
+  // the s-maxage on both routes into decoration and leave every import paying
+  // for the Atlantic crossing.
+  it('sends no Authorization header, so the response stays cacheable', async () => {
     const fetchMock = vi.fn(async () => ok([]));
     vi.stubGlobal('fetch', fetchMock);
 
-    await fetchKnownNames(req({ authorization: 'Bearer abc123' }));
+    await fetchKnownNames();
 
     for (const [, init] of fetchMock.mock.calls as unknown as [string, RequestInit][]) {
-      expect(init.headers).toEqual({ Authorization: 'Bearer abc123' });
+      expect(init.headers).not.toHaveProperty('Authorization');
     }
   });
 
@@ -62,7 +63,7 @@ describe('fetchKnownNames', () => {
       url.endsWith('/units') ? ok([{ name: '' }, { name: 'gram' }]) : ok([{ name: 'egg' }])
     ));
 
-    const { knownUnits } = await fetchKnownNames(req());
+    const { knownUnits } = await fetchKnownNames();
     expect(knownUnits).toEqual(['gram']);
   });
 
@@ -72,13 +73,13 @@ describe('fetchKnownNames', () => {
   it('returns empty lists rather than throwing when the API errors', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })));
 
-    await expect(fetchKnownNames(req())).resolves.toEqual({ knownIngredients: [], knownUnits: [] });
+    await expect(fetchKnownNames()).resolves.toEqual({ knownIngredients: [], knownUnits: [] });
   });
 
   it('returns empty lists rather than throwing when the API is unreachable', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
 
-    await expect(fetchKnownNames(req())).resolves.toEqual({ knownIngredients: [], knownUnits: [] });
+    await expect(fetchKnownNames()).resolves.toEqual({ knownIngredients: [], knownUnits: [] });
   });
 
   it('returns empty lists when no API host is configured', async () => {
@@ -87,7 +88,68 @@ describe('fetchKnownNames', () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(fetchKnownNames(req())).resolves.toEqual({ knownIngredients: [], knownUnits: [] });
+    await expect(fetchKnownNames()).resolves.toEqual({ knownIngredients: [], knownUnits: [] });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// The production shape, and the whole of the change: a relative
+// NEXT_PUBLIC_API_HOST means Netlify is in front, so the call goes to the
+// site's own hostname and meets a PoP near the function instead of crossing to
+// Frankfurt.
+describe('fetchKnownNames through the edge', () => {
+  it('calls the site hostname rather than the Fly origin', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_HOST', '/api/bigshop');
+    vi.stubEnv('API_HOST_INTERNAL', 'https://big-shop-api.fly.dev/api/bigshop');
+    vi.stubEnv('URL', 'https://www.bigshop.life');
+    const fetchMock = vi.fn(async (_url: string) => ok([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchKnownNames();
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      'https://www.bigshop.life/api/bigshop/ingredients',
+      'https://www.bigshop.life/api/bigshop/units'
+    ]);
+  });
+
+  // A deploy preview must read its own edge, not production's. NEXT_PUBLIC_HOST
+  // is inlined at build time and says www.bigshop.life on every deploy - the
+  // same trap docs/deploy-previews.md describes for Auth0 redirects - so a
+  // preview would otherwise verify nothing about itself.
+  it('prefers the deploy URL, so a preview reads its own edge', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_HOST', '/api/bigshop');
+    vi.stubEnv('URL', 'https://www.bigshop.life');
+    vi.stubEnv('DEPLOY_URL', 'https://deploy-preview-102--big-shop.netlify.app');
+    const fetchMock = vi.fn(async (_url: string) => ok([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchKnownNames();
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      'https://deploy-preview-102--big-shop.netlify.app/api/bigshop/ingredients',
+      'https://deploy-preview-102--big-shop.netlify.app/api/bigshop/units'
+    ]);
+  });
+
+  // The one misconfiguration that would be silent: no Netlify runtime variable
+  // set, a relative path, and nothing to make it absolute. Falling through to
+  // serverApiHost keeps the import working on the direct origin rather than
+  // fetching a relative URL, which throws in Node.
+  it('falls back to the direct origin when there is no site origin to use', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_HOST', '/api/bigshop');
+    vi.stubEnv('API_HOST_INTERNAL', 'https://big-shop-api.fly.dev/api/bigshop');
+    vi.stubEnv('URL', '');
+    vi.stubEnv('DEPLOY_URL', '');
+    vi.stubEnv('NEXT_PUBLIC_HOST', '');
+    const fetchMock = vi.fn(async (_url: string) => ok([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchKnownNames();
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      'https://big-shop-api.fly.dev/api/bigshop/ingredients',
+      'https://big-shop-api.fly.dev/api/bigshop/units'
+    ]);
   });
 });

--- a/lib/recipe-import/known-names.ts
+++ b/lib/recipe-import/known-names.ts
@@ -1,7 +1,9 @@
-import type { NextApiRequest } from 'next';
+import { SpanStatusCode } from '@opentelemetry/api';
+import { edgeApiHost, serverApiHost } from '../api-host';
 import { withTraceHeaders } from '../telemetry/propagate';
-import { serverApiHost } from '../api-host';
+import { safeError } from '../telemetry/span';
 import { logError } from '../telemetry/log';
+import { tracer } from '../telemetry/setup';
 
 export type KnownNames = { knownIngredients: string[]; knownUnits: string[] };
 
@@ -24,32 +26,72 @@ const EMPTY: KnownNames = { knownIngredients: [], knownUnits: [] };
 // losing the import costs the user their recipe. `extract.js` degrades
 // honestly on an empty list - buildInstructions simply omits the reuse
 // instruction rather than referring to a list that isn't there.
-export async function fetchKnownNames(req: NextApiRequest): Promise<KnownNames> {
-  // API_HOST_INTERNAL, not NEXT_PUBLIC_API_HOST - this runs in a Netlify
-  // function, where the latter's production value is a relative path. See
-  // lib/api-host.ts.
-  const host = serverApiHost();
+export async function fetchKnownNames(): Promise<KnownNames> {
+  // Netlify's edge in front of the API, falling back to the API directly.
+  //
+  // Both catalogs answer `public` with an `s-maxage` and are exempt from the
+  // API's auth gate, so this crosses the edge and a hit is served from a PoP
+  // near this function rather than from Frankfurt - which is the whole of
+  // follow-ups.md #51. Locally there is no edge, edgeApiHost returns undefined,
+  // and this goes direct exactly as it always did.
+  const host = edgeApiHost() ?? serverApiHost();
   if (!host) {
     logError('No API host configured (API_HOST_INTERNAL, or NEXT_PUBLIC_API_HOST locally) - importing without canonical names');
     return EMPTY;
   }
 
-  // Forwarded straight through from the browser. No route here validates a
-  // token itself; the Go API is the thing that decides whether it is good -
-  // which is also how lib/authenticate.ts authenticates a caller, by asking it.
-  // This call is not that check: a missing or bad token costs canonical names
-  // (see below), and any route that needs the caller authenticated says so
-  // separately.
-  const authorization = req.headers.authorization;
-  const headers: Record<string, string> = authorization ? { Authorization: authorization } : {};
+  // One span around both calls, for the same reason lib/telemetry/tool-span.ts
+  // wraps each Dave tool call: this is the identical hop - a Netlify function
+  // in us-east-2 reaching the Go API - and from the outside an import is a
+  // single slow request in which this cost is invisible.
+  //
+  // It has to be a span here rather than read off the Go API's own server span,
+  // which does hang under this trace via the traceparent below. That span
+  // measures Go's handling and nothing else; the crossing, the TLS handshake on
+  // a cold container, and now the edge lookup all happen outside it, and they
+  // are the cost #51 is about. Comparing the two spans' timestamps instead
+  // would be measuring clock skew between Netlify and Fly as much as latency.
+  //
+  // Nothing about the *contents* is recorded - names are catalog data and
+  // ADR-0008 §1 keeps content out of telemetry - only how many came back, which
+  // is the other half of #51: `GetAllIngredients` is unpaginated and grows
+  // monotonically, and this is what makes that growth visible before it matters.
+  return tracer().startActiveSpan('bigshop.known_names', async (span) => {
+    try {
+      const names = await load(host);
+      span.setAttribute('bigshop.known_names.ingredients', names.knownIngredients.length);
+      span.setAttribute('bigshop.known_names.units', names.knownUnits.length);
+      span.setAttribute('bigshop.known_names.via_edge', edgeApiHost() !== undefined);
+      return names;
+    } catch (e) {
+      // Recorded, then swallowed - this function's contract is that it never
+      // fails an import. The span is what makes "imports have been losing
+      // canonical names for a week" something anyone can find out, which was
+      // previously visible only as a log line nobody reads.
+      span.recordException(safeError(e));
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      logError('Could not load canonical Ingredient/Unit names - importing without them', e);
+      return EMPTY;
+    } finally {
+      span.end();
+    }
+  });
+}
 
+async function load(host: string): Promise<KnownNames> {
   const getNames = async (path: string): Promise<string[]> => {
+    // No Authorization header, deliberately, and it is load-bearing rather than
+    // an omission. These two routes are exempt from the API's auth gate (see
+    // GetRouter), and a shared CDN will not reliably store a response to a
+    // request carrying Authorization - so sending one would quietly turn the
+    // `s-maxage` on both routes into decoration and leave every import paying
+    // for the crossing anyway. This used to forward the browser's token; no
+    // route here ever validated it, and the Go API no longer asks for one.
+    //
     // Propagated for the same reason lib/dave/tools.ts propagates: without it
     // these two calls are traces of their own, and an import's trace has a hole
-    // in it where the canonical-name lookup should be. The spec's Phase 4 names
-    // only the Dave hop, but it is the same hop - a Netlify function calling
-    // the Go API - and leaving it out would mean two orphan traces per import.
-    const res = await fetch(`${host}${path}`, { headers: withTraceHeaders(headers) });
+    // in it where the canonical-name lookup should be.
+    const res = await fetch(`${host}${path}`, { headers: withTraceHeaders({}) });
     if (!res.ok) {
       throw new Error(`GET ${path} failed with status ${res.status}`);
     }
@@ -61,14 +103,9 @@ export async function fetchKnownNames(req: NextApiRequest): Promise<KnownNames> 
     return rows.map((row) => row.name).filter(Boolean);
   };
 
-  try {
-    const [knownIngredients, knownUnits] = await Promise.all([
-      getNames('/ingredients'),
-      getNames('/units'),
-    ]);
-    return { knownIngredients, knownUnits };
-  } catch (e) {
-    logError('Could not load canonical Ingredient/Unit names - importing without them', e);
-    return EMPTY;
-  }
+  const [knownIngredients, knownUnits] = await Promise.all([
+    getNames('/ingredients'),
+    getNames('/units'),
+  ]);
+  return { knownIngredients, knownUnits };
 }

--- a/netlify-functions/recipes/internal/pkg/app/app.go
+++ b/netlify-functions/recipes/internal/pkg/app/app.go
@@ -34,7 +34,7 @@ type App struct {
 	purger cachePurger
 	// catalogs holds the global Unit and Ingredient catalogs in process, so a
 	// shopping-list request does not re-read the whole of both tables. Cleared
-	// by the same handler that purges the edge cache - see purgeUnitsCache.
+	// by the same handler that purges the edge caches - see purgeCatalogCaches.
 	// A nil *service.Catalogs is a valid uncached cache, so nothing breaks if
 	// an App is built without one.
 	catalogs *service.Catalogs
@@ -376,12 +376,62 @@ func (a *App) GetRouter(base string) (*negroni.Negroni, huma.API, error) {
 		next(w, r)
 	}))
 	n.Use(c)
-	if os.Getenv("DISABLE_AUTH") == "true" {
-		n.Use(negroni.HandlerFunc(a.devUserMiddleware))
-	} else {
-		n.Use(jwtHandler())
-		n.Use(negroni.HandlerFunc(a.userMiddleware))
+
+	// The three global catalogs are reachable without a token, like /health and
+	// unlike everything else.
+	//
+	// This is not a relaxation - it is the gate catching up with a decision
+	// ADR-0009 already made. Each of these routes answers `public` with an
+	// `s-maxage`, which instructs a *shared* cache to store the response and
+	// hand it to whoever asks next. That is the whole point of them, and it
+	// means the contents were already public the moment the first response was
+	// cached: a gate a CDN is licensed to serve around is not a gate. ADR-0009
+	// says as much in each handler's comment ("`public` makes this readable by
+	// an unauthenticated caller"), and until now that was aspirational rather
+	// than true.
+	//
+	// Making it true is what lets Recipe Import read /ingredients through the
+	// edge at all (follow-ups.md #51). A shared CDN will not reliably store a
+	// response to a request carrying Authorization, so as long as the only way
+	// to get one was to send a token, the cache headers were decoration.
+	//
+	// What is exposed is exactly what ADR-0001 defines as global and
+	// non-personal: Ingredient names, Unit names, and the seeded Tag list. No
+	// account is named, no Recipe is reachable, and none of the three handlers
+	// takes a Caller - which is checked below rather than trusted, because a
+	// handler that started needing one would otherwise panic in production
+	// rather than fail here.
+	catalogPaths := map[string]bool{
+		base + "/ingredients": true,
+		base + "/units":       true,
+		base + "/tags":        true,
 	}
+	isPublicCatalog := func(r *http.Request) bool {
+		return r.Method == http.MethodGet && catalogPaths[r.URL.Path]
+	}
+
+	// Both branches are wrapped as one unit rather than skipped individually,
+	// because the JWT and user middlewares are a pair: running the second
+	// without the first is the "misassembled stack" callerFrom's comment warns
+	// about, and skipping only one would be exactly that.
+	var auth negroni.HandlerFunc
+	if os.Getenv("DISABLE_AUTH") == "true" {
+		auth = a.devUserMiddleware
+	} else {
+		jwt := jwtHandler()
+		auth = func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+			jwt(w, r, func(w2 http.ResponseWriter, r2 *http.Request) {
+				a.userMiddleware(w2, r2, next)
+			})
+		}
+	}
+	n.Use(negroni.HandlerFunc(func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		if isPublicCatalog(r) {
+			next(w, r)
+			return
+		}
+		auth(w, r, next)
+	}))
 	// After the auth pair, deliberately: the server span is opened outside this
 	// whole stack (main.go wraps it), but the identity that makes the span worth
 	// finding is only on the context once one of the two middlewares above has

--- a/netlify-functions/recipes/internal/pkg/app/app_test.go
+++ b/netlify-functions/recipes/internal/pkg/app/app_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"database/sql"
 	"net/http"
 	"net/http/httptest"
+	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -14,6 +17,10 @@ import (
 	"recipes/internal/pkg/common"
 
 	"github.com/danielgtaylor/huma/v2"
+	// Registered for its side effect only, so sql.Open("mysql", ...) above has
+	// a driver. main.go imports it for the same reason; the app package never
+	// names it outside this test.
+	_ "github.com/go-sql-driver/mysql"
 
 	jose "gopkg.in/go-jose/go-jose.v2"
 	josejwt "gopkg.in/go-jose/go-jose.v2/jwt"
@@ -268,9 +275,23 @@ func TestEachRouteStampsItsOwnPolicy(t *testing.T) {
 		t.Errorf("/units Netlify-Cache-Tag = %q, UnitsCacheTag = %q", units.NetlifyCacheTag, UnitsCacheTag)
 	}
 
-	// Not cached, and deliberately not `private` either - see the constant.
-	if got := (&IngredientsOutput{}).withCachePolicy().CacheControl; got != "no-store" {
+	// Five minutes and a tag, matching /units exactly. This route was
+	// `no-store` until follow-ups.md #51 pointed Recipe Import at the edge
+	// rather than at Fly directly - before that there was no shared cache in
+	// the path for a header to talk to.
+	ingredients := (&IngredientsOutput{}).withCachePolicy()
+	if got := ingredients.CacheControl; got != "public, max-age=0, s-maxage=300" {
 		t.Errorf("/ingredients Cache-Control = %q", got)
+	}
+	if ingredients.NetlifyCacheTag != IngredientsCacheTag || IngredientsCacheTag != "ingredients" {
+		t.Errorf("/ingredients Netlify-Cache-Tag = %q, IngredientsCacheTag = %q", ingredients.NetlifyCacheTag, IngredientsCacheTag)
+	}
+
+	// The two Open catalogs must not share a tag. They are purged together
+	// today, so a copy-paste here would look correct right up until one of them
+	// needed purging alone.
+	if IngredientsCacheTag == UnitsCacheTag {
+		t.Errorf("both Open catalogs use the tag %q", UnitsCacheTag)
 	}
 }
 
@@ -288,33 +309,106 @@ func (s *spyPurger) Purge(tag string) {
 	s.tags = append(s.tags, tag)
 }
 
-// A Recipe create or edit runs insertUnits, which can coin a Unit the cached
-// /units response does not have - so both purge the edge cache.
+// A Recipe create or edit runs insertUnits and insertIngredients, either of
+// which can coin a row the cached /units or /ingredients response does not have
+// - so both writes purge both edge caches.
 //
-// Exercised through purgeUnitsCache rather than through addRecipe/editRecipe,
+// Exercised through purgeCatalogCaches rather than through addRecipe/editRecipe,
 // which cannot be reached without a database. What that leaves untested is the
 // call site itself; the e2e suite covers it by saving real Recipes, and a
-// missing call would show up there as a stale unit list rather than an error.
+// missing call would show up there as a stale catalog rather than an error.
 //
-// purgeUnitsCache also clears the API's own in-process copy of the catalogs,
+// purgeCatalogCaches also clears the API's own in-process copy of the catalogs,
 // which this cannot see - Catalogs deliberately exposes no "is it loaded". That
-// half is covered by service's catalog_cache_test.go, and the reason the two
-// live in one method rather than two call sites is written up there and on
-// purgeUnitsCache itself. The interesting failure is clearing one and not the
-// other: the client would see a new Unit immediately while the Shopping List
+// half is covered by service's catalog_cache_test.go, and the reason all three
+// live in one method rather than three call sites is written up there and on
+// purgeCatalogCaches itself. The interesting failure is clearing one and not
+// another: the client would see a new Unit immediately while the Shopping List
 // went on combining without it, which reads as a combining bug.
-func TestRecipeWritesPurgeTheUnitsCache(t *testing.T) {
+func TestRecipeWritesPurgeBothOpenCatalogs(t *testing.T) {
 	spy := &spyPurger{}
 	// catalogs is left nil on purpose: a nil *service.Catalogs invalidates
 	// harmlessly, which is the property that lets a test assemble an App from
 	// only the fields it cares about.
 	application := &App{purger: spy}
 
-	application.purgeUnitsCache()
+	application.purgeCatalogCaches()
 
-	if len(spy.tags) != 1 || spy.tags[0] != UnitsCacheTag {
-		t.Errorf("purged %v, want exactly [%s]", spy.tags, UnitsCacheTag)
+	sort.Strings(spy.tags)
+	want := []string{IngredientsCacheTag, UnitsCacheTag}
+	sort.Strings(want)
+	if !slices.Equal(spy.tags, want) {
+		t.Errorf("purged %v, want exactly %v", spy.tags, want)
 	}
+
+	// /tags is seeded by migration and never written to, so purging it would
+	// only spend Netlify's rate limit against a catalog that cannot go stale.
+	if slices.Contains(spy.tags, "tags") {
+		t.Error("purged the tags cache; /tags is seeded by migration and never written to")
+	}
+}
+
+// The three global catalogs answer without a token, like /health and unlike
+// every other route.
+//
+// This is what makes their `public, s-maxage` headers mean anything: a shared
+// CDN will not reliably store a response to a request carrying Authorization,
+// so as long as a token was required the cache policy was decoration. It is
+// also the thing most likely to be "tidied" back by someone reading the
+// middleware stack and seeing an exception with no obvious reason - hence a
+// test that names the reason.
+//
+// Exercised with auth *enabled* and no token presented: a non-401 means the
+// request never reached the JWT middleware. The handler behind it then fails on
+// the database, which is fine and is the assertion working - a 500 here is a
+// request that got all the way through, which is exactly what is being checked.
+//
+// The database is opened against an unroutable port rather than left nil.
+// `database/sql` dials lazily, so this costs no connection at registration, but
+// a nil *sql.DB segfaults inside `(*DB).conn` the moment a handler queries it -
+// a panic, not a status, and nothing to assert on. A refused connection gives
+// the handler a real error to turn into a 500.
+func TestGlobalCatalogsAnswerWithoutAToken(t *testing.T) {
+	t.Setenv("DISABLE_AUTH", "")
+	t.Setenv("AUTH0_DOMAIN", "example.auth0.com")
+	t.Setenv("AUTH0_AUDIENCE", "https://big-shop-api")
+
+	db, err := sql.Open("mysql", "nobody:nothing@tcp(127.0.0.1:1)/none")
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	application, err := NewApp(&common.Env{DB: db})
+	if err != nil {
+		t.Fatalf("NewApp() error = %v", err)
+	}
+	router, _, err := application.GetRouter(testBase)
+	if err != nil {
+		t.Fatalf("GetRouter() error = %v", err)
+	}
+
+	for _, path := range []string{"/ingredients", "/units", "/tags"} {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, testBase+path, nil))
+
+			if rec.Code == http.StatusUnauthorized {
+				t.Errorf("GET %s = 401; the global catalogs must answer without a token", path)
+			}
+		})
+	}
+
+	// The carve-out is by path *and* method. A write is not a catalog read, and
+	// nothing else may slip through beside them.
+	t.Run("does not exempt other routes", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, testBase+"/recipes", nil))
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("GET /recipes = %d, want 401 - only the three catalogs are exempt", rec.Code)
+		}
+	})
 }
 
 // The /health carve-out sits ahead of CORS and the JWT middleware in the

--- a/netlify-functions/recipes/internal/pkg/app/ingredients.go
+++ b/netlify-functions/recipes/internal/pkg/app/ingredients.go
@@ -14,37 +14,52 @@ import (
 // that would otherwise collide with common.Ingredient.
 type IngredientName service.Ingredient
 
-// ingredientsCacheControl is the third answer of the three the cache audit
-// (follow-ups.md #44) arrived at, and the only one that declines to cache.
+// ingredientsCacheControl matches unitsCacheControl exactly, and for the same
+// reasons: a global catalog with no account scoping, Open rather than fixed, so
+// a short shared TTL with a purge on write.
 //
-// /ingredients looks exactly like /tags and /units - no account scoping, the
-// same bytes for every caller - so it is easy to assume it wants the same
-// treatment. It does not, because of *who reads it*. Its only consumer is
-// lib/recipe-import/known-names.ts, which runs server-side in a Netlify
-// function and calls Fly directly via API_HOST_INTERNAL. That request never
-// crosses Netlify's edge, so an `s-maxage` here would be a header nothing ever
-// acts on, plus the accepted downside of `public` for no upside at all.
+// **This route used to be `no-store`, and the reasoning for that was sound but
+// its premise has changed.** The cache audit (follow-ups.md #44) declined to
+// cache /ingredients not because it is uncacheable but because of *who reads
+// it*: its only consumer is lib/recipe-import/known-names.ts, which ran in a
+// Netlify function calling Fly directly via API_HOST_INTERNAL - a request that
+// never crossed Netlify's edge, making an `s-maxage` here a header nothing
+// would ever act on. follow-ups.md #51 changed that premise by routing the call
+// through www.bigshop.life, so the header now has a cache to talk to.
 //
-// This is stated rather than left to the default because the absence of a
-// header on the one route in this file would read as an oversight next to the
-// two beside it. The real win for this route is an in-process cache in
-// known-names.ts, which is separate work - see follow-ups.md.
+// **Shorter than /tags' day and equal to /units' five minutes**, because this
+// catalog is written to constantly: saving a Recipe upserts every Ingredient
+// its lines name, so an import coins new rows routinely. Staleness is not
+// harmless here either - a name missing from this list is a name the extractor
+// does not know exists, which is how the near-duplicates migration 029 exists
+// to undo get coined in the first place. The purge below is the real freshness
+// mechanism; five minutes is what covers a purge that failed.
+const ingredientsCacheControl = "public, max-age=0, s-maxage=300"
+
+// IngredientsCacheTag is the Netlify cache tag attached to /ingredients
+// responses, and the tag a Recipe write purges. Exported for the same reason
+// UnitsCacheTag is: a purge naming a tag no response carries is a silent no-op.
 //
-// `no-store` without `private`: unlike the account-scoped routes, there is
-// nothing personal here to keep out of a shared cache - the point is only that
-// caching it buys nothing.
-const ingredientsCacheControl = "no-store"
+// Purged strictly more often than `units` in practice. A save coins a Unit only
+// when it names one the catalog has never seen, which is rare after the first
+// few imports; it coins an Ingredient far more often, because ingredient names
+// are open text and units are effectively a closed vocabulary.
+const IngredientsCacheTag = "ingredients"
 
 // IngredientsOutput is the response body for listing ingredients.
 type IngredientsOutput struct {
 	CacheControl string `header:"Cache-Control"`
-	Body         []IngredientName
+	// See UnitsOutput for why this is Netlify's header rather than the
+	// vendor-neutral Cache-Tag.
+	NetlifyCacheTag string `header:"Netlify-Cache-Tag"`
+	Body            []IngredientName
 }
 
 // withCachePolicy stamps this route's policy onto the response. See the same
 // method on UnitsOutput for why it is a method rather than a field assignment.
 func (o *IngredientsOutput) withCachePolicy() *IngredientsOutput {
 	o.CacheControl = ingredientsCacheControl
+	o.NetlifyCacheTag = IngredientsCacheTag
 	return o
 }
 

--- a/netlify-functions/recipes/internal/pkg/app/recipe.go
+++ b/netlify-functions/recipes/internal/pkg/app/recipe.go
@@ -83,7 +83,7 @@ func (a *App) addRecipe(ctx context.Context, input *RecipeInput) (*AddRecipeOutp
 		return nil, huma.Error500InternalServerError("could not insert ingredients")
 	}
 
-	a.purgeUnitsCache()
+	a.purgeCatalogCaches()
 
 	return &AddRecipeOutput{Body: common.CreatedResponse{Status: "ok", ID: id}}, nil
 }
@@ -99,36 +99,46 @@ func (a *App) editRecipe(ctx context.Context, input *RecipeInput) (*StatusOutput
 		return nil, huma.Error500InternalServerError("could not update recipe")
 	}
 
-	a.purgeUnitsCache()
+	a.purgeCatalogCaches()
 
 	return &StatusOutput{Body: common.SimpleResponse{Status: "ok"}}, nil
 }
 
-// purgeUnitsCache invalidates both caches over the global catalogs: the /units
-// response held at Netlify's edge, and the API's own in-process copy.
+// purgeCatalogCaches invalidates every cache over the global catalogs: the
+// /units and /ingredients responses held at Netlify's edge, and the API's own
+// in-process copy.
 //
 // Called after a Recipe create or edit because both run insertUnits and
 // insertIngredients, which upsert every Unit and Ingredient the Recipe's lines
-// reference - so either can coin a Unit ("bunch", arriving via an import) that
-// the cached catalogs do not have - and then classifyNewIngredients, which
-// writes Base Units, Display Units, pantry flags and Unit Sizes. Delete is
-// deliberately not wired: it removes a Recipe's parts, never a Unit or an
-// Ingredient, so there is nothing to invalidate and a purge there would only
-// spend the rate limit.
+// reference - so either can coin a Unit ("bunch", arriving via an import) or an
+// Ingredient ("nduja") that the cached catalogs do not have - and then
+// classifyNewIngredients, which writes Base Units, Display Units, pantry flags
+// and Unit Sizes. Delete is deliberately not wired: it removes a Recipe's
+// parts, never a Unit or an Ingredient, so there is nothing to invalidate and a
+// purge there would only spend the rate limit.
 //
-// The two caches are cleared from **one** call site rather than two, on
-// purpose. They hold the same data for different readers - the edge serves
-// clients, the in-process copy serves this API's own combining logic - and a
-// save that cleared one but not the other would leave the Shopping List
-// combining against a catalog the client can already see is out of date. One
-// place that knows the catalog changed, not two that have to stay in step.
+// /tags is deliberately absent, and always will be: the `tag` table is seeded
+// by migration and no code path writes to it, which is why it carries a day's
+// s-maxage and no tag at all.
+//
+// Every cache is cleared from **one** call site rather than three, on purpose.
+// They hold the same data for different readers - the edge serves clients, the
+// in-process copy serves this API's own combining logic - and a save that
+// cleared one but not another would leave the Shopping List combining against a
+// catalog the client can already see is out of date. One place that knows the
+// catalog changed, not several that have to stay in step.
+//
+// Two Purge calls rather than one, because Purge throttles per tag: a burst of
+// saves coalesces within each tag independently, and neither catalog can crowd
+// the other out of Netlify's two-purges-per-five-seconds limit.
 //
 // Returns nothing and is called for effect, after the write has already
 // succeeded. It cannot fail the save: Purge dispatches in the background and
-// swallows its own errors, Invalidate cannot fail, and if both did nothing at
-// all the five-minute expiry on each is what makes that self-heal.
-func (a *App) purgeUnitsCache() {
+// swallows its own errors, Invalidate cannot fail, and if all three did nothing
+// at all the five-minute expiry on each is what makes that self-heal.
+func (a *App) purgeCatalogCaches() {
 	a.purger.Purge(UnitsCacheTag)
+	a.purger.Purge(IngredientsCacheTag)
 	a.catalogs.Invalidate()
 }
 

--- a/pages/api/parse-recipe-text.ts
+++ b/pages/api/parse-recipe-text.ts
@@ -20,7 +20,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     // Read from the database rather than taken from the request body - see
     // lib/recipe-import/known-names.ts for why the client is no longer asked.
-    const { knownIngredients, knownUnits } = await fetchKnownNames(req);
+    const { knownIngredients, knownUnits } = await fetchKnownNames();
     const { ingredients } = await extractRecipe({
       input: textToInput(text),
       knownIngredients,

--- a/pages/api/parse-recipe-url.ts
+++ b/pages/api/parse-recipe-url.ts
@@ -27,7 +27,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     const html = await (await fetch(url)).text();
     // Read from the database rather than taken from the request body - see
     // lib/recipe-import/known-names.ts for why the client is no longer asked.
-    const { knownIngredients, knownUnits } = await fetchKnownNames(req);
+    const { knownIngredients, knownUnits } = await fetchKnownNames();
     const result = await extractRecipe({
       input: htmlToInput(html),
       knownIngredients,

--- a/pages/api/recipe-image.ts
+++ b/pages/api/recipe-image.ts
@@ -203,7 +203,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     // entirely for a method-only import, which has no name to canonicalise.
     const { knownIngredients, knownUnits } = methodOnly
       ? { knownIngredients: [], knownUnits: [] }
-      : await fetchKnownNames(req);
+      : await fetchKnownNames();
 
     // Read the file and convert to base64
     const imageBuffer = await fs.readFile(imageFile.filepath);

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -724,6 +724,7 @@ export interface operations {
             200: {
                 headers: {
                     "Cache-Control"?: string;
+                    "Netlify-Cache-Tag"?: string;
                     [name: string]: unknown;
                 };
                 content: {


### PR DESCRIPTION
Closes follow-ups.md #51.

Every ingredient-bearing import fetched the whole Ingredient catalog from **Ohio to Frankfurt and back**. Those are Next.js API routes, so they run as Netlify functions in `us-east-2`, and `known-names.ts` called `API_HOST_INTERNAL` — the Fly origin — directly. The exact cost [ADR-0006](docs/adr/0006-go-api-leaves-netlify-functions.md) moved the API to remove, reintroduced from the other side.

## First, make it measurable

#51 says to measure before building any of the three fixes. The reason nobody had is that **the number was not obtainable**: `lib/telemetry/setup.ts` registers manual providers only, with no auto-instrumentation, so an outbound `fetch` produces no client span. The Go API's own server span *does* hang under the import's trace via the propagated `traceparent` — but it measures Go's handling and nothing else. The crossing, the TLS handshake on a cold container, and now the edge lookup all happen outside it, and they are the cost the item is about. Comparing the two spans' timestamps instead would measure clock skew between Netlify and Fly as much as latency.

So `fetchKnownNames` gets a span, the same way and for exactly the same reason `lib/telemetry/tool-span.ts` wraps the identical Netlify→Fly hop for Dave: *"from the outside that is a single slow request."* It carries `bigshop.known_names.ingredients` / `.units` (list lengths) and `.via_edge`. The lengths are the item's other half — `GetAllIngredients` is `SELECT name FROM ingredient`, unpaginated and growing monotonically, and this makes that visible before it matters. No names, per ADR-0008 §1.

The frequency half of the measurement was already answered by `bigshop.import.outcome`.

## Then cut it

The call now goes to the site's own hostname, so it meets a Netlify PoP near the function instead of crossing the Atlantic, and `/ingredients` answers `public, max-age=0, s-maxage=300` with a `Netlify-Cache-Tag` purged on every Recipe write — the same shape `/units` has had since #44.

**A miss is marginally slower than going direct** (it is the same trip with a PoP in front); a hit saves the whole crossing. That asymmetry is what makes it pay even at a low hit rate, and it is why the span is the first half of this PR rather than an afterthought.

## The thing the item did not anticipate

Every route except `/health` sat behind the JWT gate in `GetRouter` — **including `/units` and `/tags`**. So ADR-0009's *"`public` makes this readable by an unauthenticated caller"* described the response's **cacheability**, not the route's **reachability**. A shared CDN will not reliably store a response to a request carrying `Authorization`, and `known-names.ts` forwarded the browser's token — so while a token was required, the cache headers on all three catalogs were decoration.

The three global catalogs are now carved out of the auth middleware the way `/health` is. That makes ADR-0009's stated position true rather than aspirational: **a gate a CDN is licensed to serve around is not a gate** — the contents were public the moment the first response was cached.

What is exposed is exactly what [ADR-0001](docs/adr/0001-global-ingredient-catalog.md) defines as global and non-personal: Ingredient names, Unit names, and the seeded Tag list. No account is named and no Recipe is reachable. None of the three handlers takes a `Caller`, which `TestGlobalCatalogsAnswerWithoutAToken` checks rather than trusts — it also asserts `GET /recipes` still 401s, so the carve-out cannot quietly widen.

## Verification

- `gofmt -l` clean, `go vet ./...` clean, `go test ./... -race` — all packages pass.
- `docs/openapi.yaml` and `types/api.d.ts` regenerated (the new `Netlify-Cache-Tag` response header on `/ingredients`), so both drift gates are satisfied.
- `npm run lint`, `npm run typecheck` — clean.
- `npm test` — **247 passed**, including a new group covering the edge host: production shape, deploy-preview shape (`DEPLOY_URL` wins, so a preview reads its own edge rather than production's — the same trap `docs/deploy-previews.md` describes for Auth0 redirects), and the fallback to the direct origin when there is no site origin.
- `npm run test:e2e` — **27 passed**. Locally `NEXT_PUBLIC_API_HOST` is absolute, which is the signal that there is no edge in front, so e2e exercises the direct path exactly as before.

**Still to confirm on this PR's deploy preview**, and the one assumption the item flags as unverified: that Netlify's CDN caches a response fetched by one of its own functions. Now that the catalogs need no token, that is a plain unauthenticated `curl` against the preview — reading `age` / `cache-status` across two requests. I will post the result here before this is ready to merge.

No user-visible surface: this changes where a server-side lookup is fetched from, not anything rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)