### PR TITLE
Make a failing migration fail the db container, not hide in it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,24 @@ This runs `scripts/dev-full.sh`, which:
   `serve` mode — the same one the production container on Fly runs —
   `DISABLE_AUTH=true`, hot-reloaded with `air` — edit any `.go` file and
   it rebuilds automatically) services.
+
+  **A failing migration now makes the `db` container unhealthy rather than
+  silently incomplete.** The replay runs `mysql --force`, which skips just the
+  failing statement and still exits 0 — so a broken migration used to leave a
+  hole in the schema behind a container reporting Healthy, and the first
+  symptom was an application-looking 500. Every error is now reconciled against
+  `docker/mysql-init/expected-migration-errors.txt`, which lists the handful of
+  early statements that genuinely cannot apply to an empty schema and says why
+  for each. Anything else sets `bigshop._migration_status.ok = 0`, and the
+  healthcheck reads that row, so `api` never starts against the result.
+
+  The verdict is a row rather than an exit code on purpose: a non-zero exit
+  kills the container, `restart: unless-stopped` brings it straight back, and
+  the entrypoint skips the init scripts on that second start because the data
+  directory is no longer empty — producing a Healthy container with exactly
+  the broken schema the check rejected. **Fixing the migration is not enough
+  on its own for the same reason: the replay only runs against an empty data
+  directory, so recreate the volume** (`docker compose down -v`).
 - Brings up `lgtm` (`grafana/otel-lgtm` — Collector, Tempo, Loki, Prometheus
   and Grafana in one image), the local stand-in for the Grafana Cloud stack.
   Grafana is on **3200**, not 3000 — the web app keeps 3000. The API exports

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,17 +12,39 @@ services:
       - ./docker/mysql-seed:/seed:ro
       - ./docker/mysql-init:/docker-entrypoint-initdb.d:ro
     healthcheck:
-      # -h 127.0.0.1 (not "localhost") is deliberate: the MySQL client treats
-      # the literal host "localhost" as "connect via the Unix socket", and the
-      # official image's entrypoint runs docker-entrypoint-initdb.d (our
-      # migrate-and-seed script) against a temporary, --skip-networking mysqld
-      # that still binds that same socket file before the real, fully-networked
-      # server starts. A "-h localhost" ping can therefore report Healthy
-      # against that temporary instance while migrations/seeding are still
-      # running, which then lets `api` (depends_on: service_healthy) start
-      # against a half-initialized DB. Forcing TCP via "127.0.0.1" only
-      # succeeds once the real server (post-init) is listening.
-      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-proot"]
+      # Two things have to be true, and this asserts both in one query.
+      #
+      # 1. The real server is up. -h 127.0.0.1 (not "localhost") is deliberate:
+      #    the MySQL client treats the literal host "localhost" as "connect via
+      #    the Unix socket", and the official image's entrypoint runs
+      #    docker-entrypoint-initdb.d (our migrate-and-seed script) against a
+      #    temporary, --skip-networking mysqld that still binds that same
+      #    socket file before the real, fully-networked server starts. A
+      #    "-h localhost" ping can therefore report Healthy against that
+      #    temporary instance while migrations/seeding are still running, which
+      #    then lets `api` (depends_on: service_healthy) start against a
+      #    half-initialized DB. Forcing TCP via "127.0.0.1" only succeeds once
+      #    the real server (post-init) is listening.
+      #
+      # 2. The migrations actually applied. 01-migrate-and-seed.sh runs
+      #    `mysql --force`, which skips a failing statement and still exits 0,
+      #    so a broken migration used to leave a silently incomplete schema
+      #    behind a Healthy container - see
+      #    docker/mysql-init/expected-migration-errors.txt. The script now
+      #    writes its verdict to bigshop._migration_status, and this is what
+      #    reads it. Being a row in the data directory rather than an exit
+      #    code is the point: `restart: unless-stopped` would resurrect a
+      #    container that exited, and the entrypoint skips the init scripts on
+      #    that second start because the data directory is no longer empty.
+      #
+      # Unhealthy here means: `docker compose logs db`, then
+      # `docker compose down -v && docker compose up -d db` once fixed.
+      test:
+        - CMD-SHELL
+        - >-
+          mysql -h 127.0.0.1 -uroot -proot -N -B
+          -e "SELECT ok FROM bigshop._migration_status WHERE id = 1"
+          2>/dev/null | grep -qx 1
       interval: 5s
       timeout: 5s
       retries: 20

--- a/docker/README.md
+++ b/docker/README.md
@@ -187,6 +187,34 @@ npm run dev:full
 empty database again, and the synthetic migrate-and-seed step in
 `mysql-init/` runs fresh.
 
