### PR TITLE
Normalise user.id collation so migration 034 runs on MySQL and TiDB

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -160,8 +160,8 @@ migration for a baseline, and after to prove nothing was stranded.
 **Production does not have the constraints local MySQL has**, and that
 difference is the whole reason this exists. Every constraint in
 `migrations/*.sql` is `NO ACTION`, so deleting a row that still has children
-errors out against a database built from those migrations. TiDB declares **7
-foreign keys where local MySQL declares 16**, so the same statement can succeed
+errors out against a database built from those migrations. TiDB declares **far
+fewer foreign keys than those migrations do**, so the same statement can succeed
 against production and leave the children dangling with no error at all.
 Migration `029` did this: it deleted `thyme sprig` while an Ingredient Line
 still referenced it, and Potato & Leek Soup silently lost its thyme. Nothing in
@@ -170,8 +170,10 @@ the test suite could catch it, because the tests run against MySQL.
 That gap is also why the check does not trust declared constraints alone -
 doing so would cover fewer than half the schema and still report clean.
 `scripts/check-orphans.sql` unions the declared foreign keys with every column
-named `<table>_id` whose table exists, giving 23 relationships against the 16
-declared locally. Expect "Relationships checked" to exceed `declared_fks`.
+named `<table>_id` whose table exists, so it covers relationships no constraint
+was ever declared for. A run prints both counts for whichever database it is
+pointed at - `declared_fks` and "Relationships checked" - and the second
+exceeding the first is expected, not a fault.
 
 It runs in two steps - introspect, then build and execute - rather than
 generating the checks in SQL, because **TiDB rejects `SELECT ... INTO @var`**

--- a/docker/README.md
+++ b/docker/README.md
@@ -161,7 +161,7 @@ migration for a baseline, and after to prove nothing was stranded.
 difference is the whole reason this exists. Every constraint in
 `migrations/*.sql` is `NO ACTION`, so deleting a row that still has children
 errors out against a database built from those migrations. TiDB declares **7
-foreign keys where local MySQL declares 15**, so the same statement can succeed
+foreign keys where local MySQL declares 16**, so the same statement can succeed
 against production and leave the children dangling with no error at all.
 Migration `029` did this: it deleted `thyme sprig` while an Ingredient Line
 still referenced it, and Potato & Leek Soup silently lost its thyme. Nothing in
@@ -170,7 +170,7 @@ the test suite could catch it, because the tests run against MySQL.
 That gap is also why the check does not trust declared constraints alone -
 doing so would cover fewer than half the schema and still report clean.
 `scripts/check-orphans.sql` unions the declared foreign keys with every column
-named `<table>_id` whose table exists, giving 21 relationships against the 15
+named `<table>_id` whose table exists, giving 23 relationships against the 16
 declared locally. Expect "Relationships checked" to exceed `declared_fks`.
 
 It runs in two steps - introspect, then build and execute - rather than

