### PR TITLE
Retype account_id to int on recipe, list and shopping_list_event

### DIFF
--- a/migrations/039_account_id_int.sql
+++ b/migrations/039_account_id_int.sql
@@ -1,0 +1,54 @@
+-- account_id becomes an int on the three tables where it was still a string.
+--
+-- `account.id` and `account_user.account_id` have always been `int`. But
+-- `recipe.account_id`, `list.account_id` and `shopping_list_event.account_id`
+-- were `varchar(255)`: 007_user.sql widened `recipe.user_id`/`list.user_id` to
+-- hold an Auth0 subject, 008_user.sql renamed the column to `account_id`
+-- without retyping it, and 015_shopping_list_history.sql copied the shape when
+-- it created `shopping_list_event`.
+--
+-- The Go code has passed an int to all of them throughout. It works, because
+-- MySQL coerces - but it coerces THE COLUMN, NOT THE VALUE, and that is the
+-- whole problem:
+--
+--   * The index is unusable. Comparing a varchar column to a number converts
+--     every row's value to a number, so `WHERE account_id = 7` is a full table
+--     scan. `list` and `shopping_list_event` are the two largest tables in the
+--     schema, and account deletion runs an unfiltered
+--     `DELETE ... WHERE account_id = ?` against both.
+--   * Matching is loose. '07', ' 7' and '7.0' all equal 7 under numeric
+--     coercion. Nothing writes those today, so this is latent, not live.
+--
+-- No application change accompanies this: every call site already passes an
+-- int, and the driver's `interpolateParams=true` renders it unquoted.
+--
+-- BEFORE APPLYING TO PRODUCTION, confirm every value is a plain integer. A row
+-- still holding an un-migrated Auth0 subject would make the ALTERs below fail:
+--
+--   SELECT 'recipe' t, COUNT(*) FROM recipe             WHERE account_id NOT REGEXP '^[0-9]+$'
+--   UNION ALL
+--   SELECT 'list',      COUNT(*) FROM list              WHERE account_id NOT REGEXP '^[0-9]+$'
+--   UNION ALL
+--   SELECT 'sle',       COUNT(*) FROM shopping_list_event WHERE account_id NOT REGEXP '^[0-9]+$';
+--
+-- Failing is the correct outcome if it happens - under strict mode (the
+-- default on both MySQL 8 and TiDB) a non-numeric value aborts the whole ALTER
+-- and leaves the table untouched, rather than silently coercing the row to 0
+-- and orphaning it. Do not work around it; migrate the value first.
+--
+-- Foreign keys to `account(id)` are deliberately NOT added here. The retype is
+-- the fix for the two problems above, and doing it alone keeps a query-plan
+-- change attributable to one migration. The deletion path in
+-- service.deleteAccountTx already empties all three tables before
+-- `DELETE FROM account`, so the constraints would be satisfiable - see the
+-- board item for that follow-up.
+
+ALTER TABLE `recipe` MODIFY `account_id` int NOT NULL COMMENT 'account that owns this recipe';
+
+ALTER TABLE `list` MODIFY `account_id` int NOT NULL COMMENT 'account this list belongs to';
+
+-- `shopping_list_event` also carries idx_account_date (account_id, created_at)
+-- and idx_recipe_usage (account_id, recipe_id, created_at). Both survive the
+-- MODIFY, and both become usable by the queries in service/history.go for the
+-- first time.
+ALTER TABLE `shopping_list_event` MODIFY `account_id` int NOT NULL COMMENT 'account that made the change';


### PR DESCRIPTION
Closes the board item [_account_id is varchar(255) on recipe/list/shopping_list_event but int everywhere else_](https://app.notion.com/3c1c724ecda18139b218ef533963201d).

## The problem

`account.id` and `account_user.account_id` have always been `int`. Three tables held theirs as `varchar(255)`:

| where | how it got that way |
| --- | --- |
| `recipe.account_id` | `007_user.sql` widened `recipe.user_id` to carry an Auth0 subject; `008_user.sql` renamed the column without retyping it |
| `list.account_id` | same |
| `shopping_list_event.account_id` | `015_shopping_list_history.sql` copied the shape into a new table |

The Go code has passed an `int` to all of them throughout. It works, because MySQL coerces — but it coerces **the column, not the value**, so every row's value has to be converted before it can be compared.

## Measured, rather than asserted

The item says "the index is unusable". That turns out to be exactly true of the `DELETE` and slightly generous to the `SELECT`, so here are both — 20,000 rows across 50 accounts, MySQL 8.0.46, `ANALYZE TABLE` run:

**`SELECT COUNT(*) ... WHERE account_id = 7`**

```
varchar  -> Covering index SCAN   using idx_account_date  (rows=20026) actual rows=20000, 2.24ms
int      -> Covering index LOOKUP using idx_account_date  (rows=400)   actual rows=400,   0.067ms
```

The index is *used*, but only as somewhere cheap to read all 20,000 values from and convert them one by one. It is a scan, not a seek: 50× the rows read, 33× the time.

**`DELETE FROM ... WHERE account_id = 7`** — the statement account deletion actually runs:

```
varchar  type: ALL     possible_keys: NULL              rows: 20026
int      type: range   key: idx_account_date            rows: 400
```

Here the item's wording is precisely right. A full table scan, with the index not even a candidate. `list` and `shopping_list_event` are the two largest tables in the schema, and `service.deleteAccountTx` runs an unfiltered `DELETE ... WHERE account_id = ?` against both.

The second, latent problem goes away with it: `'07'`, `' 7'` and `'7.0'` all equal `7` under numeric coercion. Nothing writes those today.

## No application change

Every call site already passes an `int`, and the driver's `interpolateParams=true` renders it unquoted. This is a migration and nothing else.

## Foreign keys are deliberately not in this change

The item pairs the retype with "the foreign keys that were never added". Not doing that here, on the item's own reasoning — it asks for this to be its own change "so that a `DELETE` plan regression is attributable", and adding three constraints to the two largest tables in the same migration works against that.

They would be satisfiable: `deleteAccountTx` empties `recipe`-owned data, `list` and `shopping_list_event` before `DELETE FROM account`, so the ordering is already correct. Filed as a follow-up.

## Applying to production

The migration header carries the pre-flight query to run first:

```sql
SELECT 'recipe' t, COUNT(*) FROM recipe             WHERE account_id NOT REGEXP '^[0-9]+$'
UNION ALL SELECT 'list', COUNT(*) FROM list         WHERE account_id NOT REGEXP '^[0-9]+$'
UNION ALL SELECT 'sle', COUNT(*) FROM shopping_list_event WHERE account_id NOT REGEXP '^[0-9]+$';
```

`008_user.sql` migrated exactly one Auth0 subject on `recipe` and left `list` alone, so a straggler is plausible. If there is one the ALTER aborts under strict mode and leaves the table untouched — the correct outcome, and not one to work around.

## Verification

`./scripts/build-local.sh` green (gofmt, vet, `go test ./...`, both drift checks, `npm run package`). **37/37 e2e pass** against the retyped schema, exercising the real API and real queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)