+`down -v` is also the only way to re-run migrations at all: the MySQL
+entrypoint runs `docker-entrypoint-initdb.d` only when the data directory is
+empty, so editing a migration and restarting the container does nothing.
+
+## When the `db` container will not go healthy
+
+`mysql-init/01-migrate-and-seed.sh` applies migrations with `--force`, which
+skips a failing statement and still exits 0. Left alone that hides a broken
+migration as a hole in the schema behind a Healthy container — a
+collation-incompatible `CREATE TABLE consent_event` was skipped exactly this
+way, and surfaced as a 500 from the consent endpoint that looked like an
+application bug.
+
+Every error the replay produces is now checked against
+`mysql-init/expected-migration-errors.txt`, which names the few early
+statements that cannot apply to an empty schema and explains each. Anything
+else writes `ok = 0` to `bigshop._migration_status`, which is what the
+healthcheck reads:
+
+```bash
+docker compose logs db | grep -A20 'not in expected-migration-errors'
+docker compose exec db mysql -uroot -proot -e \
+  "SELECT * FROM bigshop._migration_status"
+```
+
+Fix the migration — or add it to the allowlist with a note, if it genuinely
+cannot apply from scratch — then `docker compose down -v && npm run dev:full`.
+
 ## Checking for orphaned rows: `scripts/check-orphans.sh`
 
 ```bash

--- a/docker/mysql-init/01-migrate-and-seed.sh
+++ b/docker/mysql-init/01-migrate-and-seed.sh
@@ -1,27 +1,121 @@
 #!/bin/bash
 set -euo pipefail
 
+MIGRATIONS=/migrations
+ALLOWLIST=/docker-entrypoint-initdb.d/expected-migration-errors.txt
+
+# Every ERROR any migration produced, normalised to "<file>:<line>:<errno>".
+ACTUAL="$(mktemp)"
+EXPECTED="$(mktemp)"
+: > "$ACTUAL"
+
+sql() { mysql -uroot -p"$MYSQL_ROOT_PASSWORD" "$@"; }
+
 # migrations/001_init.sql opens with `CREATE DATABASE bigshop;`, but that
 # doesn't select the new database for the rest of the same session - the file
 # was always run interactively with the DB pre-selected. Create the database
 # separately, then apply the rest of 001 (and everything after) with -D bigshop.
-mysql -uroot -p"$MYSQL_ROOT_PASSWORD" -e "CREATE DATABASE IF NOT EXISTS bigshop;"
-tail -n +2 /migrations/001_init.sql | mysql -uroot -p"$MYSQL_ROOT_PASSWORD" bigshop
+sql -e "CREATE DATABASE IF NOT EXISTS bigshop;"
 
-for f in /migrations/*.sql; do
+# The verdict on this replay, written before anything is applied and only
+# flipped to ok=1 at the very end. It lives in the database, not in a file or
+# an exit code, because it has to survive a container restart - see the
+# comment above the failure banner at the bottom for why that matters.
+sql bigshop -e "
+  CREATE TABLE IF NOT EXISTS \`_migration_status\` (
+    \`id\` tinyint NOT NULL,
+    \`ok\` tinyint(1) NOT NULL COMMENT '1 only if every migration applied as expected and the seed loaded',
+    \`detail\` text COMMENT 'the unexpected errors, when ok = 0',
+    \`applied_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (\`id\`)
+  ) COMMENT 'set by docker/mysql-init/01-migrate-and-seed.sh; read by the db healthcheck';
+  REPLACE INTO \`_migration_status\` (id, ok, detail) VALUES (1, 0, 'migrations did not finish');
+"
+
+for f in "$MIGRATIONS"/*.sql; do
   base="$(basename "$f")"
-  if [ "$base" = "001_init.sql" ]; then
-    continue
-  fi
   echo "Applying migration: $base"
-  # --force: these migrations were applied by hand against a live DB over
-  # time, not replayed in order from scratch, so some later files re-apply a
-  # schema change an earlier "checkpoint" migration already folded in (e.g.
-  # 002_unique.sql re-adding a column 001_init.sql already has). --force
-  # skips just the failing statement and continues, which is fine here since
-  # the end schema is what we're actually verifying, not this file in isolation.
-  mysql --force -uroot -p"$MYSQL_ROOT_PASSWORD" bigshop < "$f"
+
+  errfile="$(mktemp)"
+  # --force skips just the failing statement and continues. It is needed
+  # because a few early migrations genuinely cannot apply to an empty schema -
+  # see expected-migration-errors.txt for the list and the reasoning. It also
+  # means mysql exits 0 no matter what went wrong, which is why the errors are
+  # captured here and reconciled against that file below.
+  if [ "$base" = "001_init.sql" ]; then
+    tail -n +2 "$f" | mysql --force -uroot -p"$MYSQL_ROOT_PASSWORD" bigshop 2>"$errfile" || true
+  else
+    mysql --force -uroot -p"$MYSQL_ROOT_PASSWORD" bigshop < "$f" 2>"$errfile" || true
+  fi
+
+  while IFS= read -r line; do
+    echo "  $line" >&2
+    # "ERROR 1060 (42S21) at line 2: Duplicate column name 'remote_url'"
+    if [[ "$line" =~ ^ERROR\ ([0-9]+)\ \([^\)]*\)\ at\ line\ ([0-9]+): ]]; then
+      echo "$base:${BASH_REMATCH[2]}:${BASH_REMATCH[1]}" >> "$ACTUAL"
+    else
+      # An error with no line number (a connection failure, say). Not
+      # allowlistable by key, and shouldn't be - fail on it.
+      echo "$base:UNPARSED" >> "$ACTUAL"
+    fi
+  done < <(grep '^ERROR ' "$errfile" || true)
+  rm -f "$errfile"
 done
 
+sed -E 's/#.*//; s/[[:space:]]//g' "$ALLOWLIST" | grep -v '^$' | sort -u > "$EXPECTED"
+sort -u "$ACTUAL" -o "$ACTUAL"
+
+# In the allowlist but didn't happen: somebody fixed a migration and left the
+# entry behind. Worth saying, not worth blocking a database on.
+stale="$(comm -13 "$ACTUAL" "$EXPECTED")"
+if [ -n "$stale" ]; then
+  echo "NOTE: these expected-migration-errors.txt entries did not occur; the" >&2
+  echo "      migration may have been fixed, in which case drop them:" >&2
+  echo "$stale" | sed 's/^/        /' >&2
+fi
+
+# Happened but not in the allowlist: --force skipped a statement nobody
+# accounted for, so the schema in this container is missing whatever that
+# statement did. That is the failure mode this whole dance exists to catch.
+unexpected="$(comm -23 "$ACTUAL" "$EXPECTED")"
+if [ -n "$unexpected" ]; then
+  cat >&2 <<MSG
+
+=======================================================================
+Migration replay hit an error that is not in expected-migration-errors.txt:
+
+$(echo "$unexpected" | sed 's/^/    /')
+
+--force SKIPPED that statement, so this database is missing whatever it
+was going to do. _migration_status.ok stays 0, which fails the db
+healthcheck, so nothing that depends_on it will start against this schema.
+
+Fix the migration. If it genuinely cannot apply to an empty database, add
+it to docker/mysql-init/expected-migration-errors.txt with a note saying
+why. Then recreate the volume: the entrypoint only runs this script when
+the data directory is empty.
+
+    docker compose down -v && docker compose up -d db
+=======================================================================
+MSG
+  # Deliberately NOT `exit 1`. A non-zero exit here aborts the entrypoint and
+  # kills the container, but `restart: unless-stopped` then brings it straight
+  # back - and on that second start the data directory is no longer empty, so
+  # the entrypoint skips docker-entrypoint-initdb.d entirely and mysqld comes
+  # up reporting healthy against the very half-built schema this check exists
+  # to reject. Verified: that is exactly what happens.
+  #
+  # So the verdict is left in _migration_status instead, where a restart
+  # cannot wash it off, and the healthcheck is what refuses. The container
+  # stays up and connectable, which is also the state you want for working
+  # out what actually broke.
+  detail="$(echo "$unexpected" | tr '\n' ' ')"
+  sql bigshop -e "REPLACE INTO \`_migration_status\` (id, ok, detail) VALUES (1, 0, '$(echo "$detail" | sed "s/'/''/g")');"
+  exit 0
+fi
+
 echo "Applying dev seed data"
-mysql -uroot -p"$MYSQL_ROOT_PASSWORD" bigshop < /seed/dev-seed.sql
+sql bigshop < /seed/dev-seed.sql
+
+sql bigshop -e "REPLACE INTO \`_migration_status\` (id, ok, detail) VALUES (1, 1, NULL);"
+echo "Migrations and seed applied; _migration_status.ok = 1"

--- a/docker/mysql-init/expected-migration-errors.txt
+++ b/docker/mysql-init/expected-migration-errors.txt
@@ -1,0 +1,45 @@
+# Migration errors that are expected on a from-scratch replay.
+#
+# migrations/*.sql were applied by hand against a live database over several
+# years, not designed to be replayed in order from an empty schema. A handful
+# of statements therefore cannot succeed here, and 01-migrate-and-seed.sh runs
+# `mysql --force` so the rest of the file still applies.
+#
+# --force on its own is indiscriminate: it skips a genuinely broken statement
+# just as happily as a known-conflicting one, and mysql still exits 0. That is
+# not theoretical - a collation-incompatible `CREATE TABLE consent_event` was
+# skipped outright, the container reported healthy, and the first symptom was
+# the e2e suite failing in global-setup.ts with a 500 `could not record
+# consent`, which looks exactly like an application bug and is nothing of the
+# kind.
+#
+# So every error is checked against this list. Anything not here fails
+# container init. Format, one per line:
+#
+#     <migration file>:<line>:<mysql errno>
+#
+# The line number is part of the key deliberately. These files are frozen
+# history and should never move; if one does, the entry stops matching and
+# somebody has to look at it again. That is the intended outcome.
+#
+# Adding an entry is a claim that the statement CANNOT succeed on an empty
+# database and that skipping it leaves the schema correct. Say why, in a
+# comment, or the next person has to re-derive it.
+
+# 002 re-adds `recipe.remote_url`, which 001_init.sql - a later checkpoint of
+# the same schema, written after the fact - already includes.
+#   ERROR 1060: Duplicate column name 'remote_url'
+002_unique.sql:2:1060
+
+# 006 backfills recipe_user from the author's 45 live recipes. A from-scratch
+# database has no recipe rows, so the INSERT trips the FK to `recipe`. Data
+# migration against data that only ever existed in production; nothing to
+# apply here.
+#   ERROR 1452: Cannot add or update a child row (fk_recipe_user_recipe_id)
+006_user.sql:30:1452
+
+# 012 repoints two named Auth0 subjects at different accounts. Neither
+# account_user row exists on a fresh database, so the UPDATE trips the FK to
+# `account`. Same story as 006.
+#   ERROR 1452: Cannot add or update a child row (fk_account_user_account_id)
+012_user_account.sql:3:1452

