### PR TITLE
Read TiDB connection details from .env.tidb, prompt only for the password

### DIFF
--- a/.env.tidb
+++ b/.env.tidb
@@ -1,0 +1,24 @@
+# Which TiDB instance the scripts in scripts/ talk to.
+#
+# Read by scripts/lib/tidb-env.sh, and therefore by backup-prod.sh,
+# check-orphans.sh and sync-from-prod.sh. NOT read by Next.js - @next/env only
+# loads .env, .env.local and .env.<NODE_ENV>, so nothing here reaches the app.
+#
+# Tracked in git on purpose, like .env.development and .env.production. Nothing
+# in this file is a secret: it names an instance, it does not open one. The
+# password is never stored anywhere - each script prompts for it, silently, on
+# every run. Do not add it here.
+
+TIDB_HOST=gateway01.eu-central-1.prod.aws.tidbcloud.com
+TIDB_USER=3of82tmdiXMHzuo.root
+
+# 4000 is TiDB Cloud's protocol port, not MySQL's usual 3306.
+TIDB_PORT=4000
+TIDB_DB=bigshop
+
+# Only used by sync-from-prod.sh: which account's recipes to pull into local
+# dev. Not necessarily 1 - migration 012 swapped accounts around, so confirm
+# with `SELECT * FROM account_user;` in the TiDB console. Left unset, the
+# script asks rather than guessing, because guessing wrong syncs somebody
+# else's recipes.
+ACCOUNT_ID=1

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,14 +12,14 @@ production instead of the two made-up ones.
 
 ## What `scripts/sync-from-prod.sh` does
 
-One command, no arguments or env vars:
+One command, no arguments:
 
 ```bash
 scripts/sync-from-prod.sh
 ```
 
-It prompts for TiDB host, port (defaults to `4000`), username, password, and
-account id (defaults to `1`), then:
+It reads the connection details from `.env.tidb` and asks only for the
+password (see "Connection details" below), then:
 1. Exports full copies of the shared reference tables - `ingredient`,
    `unit`, `tag`, `department`, `ingredient_department`. These aren't
    scoped to any account, so they're pulled in whole.
