### PR TITLE
Bring the whole database to utf8mb4_bin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,12 +39,21 @@ services:
       #
       # Unhealthy here means: `docker compose logs db`, then
       # `docker compose down -v && docker compose up -d db` once fixed.
+      # 3. A data directory created before _migration_status existed is not a
+      #    failure. The script creates that table before it applies anything,
+      #    so on any volume it has ever run, the table is there - absence means
+      #    the volume predates this check entirely. The entrypoint will never
+      #    re-run migrations on it (non-empty data directory), so there is
+      #    nothing for the check to check, and it falls back to the plain ping
+      #    this healthcheck used to be. Without that, upgrading turned every
+      #    existing developer's database unhealthy and the only way out was
+      #    `down -v`, which throws away a synced copy of production.
       test:
         - CMD-SHELL
         - >-
-          mysql -h 127.0.0.1 -uroot -proot -N -B
-          -e "SELECT ok FROM bigshop._migration_status WHERE id = 1"
-          2>/dev/null | grep -qx 1
+          if mysql -h 127.0.0.1 -uroot -proot -N -B -e "SELECT ok FROM bigshop._migration_status WHERE id = 1" 2>/dev/null | grep -qx 1; then exit 0; fi;
+          if mysql -h 127.0.0.1 -uroot -proot -N -B -e "SELECT 1 FROM bigshop._migration_status LIMIT 0" >/dev/null 2>&1; then exit 1; fi;
+          mysqladmin ping -h 127.0.0.1 -uroot -proot
       interval: 5s
       timeout: 5s
       retries: 20

--- a/docker/README.md
+++ b/docker/README.md
@@ -191,6 +191,25 @@ empty database again, and the synthetic migrate-and-seed step in
 entrypoint runs `docker-entrypoint-initdb.d` only when the data directory is
 empty, so editing a migration and restarting the container does nothing.
 
+## Collation: local now matches production
+
+`migrations/040_charset_utf8mb4_bin.sql` brings every table to
+`utf8mb4` / `utf8mb4_bin`. In production that is mostly about what can be
+*stored* - four tables were `latin1`, which cannot hold a character outside
+its 256, and seven were `utf8mb3`, which cannot hold a 4-byte one.
+
+Locally it changes something else, and it is worth knowing about. A database
+built from `migrations/*.sql` used to be uniformly `utf8mb4_0900_ai_ci` -
+case- and accent-**insensitive** - while production has always been binary and
+therefore **sensitive**. So `INSERT INTO ingredient (name) VALUES ('Garlic')
+ON DUPLICATE KEY UPDATE id=id` (`service/recipe.go`) collapsed `Garlic` and
+`garlic` into one row on a laptop and created two in production. Local now
+behaves the way production does.
+
+One thing that gets better as a result: `sync-from-prod.sh` imports production
+rows into these tables, and any pair differing only by case was a
+duplicate-key error against the old local collation.
+
 ## When the `db` container will not go healthy
 
 `mysql-init/01-migrate-and-seed.sh` applies migrations with `--force`, which