--- a/migrations/003_ingredient_tweaks.sql
+++ b/migrations/003_ingredient_tweaks.sql
@@ -10,6 +10,6 @@ UPDATE part SET
   unit_id = (SELECT id FROM unit WHERE name = 'tin'),
   ingredient_id = (SELECT id FROM ingredient WHERE name = 'Chopped Tomatoes')
 WHERE
-  ingredient_id = (SELECT id FROM ingredient WHERE name = 'Tinned Tomatoes')
+  ingredient_id = (SELECT id FROM ingredient WHERE name = 'Tinned Tomatoes');
 
 DELETE FROM ingredient WHERE name = 'Tinned Tomatoes';

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,7 +45,22 @@ export default defineConfig({
     command: 'npm run dev:full',
     url: `${BASE_URL}/recipes`,
     reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
+    // Generous because on a cold CI runner almost none of this is the app
+    // starting. A measured failing run spent ~110s of its 120s budget before
+    // MySQL had even been asked to start: pulling mysql:8.0 (129MB) and
+    // building the Go API image from scratch, with `docker compose up`
+    // reporting "Container bigshop-e2e-db-1 Waiting" as the clock ran out.
+    // Locally both are cached and the whole thing is up in seconds, which is
+    // why this only ever failed in CI - and it did so on unrelated branches
+    // too, at roughly one run in four.
+    //
+    // Raising the ceiling costs nothing in the normal case: Playwright polls
+    // `url` and proceeds the moment it answers. It only changes how long a
+    // genuinely stuck stack is given - and the common cause of that, a
+    // migration that failed to apply, now makes `docker compose up` exit
+    // non-zero rather than hang, so dev-full.sh fails fast instead of
+    // burning the budget.
+    timeout: 300_000,
     env: {
       WEB_PORT: String(WEB_PORT),
       API_PORT: String(API_PORT),

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -67,12 +67,33 @@ export DB_PORT API_PORT GRAFANA_PORT OTLP_HTTP_PORT
 # out costs nothing that decision was protecting.
 START_LGTM="${START_LGTM:-true}"
 
+# `api` depends_on db being healthy, and the db healthcheck now asserts that
+# the migrations actually applied (docker-compose.yml explains what it reads
+# and why). So "dependency failed to start: container ... is unhealthy" here
+# usually means a migration failed, not that MySQL is slow - and compose's
+# message doesn't say where to look.
+compose_up_failed() {
+  cat >&2 <<'MSG'
+
+docker compose could not bring the stack up. If it reported the db as
+unhealthy, the most likely cause is a migration that failed to apply:
+
+    docker compose logs db | grep -A20 'not in expected-migration-errors'
+
+Fix the migration, then recreate the volume - the MySQL entrypoint only
+replays migrations when the data directory is empty:
+
+    docker compose down -v && npm run dev:full
+MSG
+  exit 1
+}
+
 if [ "$START_LGTM" = "true" ]; then
   echo "Starting local MySQL + Go API + LGTM (docker compose)..."
-  docker compose up -d --build db api lgtm
+  docker compose up -d --build db api lgtm || compose_up_failed
 else
   echo "Starting local MySQL + Go API (docker compose); LGTM disabled."
-  docker compose up -d --build db api
+  docker compose up -d --build db api || compose_up_failed
 fi
 
 # The health poll, the browser and server-side code all address the API through


### PR DESCRIPTION
Closes the board item [_The migration runner hides a failing migration behind `mysql --force`_](https://app.notion.com/3c2c724ecda181578c15eaf790e5d893).

## The problem

`docker/mysql-init/01-migrate-and-seed.sh` applied every migration with `mysql --force`, which skips just the failing *statement* and lets the script exit 0.

The flag's existing justification is real — these migrations were applied by hand against a live database over several years, so a few early statements cannot apply to an empty schema, and without `--force` a from-scratch replay stops at the first one. But it applies equally to a migration that is **genuinely broken**, turning a loud DDL error into a silent hole in the schema. That has already bitten once: a collation-incompatible `CREATE TABLE consent_event` was skipped outright, the container reported Healthy, and the first symptom was the e2e suite failing in `global-setup.ts` with a 500 `could not record consent` — a failure that looks like an application bug and is nothing of the kind.

## The fix

Keep `--force`, but reconcile what it swallowed.

Every error is captured and normalised to `<file>:<line>:<errno>` and checked against a new **`docker/mysql-init/expected-migration-errors.txt`**. A full replay produces exactly three, each with a note in the file saying why it cannot succeed against an empty database:

| entry | why |
| --- | --- |
| `002_unique.sql:2:1060` | re-adds `recipe.remote_url`, which the later `001_init.sql` checkpoint already has |
| `006_user.sql:30:1452` | backfills `recipe_user` from 45 live recipes; no `recipe` rows exist from scratch |
| `012_user_account.sql:3:1452` | repoints two Auth0 subjects at accounts that don't exist from scratch |

Anything else fails the container. An allowlist entry that *stops* firing prints a note (someone fixed a migration and left the entry behind) but doesn't block.

An allowlist was chosen over the file-number cutoff the item also suggested, because a cutoff grants blanket amnesty to a range and records nothing about *what* is expected to fail — and the three real entries turn out to be individually explainable, which is more useful to the next reader.

## Why the verdict is a table row and not an exit code

`exit 1` was the obvious implementation and it **does not work**. Verified:

1. The script exits 1, the entrypoint aborts, the container dies. Correct so far.
2. `restart: unless-stopped` brings it straight back.
3. On that second start the data directory is no longer empty, so the entrypoint skips `docker-entrypoint-initdb.d` entirely.
4. mysqld comes up **Healthy**, against exactly the half-built schema the check had just rejected.

So the script writes its verdict to `bigshop._migration_status` — a row in the data directory, which a restart cannot wash off — and the `db` healthcheck reads it. The container stays up and connectable, which is also the state you want for working out what broke.

## Also fixed: `003_ingredient_tweaks.sql` had never applied

Found by the check itself. Line 13 was missing its semicolon, so the parser swallowed the following `DELETE` into the `UPDATE` and rejected both — `ERROR 1064`. A genuinely broken migration, hidden by `--force` since it was written. It is a no-op on a fresh database (no `part` rows exist by 003), so nothing changes locally, but it no longer needs allowlisting.

This is the payoff the item predicted: turn the check on, immediately find a broken migration.

## Verification

Negative test, with a deliberately broken migration injected:

```
$ docker compose up -d db
$ docker inspect -f '{{.State.Health.Status}}' db          # unhealthy
$ docker restart db && docker inspect ... Health.Status    # still unhealthy
$ docker compose exec db mysql ... 'SELECT ok, detail FROM _migration_status'
0    039_ZZTEMP_broken.sql:1:3780
$ docker compose up -d api
dependency failed to start: container ...-db-1 is unhealthy
```

Clean run: healthy, `ok = 1`, seed intact. **37/37 e2e pass.**

No production impact — `_migration_status` is created by the local docker init script only; nothing in `migrations/` creates it, and `scripts/sync-from-prod.sh` truncates an explicit table list that does not include it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)