@@ -53,29 +53,69 @@ SQL editor (link in `CLAUDE.md`):
 SELECT * FROM account_user;
 ```
 
-Your row's `account_id` is the value to enter when the script prompts for it.
+Your row's `account_id` goes in `.env.tidb` as `ACCOUNT_ID`. It is the one
+value that is *not* defaulted: leave it unset and the script asks rather than
+assuming `1`, because assuming wrong would pull somebody else's recipes onto
+your laptop.
 
 ## Connection details
 
-- Host / username / password - all three can be read straight out of the
-  production `DSN` connection string, which lives in Netlify's environment
-  variables UI (see the Netlify Dashboard link in `CLAUDE.md`) rather than
-  anywhere in this repo. The `DSN` format is
-  `user:password@tcp(host:port)/bigshop?...` (see `main.go`'s
+`sync-from-prod.sh`, `check-orphans.sh` and `backup-prod.sh` share one source
+of connection details: **`.env.tidb` at the repo root**, read by
+`../scripts/lib/tidb-env.sh`. Every one of them asks for exactly one thing at
+run time, the password.
+
+```
+TIDB_HOST=...        # no default - must be set
+TIDB_USER=...        # no default - must be set
+TIDB_PORT=4000       # TiDB Cloud's protocol port, not MySQL's usual 3306
+TIDB_DB=bigshop
+ACCOUNT_ID=          # sync-from-prod.sh only; unset means it asks
+```
+
+**`.env.tidb` is tracked in git**, like `.env.development` and
+`.env.production`. Nothing in it is a secret: a hostname, a port, a username
+and a database name *identify* the instance, they do not open it. Checking them
+in is what makes these scripts a one-liner on a fresh clone instead of four
+questions on every run. The password is the secret, and it is not in there.
+
+Anything already exported in your environment beats the file, so a one-off run
+against somewhere else needs no edit and nothing put back afterwards:
+
+```bash
+TIDB_HOST=some-other-gateway scripts/check-orphans.sh
+```
+
+Missing `TIDB_HOST` or `TIDB_USER` is a hard error naming what is missing -
+they are deliberately not defaulted, because a script that silently connects
+somewhere you did not mean is worse than one that refuses.
+
+- **Host and username** can be read straight out of the production `DSN`
+  connection string, which lives in Netlify's environment variables UI (see the
+  Netlify Dashboard link in `CLAUDE.md`) rather than anywhere in this repo. The
+  `DSN` format is `user:password@tcp(host:port)/bigshop?...` (see `main.go`'s
   `sql.Open("mysql", os.Getenv("DSN"))`). The query parameters after the `?`
   are load-bearing rather than incidental - see
   [technical-architecture.md](../technical-architecture.md#the-dsns-query-parameters)
   before rewriting one.
-- Port - defaults to `4000`, TiDB Cloud's protocol port (not MySQL's usual
-  `3306`). Only enter a different one if yours differs.
-- Password - never passed as an argument or stored anywhere by the script.
-  It prompts for it once (silently) and holds it only in memory for the
-  `mysqldump` calls that need it. Credential-injection tooling (1Password
-  CLI, macOS Keychain) was considered and deliberately skipped for now -
-  1Password's seamless biometric-unlock flow is inherently host-bound and
-  can't run purely in Docker, and the fully-containerized alternative
-  (service account tokens) needs a compatible plan tier and a separate
-  shared vault, which wasn't judged worth it yet.
+- **Password** - never passed as an argument, never read from `.env.tidb` or
+  from the environment, and stored nowhere. Each script prompts once, silently,
+  and holds it in memory only for the container calls that need it, which
+  receive it as an environment variable rather than on a command line where the
+  host's process list would show it. A script whose stdin is not a terminal
+  fails with that explanation rather than reading a line from whatever is piped
+  in. Credential-injection tooling (1Password CLI, macOS Keychain) was
+  considered and deliberately skipped for now - 1Password's seamless
+  biometric-unlock flow is inherently host-bound and can't run purely in
+  Docker, and the fully-containerized alternative (service account tokens)
+  needs a compatible plan tier and a separate shared vault, which wasn't judged
+  worth it yet.
+
+`.env.tidb` is parsed, not `source`d. It holds credentials-adjacent
+configuration, not code, and sourcing it would execute whatever ended up in it
+- including a value pasted out of a console with a `$(...)` somewhere in it.
+Next.js never sees the file either: `@next/env` loads `.env`, `.env.local` and
+`.env.<NODE_ENV>`, and this is none of those.
 
 ## Why mysqldump runs inside Docker
 
@@ -251,8 +291,8 @@ account's recipes. For an actual backup of everything:
 scripts/backup-prod.sh
 ```
 
-Prompts for the same connection details, then writes a compressed logical dump
-to `~/big-shop-backups/bigshop-<timestamp>/` - one schema file and one data
+Uses the same `.env.tidb` and asks only for the password, then writes a
+compressed logical dump to `~/big-shop-backups/bigshop-<timestamp>/` - one schema file and one data
 file per table, the same layout as the older dumps in `backups/`.
 
 **It uses Dumpling, not BR.** BR is the tool people reach for and it cannot work
@@ -269,9 +309,10 @@ subject ids and invite tokens. `backups/` is tracked in git and already holds
 seven users' email addresses from 2024, which is enough of that. The script
 refuses to write anywhere inside the working tree.
 