--- a/docker/mysql-init/01-migrate-and-seed.sh
+++ b/docker/mysql-init/01-migrate-and-seed.sh
@@ -28,7 +28,8 @@ sql bigshop -e "
     \`detail\` text COMMENT 'the unexpected errors, when ok = 0',
     \`applied_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (\`id\`)
-  ) COMMENT 'set by docker/mysql-init/01-migrate-and-seed.sh; read by the db healthcheck';
+  ) COLLATE=utf8mb4_bin
+    COMMENT 'set by docker/mysql-init/01-migrate-and-seed.sh; read by the db healthcheck';
   REPLACE INTO \`_migration_status\` (id, ok, detail) VALUES (1, 0, 'migrations did not finish');
 "
 

--- a/migrations/040_charset_utf8mb4_bin.sql
+++ b/migrations/040_charset_utf8mb4_bin.sql
@@ -1,0 +1,84 @@
+-- One charset for the whole database: utf8mb4 / utf8mb4_bin.
+--
+-- Production TiDB had no single charset. Each table took whatever the server
+-- default was on the day it was hand-applied, leaving three tiers (measured
+-- 2026-08-20 via scripts/check-charsets.sh, server 8.0.11-TiDB-v8.5.3):
+--
+--   latin1_bin   ingredient, list, part, unit
+--   utf8_bin     account, account_user, department, ingredient_department,
+--                invite, recipe, user          (utf8mb3 - deprecated)
+--   utf8mb4_bin  consent_event, email_launch, email_send, ga_account_uuid,
+--                ingredient_unit_size, recipe_tag, shopping_list_event, tag
+--
+-- Two consequences have already been paid for: docker/README.md records an
+-- incompatible-FK error between recipe_tag.tag_name and tag.name when
+-- importing production's DDL, which is why sync-from-prod.sh dumps data only;
+-- and migration 034 could not be applied until user.id was normalised.
+--
+-- WHY latin1 IS THE SHARP EDGE. latin1 cannot represent anything outside its
+-- 256 characters, so an ingredient called "gochujang 고추장" cannot round-trip.
+-- ingredient.name already holds 2 non-ASCII rows of 439. Nothing is damaged
+-- today - the scan found zero mojibake anywhere in the database - so this is
+-- latent, and the point of doing it now is that it stays that way.
+--
+-- WHY THE utf8mb3 TABLES TOO. utf8mb3 holds the Basic Multilingual Plane but
+-- not the astral planes, so it rejects emoji and much CJK extension. recipe
+-- .method alone has 41 non-ASCII rows and is free text pasted from the web.
+--
+-- WHY THE utf8mb4_bin TABLES TOO, which are already correct in production.
+-- There the eight ALTERs are no-ops. They are here for the *local* database,
+-- which migrations/*.sql builds as uniformly utf8mb4_0900_ai_ci - case- and
+-- accent-INSENSITIVE, where production has always been _bin and therefore
+-- SENSITIVE. That divergence is invisible until a query that dedupes on a name
+-- behaves one way on a laptop and another in production. Converting everything
+-- makes the two match for the first time.
+--
+-- WHY utf8mb4_bin AND NOT utf8mb4_0900_ai_ci. TiDB v8.5.3 does support
+-- 0900_ai_ci (the "unavailable before 7.4" caveat no longer applies), but it
+-- would change comparison semantics on every string in production, silently
+-- merging rows that differ only by case or accent. utf8mb4_bin is what
+-- production already uses and what the user.id key family was normalised to.
+--
+-- FOREIGN_KEY_CHECKS. Two text columns in the schema are FK'd -
+-- account_user.user_id -> user.id and recipe_tag.tag_name -> tag.name. A
+-- foreign key requires both sides to share a collation, so converting either
+-- side on its own fails with ERROR 3780 "Referencing column and referenced
+-- column are incompatible". Disabling the check spans the pair; both sides are
+-- converted below, so the constraint is satisfied again by the end.
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- The database default, so anything created later inherits it rather than
+-- restarting the patchwork. Already utf8mb4_bin in production; this is what
+-- moves the local database off utf8mb4_0900_ai_ci.
+ALTER DATABASE `bigshop` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
+-- latin1_bin -> utf8mb4_bin. ingredient.name and unit.name each carry a UNIQUE
+-- index (migrations 002 and 016) and unit.kind is an enum whose value strings
+-- carry the charset; scripts/probe-charset-conversion.sh exercises both shapes.
+ALTER TABLE `ingredient` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `list`       CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `part`       CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `unit`       CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
+-- utf8mb3 -> utf8mb4.
+ALTER TABLE `account`               CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `account_user`          CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `department`            CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `ingredient_department` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `invite`                CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `recipe`                CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `user`                  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
+-- Already utf8mb4_bin in production, so no-ops there. Locally these are what
+-- move the remaining tables off utf8mb4_0900_ai_ci.
+ALTER TABLE `consent_event`        CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `email_launch`         CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `email_send`           CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `ga_account_uuid`      CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `ingredient_unit_size` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `recipe_tag`           CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `shopping_list_event`  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+ALTER TABLE `tag`                  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/scripts/build-charset-checks.py
+++ b/scripts/build-charset-checks.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Turn the column list from check-charsets.sql into a scan for damaged text.
+
+Reads tab-separated rows on stdin, writes SQL on stdout. Split out of
+check-charsets.sh for the same reason build-orphan-checks.py is: so the
+generated SQL can be read on its own (`... | scripts/build-charset-checks.py`)
+rather than only ever being piped into a database.
+
+Only columns on a table that is not utf8mb4 are scanned. Two things are
+counted per column:
+
+  mojibake  - the fingerprint of UTF-8 bytes that were stored into a latin1
+              column and are now being read back as latin1. A multi-byte
+              character becomes two or three latin1 characters, and the first
+              of them is almost always U+00C3 (A-tilde), U+00C2 (A-circumflex)
+              or the sequence 'a-circumflex, euro'. Text that was always
+              correct does not contain those next to another high character.
+
+  non_ascii - any character above U+007F at all. Not damage in itself, but it
+              is the population at risk: a column with no non-ASCII text has
+              nothing that a charset change could corrupt, which turns the
+              question from "is this a live bug" into "is this latent".
+"""
+import sys
+
+# Read as latin1, a UTF-8 two-byte character starts 0xC3 or 0xC2, and the
+# common "smart quote" three-byte ones start 0xE2 0x80 -> 'a-circumflex' +
+# 'euro'. Requiring a second high character after it keeps genuinely-latin1
+# text (a lone 'A-tilde' in a name) from counting as damage.
+MOJIBAKE = r'(Ã[\\x80-\\xBF])|(Â[\\x80-\\xBF])|(â€)'
+NON_ASCII = r'[^\\x00-\\x7F]'
+
+checks = []
+for line in sys.stdin:
+    parts = line.rstrip('\n').split('\t')
+    if len(parts) != 5:
+        continue
+    table, column, charset, collation, table_collation = parts
+    if charset == 'utf8mb4':
+        continue
+    label = f'{table}.{column} [{collation}]'
+    checks.append(
+        f"SELECT '{label}' AS col,\n"
+        f"       COUNT(*) AS rows_total,\n"
+        f"       SUM(`{column}` REGEXP '{NON_ASCII}') AS non_ascii,\n"
+        f"       SUM(`{column}` REGEXP '{MOJIBAKE}') AS mojibake\n"
+        f"  FROM `{table}`"
+    )
+
+if not checks:
+    print("SELECT 'every text column is already utf8mb4 - nothing to scan' AS col, "
+          "0 AS rows_total, 0 AS non_ascii, 0 AS mojibake;")
+    sys.exit(0)
+
+print('\nUNION ALL\n'.join(checks) + ';')

--- a/scripts/check-charsets.sh
+++ b/scripts/check-charsets.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Report the charset and collation of every table and text column, and scan the
+# non-utf8mb4 ones for text that cannot have survived being stored there.
+#
+# Read-only - counts rows and reads information_schema, nothing else - so it is
+# safe against production at any time.
+#
+# Why it exists: production TiDB has no single charset. Each table took whatever
+# the server default was on the day it was hand-applied, so `user`/`recipe`/
+# `account` are utf8 (utf8mb3, deprecated), `list` and `part` are latin1, `tag`
+# is utf8mb4, and the database default is utf8mb4. A local MySQL 8 built from
+# migrations/*.sql is uniformly utf8mb4_0900_ai_ci, so none of this is
+# reproducible locally and the only way to know the real state is to ask.
+#
+# It has already been paid for twice: docker/README.md records an
+# incompatible-FK error between `recipe_tag.tag_name` and `tag.name` when
+# importing production's DDL, which is why sync-from-prod.sh dumps data only;
+# and migration 034 could not be applied to production until `user.id` was
+# normalised.
+#
+# The scan answers the question that decides whether latin1 on `list` is a
+# latent problem or an active one: is there text in those columns that is
+# already damaged, or non-ASCII text at all that could be?
+#
+# mysql runs inside a throwaway mysql:8.0 container rather than a host install,
+# for the same reasons as check-orphans.sh: nothing to install, and it avoids
+# MySQL 9+ having dropped the mysql_native_password plugin TiDB accounts often
+# still use.
+#
+# Host, port, username and database come from .env.tidb (tracked in git - see
+# scripts/lib/tidb-env.sh); only the password is typed, on every run. It is
+# passed via the container's environment, never on the command line where it
+# would show up in the process list.
+#
+# Usage:
+#   scripts/check-charsets.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+. scripts/lib/tidb-env.sh
+tidb_env_load
+tidb_prompt_password
+
+# SQL on stdin; any extra mysql flags as arguments.
+#
+# --default-character-set=utf8mb4 is load-bearing rather than tidy: the scan
+# below looks for byte sequences, so the connection has to hand them over
+# unchanged rather than transcoding them into whatever the client guessed.
+run_mysql() {
+  docker run --rm -i -e MYSQL_PWD="$TIDB_PASSWORD" mysql:8.0 \
+    mysql -h "$TIDB_HOST" -P "$TIDB_PORT" -u "$TIDB_USER" \
+    --ssl-mode=REQUIRED --default-character-set=utf8mb4 "$@" "$TIDB_DB"
+}
+
+echo
+echo "Charsets in ${TIDB_DB} on ${TIDB_HOST}"
+echo
+
+echo "SELECT VERSION() AS server,
+       @@character_set_database AS db_charset,
+       @@collation_database AS db_collation;" | run_mysql --table
+
+echo
+echo "Per table:"
+echo "SELECT TABLE_NAME, TABLE_COLLATION
+        FROM information_schema.TABLES
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE = 'BASE TABLE'
+       ORDER BY TABLE_COLLATION, TABLE_NAME;" | run_mysql --table
+
+echo
+echo "Text columns that are not utf8mb4:"
+echo "SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, COLLATION_NAME
+        FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE()
+         AND CHARACTER_SET_NAME IS NOT NULL
+         AND CHARACTER_SET_NAME <> 'utf8mb4'
+       ORDER BY CHARACTER_SET_NAME, TABLE_NAME, ORDINAL_POSITION;" | run_mysql --table
+
+COLUMNS="$(run_mysql -N < scripts/check-charsets.sql)"
+CHECKS="$(printf '%s\n' "$COLUMNS" | scripts/build-charset-checks.py)"
+
+echo
+echo "Scanning those columns for damaged or at-risk text:"
+echo
+printf '%s\n' "$CHECKS" | run_mysql --table
+
+echo
+echo "non_ascii  = rows holding any character above U+007F. Zero means a"
+echo "             charset change on that column cannot corrupt anything,"
+echo "             because there is nothing there to corrupt."
+echo "mojibake   = rows already showing the UTF-8-stored-as-latin1 fingerprint."
+echo "             Anything above zero is damage that a plain ALTER would"
+echo "             preserve rather than repair - fix the data first."

--- a/scripts/check-charsets.sql
+++ b/scripts/check-charsets.sql
@@ -1,0 +1,18 @@
+-- Every text column in the database, with the charset and collation it
+-- actually has. Read by scripts/build-charset-checks.py, which turns the
+-- non-utf8mb4 ones into a scan for text that cannot have survived the trip.
+--
+-- Tab-separated, no header - the caller runs it with -N.
+SELECT
+  c.TABLE_NAME,
+  c.COLUMN_NAME,
+  c.CHARACTER_SET_NAME,
+  c.COLLATION_NAME,
+  t.TABLE_COLLATION
+FROM information_schema.COLUMNS c
+JOIN information_schema.TABLES t
+  ON t.TABLE_SCHEMA = c.TABLE_SCHEMA AND t.TABLE_NAME = c.TABLE_NAME
+WHERE c.TABLE_SCHEMA = DATABASE()
+  AND c.CHARACTER_SET_NAME IS NOT NULL
+  AND t.TABLE_TYPE = 'BASE TABLE'
+ORDER BY c.TABLE_NAME, c.ORDINAL_POSITION;

--- a/scripts/probe-charset-conversion.sh
+++ b/scripts/probe-charset-conversion.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Find out which charset conversions TiDB will actually accept, by trying them
+# on scratch tables that mirror the real ones.
+#
+# ---------------------------------------------------------------------------
+# THIS SCRIPT WRITES TO THE DATABASE
+# ---------------------------------------------------------------------------
+# Unlike check-orphans.sh and check-charsets.sh, this is not read-only. It
+# CREATEs and DROPs tables named `_charset_probe_*` and touches nothing else -
+# no existing table is read, altered or locked. It asks for confirmation before
+# doing anything, and drops what it made on the way out, including on failure.
+#
+# ---------------------------------------------------------------------------
+# Why it has to exist
+# ---------------------------------------------------------------------------
+# Production is a charset patchwork: four tables are latin1_bin, seven are
+# utf8_bin (utf8mb3, deprecated), eight are already utf8mb4_bin. The plan is to
+# bring all of them to utf8mb4_bin. The blocker is that TiDB has historically
+# supported `ALTER TABLE ... CONVERT TO CHARACTER SET` only for utf8 ->
+# utf8mb4, and may reject latin1 -> utf8mb4 outright with "Unsupported modify
+# charset". Whether that still holds on v8.5.3 decides whether the migration is
+# four ALTERs or something considerably more careful, and it cannot be found
+# out locally: a MySQL 8 built from migrations/*.sql is uniformly utf8mb4, so
+# there is no latin1 table to convert and MySQL would accept it anyway.
+#
+# Guessing here is expensive in a specific way. These migrations are applied to
+# production by hand, so a form TiDB rejects is discovered halfway through a
+# manual run, against real tables, with some already converted.
+#
+# ---------------------------------------------------------------------------
+# What it probes
+# ---------------------------------------------------------------------------
+# Both source charsets, both conversion forms, and the two shapes in the real
+# schema that are more than a plain varchar:
+#
+#   * a UNIQUE-indexed varchar   - ingredient.name and unit.name both have one
+#                                  (migrations 002 and 016). Changing the
+#                                  collation under a unique index changes what
+#                                  "duplicate" means, and is the most likely
+#                                  thing to be refused.
+#   * an enum                    - unit.kind is enum('weight','volume',
+#                                  'relative') latin1_bin. An enum's value
+#                                  strings carry the charset, so it converts
+#                                  like a varchar and fails like one.
+#
+# It also checks the thing that actually matters afterwards: that non-ASCII
+# text survives the conversion as the same characters, and that a 4-byte
+# character - the whole point of utf8mb4 - can be stored once it is done.
+#
+# Connection details come from .env.tidb, password typed on every run, mysql in
+# a throwaway container - all exactly as check-charsets.sh does it.
+#
+# Usage:
+#   scripts/probe-charset-conversion.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+. scripts/lib/tidb-env.sh
+tidb_env_load
+
+cat <<MSG
+
+This probe CREATEs and DROPs tables named _charset_probe_* on:
+
+    ${TIDB_DB} at ${TIDB_HOST}
+
+It reads and alters no existing table. Nothing else is touched.
+
+MSG
+
+read -r -p "Continue? [y/N] " reply
+case "$reply" in
+  [yY]|[yY][eE][sS]) ;;
+  *) echo "Aborted."; exit 1 ;;
+esac
+
+tidb_prompt_password
+
+run_mysql() {
+  docker run --rm -i -e MYSQL_PWD="$TIDB_PASSWORD" mysql:8.0 \
+    mysql -h "$TIDB_HOST" -P "$TIDB_PORT" -u "$TIDB_USER" \
+    --ssl-mode=REQUIRED --default-character-set=utf8mb4 "$@" "$TIDB_DB"
+}
+
+cleanup() {
+  echo
+  echo "Dropping probe tables..."
+  echo "DROP TABLE IF EXISTS _charset_probe_latin1, _charset_probe_utf8,
+                              _charset_probe_col, _charset_probe_enum;" \
+    | run_mysql 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Runs one statement and reports whether TiDB accepted it. Never fatal - a
+# refusal is a result, not an error, and the next probe still needs to run.
+# $1 = label, rest = SQL.
+try() {
+  local label="$1"; shift
+  local err
+  err="$(printf '%s' "$*" | run_mysql 2>&1 >/dev/null)" && {
+    printf '  ACCEPTED  %s\n' "$label"
+    return 0
+  }
+  printf '  REFUSED   %s\n' "$label"
+  printf '%s\n' "$err" | grep -i '^ERROR' | sed 's/^/              /'
+  return 1
+}
+
+cleanup >/dev/null 2>&1 || true
+trap cleanup EXIT
+
+echo
+echo "Server:"
+echo "SELECT VERSION() AS server;" | run_mysql --table
+
+# ---------------------------------------------------------------------------
+# 1. Whole-table CONVERT TO, from each source charset.
+# ---------------------------------------------------------------------------
+echo
+echo "1. ALTER TABLE ... CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin"
+echo
+
+printf '%s' "
+CREATE TABLE _charset_probe_latin1 (
+  id int NOT NULL AUTO_INCREMENT,
+  name varchar(255) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_name (name)
+) DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
+INSERT INTO _charset_probe_latin1 (name) VALUES ('plain ascii'), ('Crème Fraîche');
+" | run_mysql
+
+printf '%s' "
+CREATE TABLE _charset_probe_utf8 (
+  id int NOT NULL AUTO_INCREMENT,
+  name varchar(255) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_name (name)
+) DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+INSERT INTO _charset_probe_utf8 (name) VALUES ('plain ascii'), ('Crème Fraîche');
+" | run_mysql
+
+latin1_ok=0
+utf8_ok=0
+try "latin1_bin -> utf8mb4_bin, UNIQUE-indexed varchar" \
+  "ALTER TABLE _charset_probe_latin1 CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;" \
+  && latin1_ok=1
+try "utf8_bin   -> utf8mb4_bin, UNIQUE-indexed varchar" \
+  "ALTER TABLE _charset_probe_utf8 CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;" \
+  && utf8_ok=1
+
+# ---------------------------------------------------------------------------
+# 2. Per-column MODIFY - the fallback if CONVERT TO is refused.
+# ---------------------------------------------------------------------------
+echo
+echo "2. ALTER TABLE ... MODIFY COLUMN ... CHARACTER SET utf8mb4 (the fallback)"
+echo
+
+printf '%s' "
+CREATE TABLE _charset_probe_col (
+  id int NOT NULL AUTO_INCREMENT,
+  name varchar(255) NOT NULL,
+  PRIMARY KEY (id)
+) DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
+INSERT INTO _charset_probe_col (name) VALUES ('Crème Fraîche');
+" | run_mysql
+
+try "latin1_bin -> utf8mb4_bin, single column" \
+  "ALTER TABLE _charset_probe_col MODIFY name varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;"
+
+# ---------------------------------------------------------------------------
+# 3. An enum - unit.kind is one, and its value strings carry the charset.
+# ---------------------------------------------------------------------------
+echo
+echo "3. An enum column (unit.kind's shape)"
+echo
+
+printf '%s' "
+CREATE TABLE _charset_probe_enum (
+  id int NOT NULL AUTO_INCREMENT,
+  kind enum('weight','volume','relative') NOT NULL,
+  PRIMARY KEY (id)
+) DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
+INSERT INTO _charset_probe_enum (kind) VALUES ('weight'), ('volume');
+" | run_mysql
+
+try "latin1_bin -> utf8mb4_bin, enum column" \
+  "ALTER TABLE _charset_probe_enum CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;"
+
+echo
+echo "  Enum values and rows after the attempt:"
+echo "SELECT COLUMN_TYPE, COLLATION_NAME FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '_charset_probe_enum'
+         AND COLUMN_NAME = 'kind';
+      SELECT kind, COUNT(*) AS rows_kept FROM _charset_probe_enum GROUP BY kind;" \
+  | run_mysql --table | sed 's/^/  /'
+
+# ---------------------------------------------------------------------------
+# 4. Did the text survive, and can 4-byte characters be stored now?
+# ---------------------------------------------------------------------------
+echo
+echo "4. Data integrity after conversion"
+echo
+echo "   'text_intact' must be 1: the non-ASCII row still reads as the same"
+echo "   characters. HEX changes on purpose - that is the re-encoding."
+echo
+
+for t in _charset_probe_latin1 _charset_probe_utf8; do
+  echo "SELECT '$t' AS probe, name, HEX(name) AS bytes,
+                (name = 'Crème Fraîche') AS text_intact,
+                (SELECT COLLATION_NAME FROM information_schema.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '$t'
+                    AND COLUMN_NAME = 'name') AS collation_now
+           FROM $t WHERE id = 2;" | run_mysql --table | sed 's/^/  /'
+done
+
+echo
+echo "   A 4-byte character is what utf8mb4 buys. Before conversion both"
+echo "   tables reject it; after a successful one they should accept it."
+echo
+if [ "$latin1_ok" = "1" ]; then
+  try "storing a 4-byte character in the converted latin1 table" \
+    "INSERT INTO _charset_probe_latin1 (name) VALUES ('smoked paprika 🌶');"
+fi
+if [ "$utf8_ok" = "1" ]; then
+  try "storing a 4-byte character in the converted utf8mb3 table" \
+    "INSERT INTO _charset_probe_utf8 (name) VALUES ('smoked paprika 🌶');"
+fi
+
+echo
+echo "---------------------------------------------------------------------"
+echo "Read the ACCEPTED/REFUSED lines above. Every conversion the migration"
+echo "needs must be ACCEPTED here before it is written, and any REFUSED line"
+echo "carries the error TiDB gave - that is the constraint to design around."
+echo "---------------------------------------------------------------------"


### PR DESCRIPTION
Closes the board item [_Production's charsets are a patchwork_](https://app.notion.com/3c2c724ecda1818d932ec1d151eb870a).

> **Contains a regression fix for #119** (`e173442`), unrelated to charsets and worth reviewing first: the healthcheck that PR added turned **every existing developer's database unhealthy** on pulling master, with `docker compose down -v` — throwing away a synced copy of production — as the only way out. Details below.

## What production actually looked like

Two new scripts had to exist before a migration could be written honestly, because none of this is reproducible locally — a MySQL 8 built from `migrations/*.sql` is uniformly `utf8mb4_0900_ai_ci`.

**`scripts/check-charsets.sh`** (read-only) reports the charset of every table and column, then scans the non-utf8mb4 ones for mojibake and for non-ASCII text at all. Run against `8.0.11-TiDB-v8.5.3-serverless`:

| collation | tables |
| --- | --- |
| `latin1_bin` | `ingredient`, `list`, `part`, `unit` |
| `utf8_bin` (utf8mb3) | `account`, `account_user`, `department`, `ingredient_department`, `invite`, `recipe`, `user` |
| `utf8mb4_bin` | the remaining eight |

**It corrects the item twice.** The latin1 set is four tables, not the two named. And `list`/`part` turn out to be the *least* of it — neither holds any non-ASCII text at all (`list.name` 0/38, `part.quantity` 0/1654), and `part`'s only text column is a mixed number like `1 1/2`. The real latin1 exposure is **`ingredient.name`, already 2 non-ASCII rows of 439**, which the item never mentions.

**Nothing is damaged** — zero mojibake in every text column. The item's open question was latent-or-active; it is latent, and the point of acting now is that it stays that way.

**`scripts/probe-charset-conversion.sh`** (this one writes, to scratch `_charset_probe_*` tables only) exists because TiDB has historically supported `CONVERT TO CHARACTER SET` only for `utf8 → utf8mb4`. Guessing is expensive in a specific way: these migrations are hand-applied, so a rejected form is found halfway through a manual run with some tables already converted. It probes both source charsets, both conversion forms, and the two shapes that are more than a plain varchar — a `UNIQUE`-indexed varchar (`ingredient.name`, `unit.name`) and an `enum` (`unit.kind`).

## The migration

`040_charset_utf8mb4_bin.sql` — all 19 tables and the database default to `utf8mb4` / `utf8mb4_bin`.

- **`utf8mb4_bin`, not `utf8mb4_0900_ai_ci`.** v8.5.3 does support the latter (the item's "unavailable before 7.4" no longer applies), but it would change comparison semantics on every string in production, silently merging rows differing only by case or accent.
- **`FOREIGN_KEY_CHECKS` off across the conversions.** An FK requires both sides to share a collation, and there are two text FKs — `account_user.user_id → user.id` and `recipe_tag.tag_name → tag.name`. Both sides of both are converted here, so the constraints hold again by the end. (This is the same `ERROR 3780` that blocked migration 034.)
- **The eight already-correct tables are included on purpose.** In production they're no-ops. Locally they close a divergence nobody had noticed.

## The local divergence this closes

A local database was uniformly `utf8mb4_0900_ai_ci` — case- and accent-**insensitive** — while production has always been binary and therefore **sensitive**. So the ingredient/unit upserts in `service/recipe.go` (`INSERT ... ON DUPLICATE KEY UPDATE id=id`) collapsed `Garlic` and `garlic` into **one** row on a laptop and created **two** in production. Verified after this change: two rows locally as well.

A side benefit — `sync-from-prod.sh` imports production rows into these tables, and any pair differing only by case was a duplicate-key error against the old local collation.

## The #119 regression, and the fix

The healthcheck asserted `_migration_status.ok = 1`. A data directory created *before* that table existed has no such table, and the entrypoint never re-runs the init script against a non-empty data directory — so existing databases went unhealthy and stayed that way. Hit while running `build-local.sh` here.

Absence of the table is unambiguous: the script creates it before applying anything, so on any volume it has ever run the table is present. Absent means the volume predates the check, there is nothing to check, and the right answer is the plain ping this healthcheck used to be. All three paths verified — legacy volume healthy, fresh good volume healthy, injected broken migration unhealthy with the error recorded.

## Verification

Fresh replay: **19/19 tables and the database default at `utf8mb4_bin`**, data intact, and `gochujang 고추장` stores as proper 3-byte UTF-8 (`EAB3A0 ECB694 EC9EA5`) where latin1 could not have held it at all. `./scripts/build-local.sh` green. **37/37 e2e pass.**

## Before applying to production

Run `scripts/probe-charset-conversion.sh` first. If it reports any form REFUSED, the migration needs the fallback shape rather than `CONVERT TO`, and that's the constraint to design around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)