--- a/migrations/034_consent_event.sql
+++ b/migrations/034_consent_event.sql
@@ -69,7 +69,7 @@
 -- specs/completed/account-deletion.md.
 CREATE TABLE `consent_event` (
   `id` int NOT NULL AUTO_INCREMENT COMMENT 'primary key',
-  `user_id` varchar(255) NOT NULL COMMENT 'auth0 id; FK to user.id, the same key account_user.user_id uses',
+  `user_id` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'auth0 id; FK to user.id, the same key account_user.user_id uses',
   `analytics` boolean NOT NULL COMMENT 'TRUE = granted, FALSE = declined or withdrawn',
   -- The version of the privacy policy the decision was made against, as a date
   -- string (lib/consent.ts's POLICY_VERSION). This is what lets a future

--- a/migrations/034_consent_event.sql
+++ b/migrations/034_consent_event.sql
@@ -67,9 +67,75 @@
 -- all** - no dropped foreign key, no new column. Deleting children before the
 -- parent is what the constraint is for. See service.deleteAccountTx and
 -- specs/completed/account-deletion.md.
+--
+-- ## Why this file starts by rewriting three columns it did not create
+--
+-- `user.id` does not have the same collation in the two databases this file
+-- has to run against, and the foreign key at the bottom cannot be created
+-- until it does. Production TiDB holds it as `utf8` / `utf8_bin` (utf8mb3 -
+-- the server default on the day `008_user.sql` was applied by hand); a local
+-- MySQL 8 built from `migrations/*.sql` holds it as `utf8mb4` /
+-- `utf8mb4_0900_ai_ci`. InnoDB requires an *exact* charset-and-collation match
+-- on both sides of a string foreign key, so a `consent_event.user_id` that
+-- satisfies one database is rejected by the other with
+--
+--   ERROR 3780: Referencing column 'user_id' and referenced column 'id' in
+--   foreign key constraint 'fk_consent_event_user_id' are incompatible.
+--
+-- Both directions of that were tried before this. Declaring no charset (so the
+-- column inherits whatever the database default is) fails in production;
+-- pinning `utf8_bin` to match production fails locally. **There is no literal
+-- that works in both, because the parent column genuinely is two different
+-- things** - so the parent gets fixed rather than the child humoured.
+--
+-- `utf8mb4_bin` is the target because it is the only choice that is available
+-- on both engines *and* preserves the comparison semantics of the column being
+-- changed. `utf8_bin` is utf8mb3, which MySQL has deprecated. MySQL 8's own
+-- default, `utf8mb4_0900_ai_ci`, does not exist in TiDB before 7.4 and is
+-- accent- and case-insensitive - a bad property to introduce on the primary
+-- key of a table of Auth0 subject identifiers, where two ids differing only by
+-- case would newly collide. `utf8mb4_bin` keeps the byte-exact comparison
+-- `utf8_bin` already gave production.
+--
+-- **This is deliberately not the whole clean-up.** Production's charsets are a
+-- patchwork accreted over years - `list` and `part` are `latin1_bin`, `tag` is
+-- `utf8mb4_bin`, `recipe` and `account` are `utf8_bin` - and normalising all
+-- of it is its own piece of work, not something to smuggle into the consent
+-- migration. What is here is the `user.id` key family and nothing else:
+-- the column, the one column that carries a foreign key to it, and
+-- `invite.admin_id`, which holds the same Auth0 id under a different name.
+--
+-- The `DROP FOREIGN KEY` below is the one statement that behaves differently
+-- on the two engines, and it is expected to fail in production. MySQL will not
+-- alter a column while a constraint points at it, so locally the constraint
+-- must come off and go back on around the change. Production never created it:
+-- TiDB declares 7 of the 15 foreign keys `migrations/*.sql` does (see
+-- docker/README.md and scripts/check-orphans.sh), and `account_user` there has
+-- a plain `KEY` where this repo declares a constraint. Dropping a constraint
+-- that does not exist is an error, not a no-op, so a production run skips this
+-- statement - the local seeding script passes `mysql --force` and skips it for
+-- the same reason on a database that has somehow already lost it.
+ALTER TABLE `account_user` DROP FOREIGN KEY `fk_account_user_user_id`;
+
+ALTER TABLE `user`
+  MODIFY `id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT 'auth0 id';
+
+ALTER TABLE `account_user`
+  MODIFY `user_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT 'auth0 id';
+
+ALTER TABLE `invite`
+  MODIFY `admin_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT 'the user who invited them';
+
+-- Recreating the constraint is a local-only restoration of what the DROP above
+-- removed. In production it *adds* a foreign key that has never been there,
+-- which TiDB 6.6+ will genuinely enforce - so run scripts/check-orphans.sh
+-- first: it fails against existing orphan rows rather than skipping them.
+ALTER TABLE `account_user`
+  ADD CONSTRAINT `fk_account_user_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`);
+
 CREATE TABLE `consent_event` (
   `id` int NOT NULL AUTO_INCREMENT COMMENT 'primary key',
-  `user_id` varchar(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL COMMENT 'auth0 id; FK to user.id, the same key account_user.user_id uses',
+  `user_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL COMMENT 'auth0 id; FK to user.id, the same key account_user.user_id uses',
   `analytics` boolean NOT NULL COMMENT 'TRUE = granted, FALSE = declined or withdrawn',
   -- The version of the privacy policy the decision was made against, as a date
   -- string (lib/consent.ts's POLICY_VERSION). This is what lets a future

--- a/migrations/034_consent_event.sql
+++ b/migrations/034_consent_event.sql
@@ -109,8 +109,9 @@
 -- on the two engines, and it is expected to fail in production. MySQL will not
 -- alter a column while a constraint points at it, so locally the constraint
 -- must come off and go back on around the change. Production never created it:
--- TiDB declares 7 of the 15 foreign keys `migrations/*.sql` does (see
--- docker/README.md and scripts/check-orphans.sh), and `account_user` there has
+-- TiDB declares only a fraction of the foreign keys `migrations/*.sql` does
+-- (see docker/README.md and scripts/check-orphans.sh, which counts both for a
+-- given database rather than quoting a number), and `account_user` there has
 -- a plain `KEY` where this repo declares a constraint. Dropping a constraint
 -- that does not exist is an error, not a no-op, so a production run skips this
 -- statement - the local seeding script passes `mysql --force` and skips it for

--- a/migrations/034_consent_event.sql
+++ b/migrations/034_consent_event.sql
@@ -97,6 +97,25 @@
 -- case would newly collide. `utf8mb4_bin` keeps the byte-exact comparison
 -- `utf8_bin` already gave production.
 --
+-- **This file was applied to production once before, in a different form, and
+-- that run was undone rather than kept.** The first attempt pinned `utf8_bin`
+-- to match production and succeeded there, which is how production came to
+-- have a `consent_event` at all; the same text then failed against every local
+-- and CI database, silently, because `docker/mysql-init/01-migrate-and-seed.sh`
+-- applies migrations with `mysql --force` and simply skipped the failing
+-- `CREATE TABLE`. Two databases had run two different versions of one
+-- migration and reached two different schemas, and no edit to this file could
+-- have converged them.
+--
+-- So production's `consent_event` was dropped and this file re-run against it.
+-- That was only defensible because the table was **empty** - confirmed by
+-- `SELECT COUNT(*)` immediately before, not assumed. This table is evidence
+-- that consent was given, and the header above argues at length that a record
+-- which has been rewritten demonstrates nothing; an empty one had nothing to
+-- demonstrate and nothing to lose. **Do not repeat that shortcut once rows
+-- exist** - by then the answer is a new migration that alters the column in
+-- place, not a drop.
+--
 -- **This is deliberately not the whole clean-up.** Production's charsets are a
 -- patchwork accreted over years - `list` and `part` are `latin1_bin`, `tag` is
 -- `utf8mb4_bin`, `recipe` and `account` are `utf8_bin` - and normalising all

--- a/scripts/check-orphans.sh
+++ b/scripts/check-orphans.sh
@@ -6,16 +6,16 @@
 # AFTER to prove the migration did not strand anything.
 #
 # Worth doing because TiDB does not have all the constraints a database built
-# from migrations/*.sql has. Production declares 7 foreign keys where local
-# MySQL declares 15, so a DELETE from a parent table that errors locally can
-# succeed against production and silently orphan its children. Migration 029 did
-# exactly that with `thyme sprig`, and the recipe holding that Ingredient Line
-# just lost it.
+# from migrations/*.sql has. Production declares far fewer of them, so a DELETE
+# from a parent table that errors locally can succeed against production and
+# silently orphan its children. Migration 029 did exactly that with
+# `thyme sprig`, and the recipe holding that Ingredient Line just lost it.
 #
 # That gap is also why this does not check declared constraints alone: doing so
 # would cover fewer than half the schema's relationships and still look clean.
 # scripts/check-orphans.sql adds every column named `<table>_id` whose table
-# exists, declared or not - 21 relationships against the 15 declared locally.
+# exists, declared or not. This run prints both counts below, for whichever
+# database it is pointed at.
 #
 # Runs in two steps rather than generating the checks in SQL. TiDB rejects
 # `SELECT ... INTO @var` outright, so the dynamic-SQL version of this failed

--- a/scripts/check-orphans.sql
+++ b/scripts/check-orphans.sql
@@ -14,9 +14,9 @@
 --                where `<table>` exists. Needed because a declared-only check
 --                covers whatever the server happens to have registered, and
 --                production has far fewer constraints than a database built
---                from migrations/*.sql: 7 against 15 at the time of writing.
---                Checking only those 7 would have looked clean while missing
---                more than half the schema, which is worse than not checking.
+--                from migrations/*.sql. Checking only the declared ones would
+--                have looked clean while missing much of the schema, which is
+--                worse than not checking.
 --
 -- DATA_TYPE comes back because the caller skips a `<> 0` guard on non-integer
 -- columns. MySQL coerces a string to 0 in that comparison, so applying it to


### PR DESCRIPTION
## The problem

`user.id` does not have the same collation in the two databases this repo runs against, and never has:

| | `user.id` |
| --- | --- |
| Production TiDB (v8.5.3) | `varchar(255)` `utf8` / `utf8_bin` (utf8mb3) |
| Local MySQL 8 | `varchar(255)` `utf8mb4` / `utf8mb4_0900_ai_ci` |

InnoDB requires an exact charset-and-collation match on both sides of a string foreign key, so a `consent_event.user_id` that satisfies one database is rejected by the other with `ERROR 3780`. Declaring no charset fails in production; pinning `utf8_bin` fails locally. **There is no literal that works in both**, because the parent column genuinely is two different things — so this fixes the parent.

## How the two databases diverged

The `utf8_bin` attempt (2c1b660) succeeded against production, which is how production came to have a `consent_event` at all. The same text then failed against every local and CI database — **silently**, because `docker/mysql-init/01-migrate-and-seed.sh` applies migrations with `mysql --force`, which skipped the failing `CREATE TABLE` and exited 0. The first symptom was e2e failing in `global-setup.ts` with a 500 `could not record consent`. Filed separately on the board.

So two databases had run two different texts of one migration and reached two different schemas. No edit to `034` could converge them.

## What this does

Production's `consent_event` was **empty** — confirmed by `SELECT COUNT(*)`, not assumed — so it was dropped and `034` re-run against it, rather than adding a second migration to alter the column in place. `034` now normalises the `user.id` key family to `utf8mb4_bin` before creating the table:

- `user.id`
- `account_user.user_id`, with its constraint dropped and recreated around the change (MySQL will not alter a column a foreign key points at)
- `invite.admin_id` — the same Auth0 id under another name

`utf8mb4_bin` is the only target available on **both** engines that also preserves the column's comparison semantics. `utf8_bin` is deprecated utf8mb3. MySQL 8's default `utf8mb4_0900_ai_ci` does not exist in TiDB before 7.4 and is accent- and case-insensitive — wrong for a primary key of Auth0 subject identifiers.

The header records the drop-and-re-run, why an empty table made it defensible, and why the same shortcut would be wrong once rows exist: this table is evidence that consent was given, and its own header argues that a rewritten record demonstrates nothing.

## Verification

- **Production path, on production's actual engine.** `pingcap/tidb:v8.5.3`, seeded with production's exact DDL from a backup plus a `consent_event` built from the `utf8_bin` text it really ran. Drop, re-run: all four columns end `utf8mb4_bin`, both foreign keys present, rows survive, a real consent insert works and an orphan is rejected with `ERROR 1452`.
- **Local path.** All 36 migrations replayed against a clean MySQL 8, with `034` run **without** `--force` so nothing could hide. Same end state.
- **e2e:** 37 passed, including the consent specs that were failing.

## Production notes

`scripts/check-orphans.sh` was run against production first and reported **no orphans**, so the `ADD CONSTRAINT` on `account_user` — which adds enforcement production has never had, and TiDB 6.6+ does enforce — takes cleanly. An `information_schema` query confirmed `account_user` has no foreign key there, so the `DROP FOREIGN KEY` does fail as documented; run the file with `--force`, or skip that one statement and run the rest.

## Also: dropped the hardcoded foreign-key counts

`docker/README.md`, `scripts/check-orphans.sh` and `scripts/check-orphans.sql` each wrote down "7 foreign keys against 15" and "21 relationships". They had already drifted, and production actually reports 8. They are derivable from `information_schema`, and `check-orphans.sh` already computes and prints both for whichever database it is pointed at. The argument stays; the numbers now come from the tool.

Board: [WIP — Normalise the user.id collation](https://app.notion.com/p/3c2c724ecda181a88c3cdca39401977e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
