### PR TITLE
Give account_id the foreign keys it never had

### DIFF
--- a/migrations/041_account_id_foreign_keys.sql
+++ b/migrations/041_account_id_foreign_keys.sql
@@ -1,0 +1,58 @@
+-- account_id gets the foreign keys it never had, on the three tables that
+-- carry one directly.
+--
+-- `account_user.account_id` has referenced `account(id)` since 008_user.sql.
+-- `recipe`, `list` and `shopping_list_event` never did: their column started
+-- life as an Auth0 subject string (007_user.sql), was renamed rather than
+-- retyped (008_user.sql), and only became an int in 039_account_id_int.sql.
+-- Until that migration the types did not even match, so the constraint could
+-- not have been declared.
+--
+-- Deliberately split from 039 rather than bundled with it. That migration
+-- changed a query plan on the two largest tables in the schema and wanted to
+-- be the only thing that did, so a regression stayed attributable to one
+-- change. This is the other half.
+--
+-- ORDERING IS ALREADY CORRECT. service.deleteAccountTx empties recipe-owned
+-- data, then `list`, then `shopping_list_event`, and only then runs
+-- `DELETE FROM account` - so these constraints are satisfied by the existing
+-- deletion path rather than tripped by it. See netlify-functions/recipes/
+-- internal/pkg/service/account.go.
+--
+-- NO `ON DELETE` CLAUSE, matching fk_account_user_account_id. Plain RESTRICT
+-- is the safer choice here precisely because the deletion path already removes
+-- these rows explicitly: CASCADE would make those statements redundant, and a
+-- future reordering bug would then delete rows silently instead of failing
+-- loudly. The constraint is here to catch that, not to paper over it.
+--
+-- BEFORE APPLYING TO PRODUCTION, check for orphans. `ADD CONSTRAINT` fails
+-- outright if any row points at an account that no longer exists, and
+-- production declares far fewer constraints than a local database does, so
+-- orphans are plausible rather than theoretical:
+--
+--   scripts/check-orphans.sh
+--
+-- or directly:
+--
+--   SELECT 'recipe' t, COUNT(*) FROM recipe r
+--     LEFT JOIN account a ON a.id = r.account_id WHERE a.id IS NULL
+--   UNION ALL SELECT 'list', COUNT(*) FROM list l
+--     LEFT JOIN account a ON a.id = l.account_id WHERE a.id IS NULL
+--   UNION ALL SELECT 'shopping_list_event', COUNT(*) FROM shopping_list_event s
+--     LEFT JOIN account a ON a.id = s.account_id WHERE a.id IS NULL;
+--
+-- Failing is the right outcome if it happens. An orphaned row is data belonging
+-- to an account that no longer exists, which is a deletion that did not finish;
+-- decide what to do with it rather than declaring the constraint around it.
+
+ALTER TABLE `recipe`
+  ADD CONSTRAINT `fk_recipe_account_id`
+  FOREIGN KEY (`account_id`) REFERENCES `account` (`id`);
+
+ALTER TABLE `list`
+  ADD CONSTRAINT `fk_list_account_id`
+  FOREIGN KEY (`account_id`) REFERENCES `account` (`id`);
+
+ALTER TABLE `shopping_list_event`
+  ADD CONSTRAINT `fk_shopping_list_event_account_id`
+  FOREIGN KEY (`account_id`) REFERENCES `account` (`id`);


### PR DESCRIPTION
Closes the board item [_account_id has no foreign key to account on recipe, list or shopping_list_event_](https://app.notion.com/p/3c2c724ecda181b99bf7d0455c94ec92), split out of the [`account_id` retype](https://github.com/Ianfeather/big-shop/pull/120).

## Why these were missing

`account_user.account_id` has referenced `account(id)` since `008_user.sql`. `recipe`, `list` and `shopping_list_event` never did — their column started life as an Auth0 subject string (`007_user.sql`), was renamed rather than retyped (`008_user.sql`), and only became an `int` in `039_account_id_int.sql`. Until that migration **the types did not match, so the constraint could not have been declared at all.**

Splitting it from 039 was deliberate: that migration changed a query plan on the two largest tables in the schema and wanted to be the only thing that did, so a regression stayed attributable. This is the other half.

## `RESTRICT`, not `CASCADE`

No `ON DELETE` clause, matching `fk_account_user_account_id`.

Plain `RESTRICT` is the safer choice here *precisely because* `service.deleteAccountTx` already removes these rows explicitly. `CASCADE` would make those statements redundant, and a future reordering bug would then delete rows silently instead of failing loudly. The constraint is here to catch that, not to paper over it.

## Verified against the real API, not the ordering comment

A sole-member account populated across all three constrained tables — 2 recipes, 11 `part` rows, 2 `list` rows, 2 `shopping_list_event` rows — deleted via `DELETE /account`:

```
{"accountDeleted":true}   HTTP 200

recipes  list_rows  events  accounts  memberships  users
      0          0       0         0            0      0
```

No foreign key error in the API log.

**The first attempt tested nothing, which is worth recording.** Account 1 has a second member from `008_user.sql`, so `DeleteUserAndAccount` took the *shared* branch — returned `accountDeleted: false` and left all three tables untouched. The FK-critical path never ran. The extra membership had to be deleted first to get a genuine sole-member account. Anyone re-testing this locally will hit the same thing.

Also confirmed the constraint actually bites — an `INSERT` into `list` naming a non-existent account is now rejected with `ERROR 1452`.

## Before applying to production

Run **`scripts/check-orphans.sh`** first. `ADD CONSTRAINT` fails outright if any row points at an account that no longer exists, and its own header notes production declares far fewer constraints than a local database does, so orphans are plausible rather than theoretical. It already covers these three relationships — it derives checks from every `<table>_id` column whose table exists, declared or not.

Failing is the right outcome if it happens. An orphaned row is data belonging to an account that no longer exists, which is a deletion that did not finish — decide what to do with it rather than declaring the constraint around it.

Note the two `ADD CONSTRAINT`s on `list` and `shopping_list_event` each need a validation scan of the whole table, so they will not be instant on production.

## Verification

`./scripts/build-local.sh` green. **37/37 e2e pass.** Fresh replay applies `041` cleanly with `_migration_status.ok = 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)