-Three knobs, all env vars: `BACKUP_ROOT` to change the destination,
-`CONSISTENCY=none` if the instance rejects Dumpling's default snapshot read, and
-`CA_FILE` if you ever need a private CA.
+Three further knobs, all env vars, and none of them in `.env.tidb` because all
+three are per-run rather than per-instance: `BACKUP_ROOT` to change the
+destination, `CONSISTENCY=none` if the instance rejects Dumpling's default
+snapshot read, and `CA_FILE` if you ever need a private CA.
 
 **A Docker Desktop trap worth knowing**, since the first version of this script
 hit it: don't bind-mount the host's `/etc/ssl/cert.pem` into the container. On

--- a/scripts/backup-prod.sh
+++ b/scripts/backup-prod.sh
@@ -5,6 +5,9 @@
 # Usage:
 #   scripts/backup-prod.sh
 #
+# Host, port, username and database come from .env.tidb (tracked in git - see
+# scripts/lib/tidb-env.sh); only the password is typed, on every run.
+#
 # ---------------------------------------------------------------------------
 # Why Dumpling and not BR
 # ---------------------------------------------------------------------------
@@ -68,16 +71,10 @@ if [ -n "$CA_FILE" ] && [ ! -f "$CA_FILE" ]; then
   exit 1
 fi
 
-read -rp "TiDB host: " TIDB_HOST
-read -rp "TiDB port [4000]: " TIDB_PORT
-TIDB_PORT="${TIDB_PORT:-4000}"
-read -rp "TiDB username: " TIDB_USER
-read -rsp "TiDB password: " TIDB_PASSWORD
-echo
-read -rp "Database [bigshop]: " DB_NAME
-DB_NAME="${DB_NAME:-bigshop}"
+. scripts/lib/tidb-env.sh
+tidb_env_load
 
-OUT_DIR="${BACKUP_ROOT}/${DB_NAME}-$(date +%Y%m%d-%H%M%S)"
+OUT_DIR="${BACKUP_ROOT}/${TIDB_DB}-$(date +%Y%m%d-%H%M%S)"
 
 # Guard: a backup full of email addresses must not land somewhere git tracks.
 case "$(cd "$(dirname "$OUT_DIR")" 2>/dev/null && pwd -P || echo "$OUT_DIR")" in
@@ -88,6 +85,11 @@ case "$(cd "$(dirname "$OUT_DIR")" 2>/dev/null && pwd -P || echo "$OUT_DIR")" in
     ;;
 esac
 
+# Deliberately after the guard above: nothing should ask for a password and
+# then refuse to run. Also before the mkdir, so abandoning the prompt does not
+# leave an empty dated directory behind.
+tidb_prompt_password
+
 mkdir -p "$OUT_DIR"
 
 CA_IN_CONTAINER="$CONTAINER_CA"
@@ -97,7 +99,7 @@ if [ -n "$CA_FILE" ]; then
   echo "Using the CA at $CA_FILE"
 fi
 
-echo "Backing up ${DB_NAME} from ${TIDB_HOST} to ${OUT_DIR} ..."
+echo "Backing up ${TIDB_DB} from ${TIDB_HOST} to ${OUT_DIR} ..."
 
 # --consistency: "auto" resolves to TiDB's snapshot isolation, which needs no
 #   locks and no privileges a TiDB Cloud user lacks. If the instance rejects it
@@ -125,7 +127,7 @@ docker run --rm \
     --filetype sql \
     --consistency "$4" \
     --compress gzip' \
-  "$TIDB_HOST" "$TIDB_PORT" "$TIDB_USER" "$DB_NAME" "${CONSISTENCY:-auto}" "$CA_IN_CONTAINER"
+  "$TIDB_HOST" "$TIDB_PORT" "$TIDB_USER" "$TIDB_DB" "${CONSISTENCY:-auto}" "$CA_IN_CONTAINER"
 
 rm -f "$OUT_DIR/.ca.pem"
 
@@ -139,7 +141,7 @@ echo "⚠  This backup contains real user emails, Auth0 ids and invite tokens."
 echo "   Keep it out of the repository and off anything shared."
 echo
 echo "To restore into your local dev database:"
-echo "   gunzip -c ${OUT_DIR}/*.sql.gz | docker compose exec -T db mysql -uroot -proot ${DB_NAME}"
+echo "   gunzip -c ${OUT_DIR}/*.sql.gz | docker compose exec -T db mysql -uroot -proot ${TIDB_DB}"
 echo
 echo "To restore into a fresh TiDB Cloud instance, use TiDB Lightning or the"
 echo "console's import - a plain mysql client replay works for a database this"

--- a/scripts/check-orphans.sh
+++ b/scripts/check-orphans.sh
@@ -28,23 +28,19 @@
 # MySQL 9+ having dropped the mysql_native_password plugin TiDB accounts often
 # still use.
 #
-# Credentials come from the TiDB Cloud console. The password is passed via the
-# container's environment, never on the command line where it would show up in
-# the process list.
+# Host, port, username and database come from .env.tidb (tracked in git - see
+# scripts/lib/tidb-env.sh); only the password is typed, on every run. It is
+# passed via the container's environment, never on the command line where it
+# would show up in the process list.
 #
 # Usage:
 #   scripts/check-orphans.sh
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-read -rp "TiDB host: " TIDB_HOST
-read -rp "TiDB port [4000]: " TIDB_PORT
-TIDB_PORT="${TIDB_PORT:-4000}"
-read -rp "TiDB username: " TIDB_USER
-read -rsp "TiDB password: " TIDB_PASSWORD
-echo
-read -rp "Database [bigshop]: " TIDB_DB
-TIDB_DB="${TIDB_DB:-bigshop}"
+. scripts/lib/tidb-env.sh
+tidb_env_load
+tidb_prompt_password
 
 # SQL on stdin; any extra mysql flags as arguments.
 run_mysql() {

--- a/scripts/lib/tidb-env.sh
+++ b/scripts/lib/tidb-env.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Shared TiDB connection details for the scripts that talk to production.
+#
+# Source it, then call the two functions:
+#
+#   . "$(dirname "$0")/lib/tidb-env.sh"
+#   tidb_env_load       # TIDB_HOST/PORT/USER/DB, from the environment
+#   tidb_prompt_password  # TIDB_PASSWORD, typed silently, held in memory only
+#
+# ---------------------------------------------------------------------------
+# Why the two are separate calls
+# ---------------------------------------------------------------------------
+# So a caller can do all of its own validation - the "is this path inside the
+# repo" guard in backup-prod.sh, for instance - between knowing where it is
+# connecting and asking a human to type a password. Prompting first and then
+# refusing to run wastes the one step that cannot be automated away.
+#
+# ---------------------------------------------------------------------------
+# Where the values come from
+# ---------------------------------------------------------------------------
+# `.env.tidb` at the repo root, which is **tracked in git** like
+# `.env.development` and `.env.production` are. None of what it holds is a
+# secret: a hostname, a port, a username and a database name identify the
+# instance but grant nothing without the password, which is not in there and
+# never will be. Checking them in is what makes these scripts a one-liner on a
+# fresh clone instead of four questions every run.
+#
+# Anything already exported in the environment wins over the file, so a one-off
+# run against a different instance is `TIDB_HOST=other scripts/check-orphans.sh`
+# with nothing edited and nothing to put back afterwards.
+#
+# The password is read from neither. It is typed on every run and lives only in
+# this shell's memory for as long as the script does - the posture
+# docker/README.md has always documented, and the reason none of these scripts
+# ever put a password on a command line.
+#
+# The file is parsed, not sourced. A plain `source` would execute whatever
+# ended up in it, including a value pasted out of a console with a `$(...)`
+# somewhere in it.
+
+# Resolve the repo root from this file's own location, so it does not matter
+# what the caller has cd'd to.
+TIDB_ENV_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+# Read KEY=VALUE lines from $1 into the environment, without overwriting
+# anything already set to a non-empty value.
+tidb_env_read_file() {
+  local file="$1" line key value
+  [ -f "$file" ] || return 0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line#"${line%%[![:space:]]*}"}"   # strip leading whitespace
+    case "$line" in ''|'#'*) continue ;; esac
+    line="${line#export }"
+
+    key="${line%%=*}"
+    [ "$key" = "$line" ] && continue          # no '=' on the line at all
+    value="${line#*=}"
+
+    key="${key%"${key##*[![:space:]]}"}"      # strip trailing whitespace
+    [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    case "$value" in
+      \"*\") value="${value#\"}"; value="${value%\"}" ;;
+      \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    esac
+
+    # Treat set-but-empty as unset: an exported TIDB_HOST= should not defeat
+    # the file it was presumably meant to be read from.
+    if [ -z "${!key:-}" ]; then
+      printf -v "$key" '%s' "$value"
+      export "$key"
+    fi
+  done < "$file"
+}
+
+# TIDB_HOST, TIDB_PORT, TIDB_USER and TIDB_DB, or a usable error.
+tidb_env_load() {
+  tidb_env_read_file "$TIDB_ENV_REPO_ROOT/.env.tidb"
+
+  # 4000 is TiDB Cloud's protocol port, not MySQL's usual 3306.
+  TIDB_PORT="${TIDB_PORT:-4000}"
+  TIDB_DB="${TIDB_DB:-bigshop}"
+
+  local missing=""
+  [ -n "${TIDB_HOST:-}" ] || missing="TIDB_HOST"
+  [ -n "${TIDB_USER:-}" ] || missing="${missing:+$missing }TIDB_USER"
+
+  if [ -n "$missing" ]; then
+    echo "Missing required connection detail(s): $missing" >&2
+    echo >&2
+    echo "Set them in $TIDB_ENV_REPO_ROOT/.env.tidb (tracked in git - none of" >&2
+    echo "it is secret), or export them for a one-off run." >&2
+    echo >&2
+    echo "Both can be read out of the production DSN in Netlify's environment" >&2
+    echo "variables UI: user:password@tcp(host:port)/bigshop?..." >&2
+    echo "See docker/README.md, 'Connection details'." >&2
+    exit 1
+  fi
+
+  export TIDB_HOST TIDB_PORT TIDB_USER TIDB_DB
+}
+
+# TIDB_PASSWORD, typed silently. Never defaulted from the environment or the
+# file - see the header.
+tidb_prompt_password() {
+  if [ ! -t 0 ]; then
+    echo "Cannot prompt for the TiDB password: stdin is not a terminal." >&2
+    echo "These scripts are interactive by design; the password is never read" >&2
+    echo "from the environment or from a file." >&2
+    exit 1
+  fi
+
+  read -rsp "TiDB password for ${TIDB_USER}@${TIDB_HOST}: " TIDB_PASSWORD
+  echo
+
+  if [ -z "$TIDB_PASSWORD" ]; then
+    echo "No password entered." >&2
+    exit 1
+  fi
+}

--- a/scripts/sync-from-prod.sh
+++ b/scripts/sync-from-prod.sh
@@ -17,17 +17,27 @@
 #
 # Usage:
 #   scripts/sync-from-prod.sh
+#
+# Host, port, username, database and account id come from .env.tidb (tracked in
+# git - see scripts/lib/tidb-env.sh); only the password is typed, on every run.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-read -rp "TiDB host: " TIDB_HOST
-read -rp "TiDB port [4000]: " TIDB_PORT
-TIDB_PORT="${TIDB_PORT:-4000}"
-read -rp "TiDB username: " TIDB_USER
-read -rsp "TiDB password: " TIDB_PASSWORD
-echo
-read -rp "Account id [1]: " ACCOUNT_ID
-ACCOUNT_ID="${ACCOUNT_ID:-1}"
+. scripts/lib/tidb-env.sh
+tidb_env_load
+
+# ACCOUNT_ID is the one value that still asks when it has not been set. It can
+# live in .env.tidb like the rest, but it must not silently default: migration
+# 012 swapped accounts around, so 1 is not reliably yours in production, and a
+# wrong guess pulls somebody else's recipes onto your laptop. Unset means ask.
+if [ -z "${ACCOUNT_ID:-}" ]; then
+  echo "ACCOUNT_ID is not set in .env.tidb. Find yours with"
+  echo "  SELECT * FROM account_user;   -- in the TiDB console"
+  read -rp "Account id [1]: " ACCOUNT_ID
+  ACCOUNT_ID="${ACCOUNT_ID:-1}"
+fi
+
+tidb_prompt_password
 
 mkdir -p docker/prod-dumps
 DUMP_FILE="docker/prod-dumps/prod-sync-${ACCOUNT_ID}-$(date +%Y%m%d-%H%M%S).sql"
@@ -70,17 +80,17 @@ run_mysqldump() {
 }
 
 echo "Exporting shared reference tables (ingredients, units, tags, departments)..."
-run_mysqldump bigshop department unit ingredient tag ingredient_department > "$DUMP_FILE"
+run_mysqldump "$TIDB_DB" department unit ingredient tag ingredient_department > "$DUMP_FILE"
 
 echo "Exporting your recipes (account_id=${ACCOUNT_ID})..."
-run_mysqldump bigshop recipe --where="account_id=${ACCOUNT_ID}" >> "$DUMP_FILE"
+run_mysqldump "$TIDB_DB" recipe --where="account_id=${ACCOUNT_ID}" >> "$DUMP_FILE"
 
 echo "Exporting those recipes' ingredients..."
-run_mysqldump bigshop part \
+run_mysqldump "$TIDB_DB" part \
   --where="recipe_id IN (SELECT id FROM recipe WHERE account_id=${ACCOUNT_ID})" >> "$DUMP_FILE"
 
 echo "Exporting those recipes' tags..."
-run_mysqldump bigshop recipe_tag \
+run_mysqldump "$TIDB_DB" recipe_tag \
   --where="recipe_id IN (SELECT id FROM recipe WHERE account_id=${ACCOUNT_ID})" >> "$DUMP_FILE"
 
 echo "Saved to ${DUMP_FILE}"

--- a/technical-architecture.md
+++ b/technical-architecture.md
@@ -270,6 +270,30 @@ NEXT_PUBLIC_HOST=https://www.bigshop.life
 Netlify UI wins over this file. That is what makes the UI the control surface and this the
 default — and why rolling the API cutover back means changing the UI values, not this file.
 
+### Script variables (`.env.tidb`)
+
+Read by `scripts/lib/tidb-env.sh`, and therefore by `scripts/sync-from-prod.sh`,
+`scripts/check-orphans.sh` and `scripts/backup-prod.sh`. Nothing in the running
+application reads them — `@next/env` loads `.env`, `.env.local` and
+`.env.<NODE_ENV>`, and `.env.tidb` is none of those.
+
+| Variable | Default | Notes |
+|---|---|---|
+| `TIDB_HOST` | none — required | From the production `DSN` in the Netlify UI |
+| `TIDB_USER` | none — required | Same place |
+| `TIDB_PORT` | `4000` | TiDB Cloud's protocol port, not MySQL's `3306` |
+| `TIDB_DB` | `bigshop` | |
+| `ACCOUNT_ID` | none — asks | `sync-from-prod.sh` only; deliberately not defaulted to `1` |
+
+**The file is committed, and that is the point.** A host, port, username and
+database name identify an instance without opening it, so none of them is a
+secret, and checking them in is what reduces every one of those scripts to a
+single password prompt. The password is the secret and lives in none of this:
+it is typed on each run, held in memory, and passed to the `mysql`/`mysqldump`/
+Dumpling containers through their environment rather than on a command line the
+host's process list would show. Exported environment variables override the
+file, so a one-off run elsewhere edits nothing.
+
 ### Telemetry variables, and which of them are secret
 
 Set in the Netlify UI, not committed. Three runtimes, three different shapes,


### PR DESCRIPTION
The three scripts that talk to production TiDB — `sync-from-prod.sh`,
`check-orphans.sh` and `backup-prod.sh` — each asked four questions before doing
anything: host, port, username, password, plus a database name or account id on
top. Every answer but one was identical on every run, and the one that varies is
the one that cannot be stored.

They now share `scripts/lib/tidb-env.sh`, which reads `TIDB_HOST`, `TIDB_USER`,
`TIDB_PORT` and `TIDB_DB` from `.env.tidb` at the repo root and prompts for the
password alone.

```
$ scripts/check-orphans.sh
TiDB password for 3of82tmdiXMHzuo.root@gateway01.eu-central-1.prod.aws.tidbcloud.com:
```

### Why `.env.tidb` is committed

Tracked in git, like `.env.development` and `.env.production` already are. A
hostname, port, username and database name *identify* the instance without
opening it, so none of them is a secret, and committing them is what reduces
these scripts to a single prompt on a fresh clone rather than four questions
every run.

The password is the secret, it is in none of this, and the helper will not read
it from the environment or from a file even if asked. It is typed on each run,
held in memory for the life of the script, and passed to the `mysql` /
`mysqldump` / Dumpling containers through their environment rather than on a
command line the host's process list would show — which is the posture
`docker/README.md` already documented and this change preserves exactly.

Exported environment variables beat the file, so a one-off run elsewhere edits
nothing and needs nothing put back:

```bash
TIDB_HOST=some-other-gateway scripts/check-orphans.sh
```

### Three decisions worth reviewing

- **`TIDB_HOST` and `TIDB_USER` are not defaulted.** Missing either is a hard
  error naming it. A script that silently connects somewhere you did not mean is
  worse than one that refuses.
- **`sync-from-prod.sh`'s `ACCOUNT_ID` still asks when unset**, rather than
  defaulting to `1`. Migration 012 swapped accounts around, so `1` is not
  reliably yours in production, and guessing wrong syncs somebody else's recipes
  onto your laptop.
- **`backup-prod.sh` prompts after its "refusing to write inside the repo"
  guard, and before its `mkdir`.** It can no longer make you type a password and
  then decline to run, nor leave an empty dated directory behind when the prompt
  is abandoned.

The file is parsed, not `source`d — sourcing would execute whatever ended up in
it, including a value pasted out of a console with a `$(...)` somewhere in it.
Next.js never loads it either: `@next/env` reads `.env`, `.env.local` and
`.env.<NODE_ENV>`, and this is none of those.

`sync-from-prod.sh` was also hardcoding `bigshop` in its four `mysqldump` calls;
those now honour `TIDB_DB`. The local-container references stay hardcoded, being
the docker-compose database rather than the remote one.

### Testing

No screenshots: these are developer shell scripts with no user-visible surface.

Verified with a stubbed `docker` binary, driven through a real pty:

- one silent prompt, echo suppressed, and host/port/user/db reaching the client
  arguments correctly (`-h ... -P 4000 -u ... bigshop`);
- the file parser handling quoted values, `export ` prefixes, comments, spaces
  around `=`, a missing final newline, and leaving `$(echo pwned)` a literal
  string;
- exported environment beating the file, and set-but-empty treated as unset;
- missing `TIDB_HOST`/`TIDB_USER` failing with a message naming them, from all
  three scripts;
- non-tty stdin refused with an explanation instead of silently reading a piped
  line as the password.

**Not** run against real production TiDB — the password prompt is interactive by
design, so the first live run is a human one.

### Docs

`docker/README.md`'s "Connection details" is rewritten around the new
arrangement, and `technical-architecture.md` gains a "Script variables" table so
the environment-variable reference `CLAUDE.md` points at stays complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)