### PR TITLE
Point the API and the browser at the auth.bigshop.life custom domain

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -18,6 +18,15 @@ NEXT_PUBLIC_HOST=http://localhost:3000
 # Must be NEXT_PUBLIC_ prefixed so the value is also available client-side
 # (Next.js strips non-prefixed vars from the browser bundle) - without the
 # prefix these silently no-op in the client and only apply during SSR.
+#
+# Setting this to 'false' does not give you a working local login. When the
+# tenant was made production-grade, http://localhost:3000 was removed from the
+# Auth0 application's Allowed Callback URLs / Allowed Logout URLs / Allowed Web
+# Origins - Auth0's readiness check flags a plaintext-http callback on a
+# production tenant, and nothing here had used those entries since this flag
+# became the committed default. So real login now fails at the callback with a
+# URL mismatch, which does not name its own cause. Exercise the real flow on the
+# preview slot instead: docs/deploy-previews.md.
 NEXT_PUBLIC_DISABLE_AUTH=true
 
 # Set to 'true' to show the per-tag icon dots on recipe list rows. Off by

--- a/.env.production
+++ b/.env.production
@@ -18,7 +18,14 @@ NEXT_PUBLIC_API_HOST=/api/bigshop
 # unproxied origin to every visitor. See lib/api-host.ts.
 API_HOST_INTERNAL=https://big-shop-api.fly.dev/api/bigshop
 
-NEXT_PUBLIC_AUTH0_DOMAIN=dev-x-n37k6b.eu.auth0.com
+# The custom domain. Must agree with AUTH0_DOMAIN in
+# netlify-functions/recipes/fly.toml - the browser asks this host for a token and
+# the Go API validates the issuer of the result against that one, so a mismatch
+# 401s every authenticated request. Being NEXT_PUBLIC_ it is inlined at build
+# time, so changing it needs a rebuild, not just a redeploy - and a value set in
+# the Netlify UI overrides this file, which is where to look first if a change
+# here appears to do nothing.
+NEXT_PUBLIC_AUTH0_DOMAIN=auth.bigshop.life
 NEXT_PUBLIC_AUTH0_CLIENT_ID=HxkTOH3ZYxjbsgrVI4ii1CV2TQx7hk9G
 NEXT_PUBLIC_AUTH0_AUDIENCE=https://big-shop-api
 # A fallback, not the value the browser acts on. Being NEXT_PUBLIC_ it is

--- a/docs/fly-migration-runbook.md
+++ b/docs/fly-migration-runbook.md
@@ -110,11 +110,17 @@ fly secrets set \
   AUTH0_MGMT_CLIENT_SECRET='<its client secret>'
 ```
 
-**If the tenant ever gets a custom domain, set `AUTH0_TENANT_DOMAIN` too**, to the
-canonical `something.region.auth0.com` name. Auth0 requires the Management API
-audience to remain the canonical domain even behind a custom one, while `AUTH0_DOMAIN`
-must become the custom domain for login-token validation. The code falls back to
-`AUTH0_DOMAIN` while the two are the same, which is why it is unset today.
+**The tenant now has a custom domain (`auth.bigshop.life`), so `AUTH0_TENANT_DOMAIN`
+is set** to the canonical `dev-x-n37k6b.eu.auth0.com` name. Auth0 requires the
+Management API audience to remain the canonical domain even behind a custom one,
+while `AUTH0_DOMAIN` must become the custom domain for login-token validation. The
+code falls back to `AUTH0_DOMAIN` while the two are the same, which is why it was
+unset until then.
+
+**It is not a `fly secrets` value, despite appearing in this section.** A domain name
+is a public identifier, so it lives in `fly.toml`'s `[env]` alongside `AUTH0_DOMAIN`
+and `AUTH0_AUDIENCE` — in version control, where a deploy cannot forget it. It is
+described here because this is where its consequences are, not because it is a secret.
 
 **Leaving these unset is not a clean degradation, and this one matters.** Deletion still
 runs and still deletes every database row, but it *skips* removing the Auth0 identity —

--- a/netlify-functions/recipes/fly.toml
+++ b/netlify-functions/recipes/fly.toml
@@ -53,15 +53,20 @@ primary_region = "fra"
 [build]
   dockerfile = "Dockerfile"
 
-# The Go process reads five environment variables (grep os.Getenv). Two are
-# public identifiers and live here, in version control, so a deploy cannot
-# forget them:
+# Three of the Go process's environment variables (grep os.Getenv) are public
+# identifiers and live here, in version control, so a deploy cannot forget them:
 #
 #   AUTH0_DOMAIN / AUTH0_AUDIENCE - both are already public in
 #     .env.development. Getting these wrong does not fail loudly: with
 #     AUTH0_DOMAIN unset the JWKS fetch goes to https:///.well-known/jwks.json
 #     and every authenticated route rejects, while /health stays green and the
 #     machine looks perfectly healthy.
+#
+#   AUTH0_TENANT_DOMAIN - the canonical tenant domain, needed only because
+#     AUTH0_DOMAIN is now a custom one. A domain name is not a secret, so it
+#     belongs here rather than in `fly secrets` - which is where
+#     docs/fly-migration-runbook.md used to imply it went. See the note by the
+#     value itself.
 #
 # Two are secrets, set out-of-band with `fly secrets set` (see
 # docs/fly-migration-runbook.md) and deliberately absent from this file:
@@ -84,8 +89,34 @@ primary_region = "fra"
 # holds more strongly than it reads: the API container need never be given a
 # Grafana credential at all, and the collector need never be given DSN.
 [env]
-  AUTH0_DOMAIN = "dev-x-n37k6b.eu.auth0.com"
+  # The custom domain, because it is the issuer of the login tokens this API
+  # validates: a token minted at auth.bigshop.life carries
+  # `iss: https://auth.bigshop.life/`, and newJWTMiddleware pins the validator to
+  # exactly one issuer string. It also fixes the JWKS origin, which is fine -
+  # Auth0 serves the same keys on both names.
+  #
+  # **This value and the browser's NEXT_PUBLIC_AUTH0_DOMAIN must agree.** They
+  # are deployed by two different systems - Netlify builds the site, and
+  # .github/workflows/deploy-api.yml ships this - so they can disagree for as
+  # long as one deploy outlives the other, and while they do, every
+  # authenticated request 401s. Change them in the same commit; expect a short
+  # window regardless.
+  AUTH0_DOMAIN = "auth.bigshop.life"
   AUTH0_AUDIENCE = "https://big-shop-api"
+
+  # The **canonical** tenant domain, for the Management API only, and the one
+  # value here whose absence is silent rather than loud.
+  #
+  # Auth0's rule behind a custom domain is asymmetric: the Management API
+  # audience must stay the canonical domain, while the token request and the API
+  # call must share a host. service.auth0TenantDomain falls back to AUTH0_DOMAIN
+  # when this is unset - correct only while the two were the same string, which
+  # stopped being true the line above. Without this, the audience follows the
+  # custom domain somewhere Auth0 rejects, and account deletion carries on
+  # deleting every database row while silently skipping the Auth0 identity: the
+  # deleted user can still log in, resolving to nothing. That is exactly the bug
+  # board item #59 existed to fix, reintroduced by a domain change.
+  AUTH0_TENANT_DOMAIN = "dev-x-n37k6b.eu.auth0.com"
 
   # Without this, production telemetry arrives labelled `development` (the
   # default in telemetry.environment()) and is indistinguishable from a laptop's

--- a/technical-architecture.md
+++ b/technical-architecture.md
@@ -263,6 +263,7 @@ DISABLE_AUTH=false
 ```
 NEXT_PUBLIC_API_HOST=/api/bigshop
 API_HOST_INTERNAL=https://big-shop-api.fly.dev/api/bigshop
+NEXT_PUBLIC_AUTH0_DOMAIN=auth.bigshop.life
 NEXT_PUBLIC_HOST=https://www.bigshop.life
 ```
 
@@ -424,16 +425,20 @@ unproxied origin to every visitor and undo the same-origin property.
   than incidental, and a third that must never be added — see below.
 - `OPENAI_API_KEY` — GPT-4 Vision + GPT-3.5-turbo
 - `SENDGRID_API_KEY` — Email invitations
-- `AUTH0_DOMAIN` / `AUTH0_AUDIENCE` — Go JWT validation
+- `AUTH0_DOMAIN` / `AUTH0_AUDIENCE` — Go JWT validation. `AUTH0_DOMAIN` is
+  `auth.bigshop.life`, the custom domain, because that is what issues the tokens;
+  it must match the browser's `NEXT_PUBLIC_AUTH0_DOMAIN` or every authenticated
+  request 401s. Both live in `fly.toml`'s `[env]`, not the Netlify UI.
 - `AUTH0_TENANT_DOMAIN` — the **canonical** tenant domain
-  (`something.region.auth0.com`), used only for the Management API. Unset today,
-  because `AUTH0_DOMAIN` is still the canonical domain and the code falls back to it.
-  **It must be set the moment a custom domain is adopted**: Auth0 requires the
-  Management API `audience` to stay the canonical domain even behind a custom one,
-  while `AUTH0_DOMAIN` has to become the custom domain so the Go API can validate
-  the issuer of login tokens. Without this split the audience follows `AUTH0_DOMAIN`
-  somewhere Auth0 rejects, and account deletion starts failing in a way that reads
-  like an Auth0 outage. See `service.auth0TenantDomain`.
+  (`dev-x-n37k6b.eu.auth0.com`), used only for the Management API. **Now set**, in
+  `netlify-functions/recipes/fly.toml`'s `[env]` rather than as a secret — a domain
+  name is not one. It became necessary when the tenant adopted the custom domain
+  `auth.bigshop.life`: Auth0 requires the Management API `audience` to stay the
+  canonical domain even behind a custom one, while `AUTH0_DOMAIN` has to become the
+  custom domain so the Go API can validate the issuer of login tokens. Without this
+  split the audience follows `AUTH0_DOMAIN` somewhere Auth0 rejects, and account
+  deletion silently skips removing the Auth0 identity while still deleting every
+  database row. See `service.auth0TenantDomain`.
 - `AUTH0_MGMT_CLIENT_ID` / `AUTH0_MGMT_CLIENT_SECRET` — a machine-to-machine
   application authorised for the Auth0 Management API, used by account deletion to
   remove the identity a departing user logs in with. **Both unset means the Auth0 step


### PR DESCRIPTION
Step 3 of [Make the Auth0 tenant production-grade](https://app.notion.com/p/3c2c724ecda1816fbfc9e8ec3f20c645), now that `auth.bigshop.life` is configured in Auth0.

> [!WARNING]
> **Merging this triggers a production cutover.** Read the sequencing section before merging — there is a Netlify setting to check *first*, and one thing to verify afterwards that fails silently.

## The change

| Variable | From | To | Where |
| --- | --- | --- | --- |
| `AUTH0_DOMAIN` | `dev-x-n37k6b.eu.auth0.com` | `auth.bigshop.life` | `fly.toml` `[env]` |
| `AUTH0_TENANT_DOMAIN` | *(unset)* | `dev-x-n37k6b.eu.auth0.com` | `fly.toml` `[env]` |
| `NEXT_PUBLIC_AUTH0_DOMAIN` | `dev-x-n37k6b.eu.auth0.com` | `auth.bigshop.life` | `.env.production` |

`AUTH0_AUDIENCE` is untouched — it is an API identifier, not a domain.

**Answering "does `fly.toml` suffice?": for the Fly side, yes — but it is two lines, not one, and it does not cover the cutover.** `AUTH0_TENANT_DOMAIN` belongs in `[env]` rather than `fly secrets`: a domain name is a public identifier, and `fly.toml`'s comment already argues that these live in version control so a deploy cannot forget them. The runbook implied it was a secret; corrected here. The half `fly.toml` cannot cover is the browser, which needs `NEXT_PUBLIC_AUTH0_DOMAIN` moved in the same window.

## Why `AUTH0_TENANT_DOMAIN` is the important line

It is the one whose absence is silent. `service.auth0TenantDomain` falls back to `AUTH0_DOMAIN` when unset — correct only while the two are the same string, which this PR stops being true.

Without it: the Management API audience follows the custom domain somewhere Auth0 rejects, and **account deletion keeps deleting every database row while skipping the Auth0 identity**. The deleted user can still log in, resolving to nothing. That is exactly the defect board item #59 existed to fix, reintroduced by a domain change rather than by any code change. Nothing raises an error; it records a warning on the request's span and carries on.

## Sequencing — please read before merging

**1. Check the Netlify UI first.** `@next/env` never replaces a key already in `process.env`, so a `NEXT_PUBLIC_AUTH0_DOMAIN` set in the Netlify UI **overrides `.env.production` and this PR does nothing**. If it is set there, change it to `auth.bigshop.life` *before* merging, so the build this merge triggers picks up the new value. If it is not set, this PR is the value and there is nothing to do.

**2. Confirm the Google OAuth client accepts the new callback.** If the Google connection is on your own client now, `https://auth.bigshop.life/login/callback` must be in its Authorized redirect URIs, alongside the canonical one. Missing it means Google login fails with `redirect_uri_mismatch` from the first request. (Auth0's own dev keys are incompatible with custom domains, so if the connection is still on them, that is the thing to fix before any of this.)

**3. Expect a short 401 window.** Netlify builds the site and `deploy-api.yml` ships the API — two systems, two timings, one shared value. While they disagree, authenticated requests 401. There is no dual-issuer support in `newJWTMiddleware` (it pins exactly one issuer string), so this cannot be avoided without a code change; it can only be kept short.

**4. Expect to log in again.** Tokens minted by the old issuer no longer validate.

**5. Verify account deletion afterwards.** This is the silent one. `/account`'s delete button should remove the Auth0 login, not just the database rows — the e2e suite runs under `DISABLE_AUTH` and never reaches the Management API, so nothing in CI can tell you this works.

## Also on this branch

A second commit adds a comment to `.env.development` recording that `http://localhost:3000` has been removed from the Auth0 application's Allowed Callback URLs / Logout URLs / Web Origins — done in the console as part of the same ticket, to clear the production-readiness check. Nothing local used those entries (`NEXT_PUBLIC_DISABLE_AUTH=true` is the committed default), but the symptom for whoever next flips that flag to `false` is a callback URL mismatch that names nothing, and console state is invisible from a checkout. Same reasoning as `docs/deploy-previews.md` layer 2. No behaviour change.

## Testing

- `fly config validate` — Configuration is valid
- `npm run typecheck`, `npm run lint` — clean
- No Go or TypeScript source changed; `service.auth0TenantDomain`'s existing regression test already fails if the audience ever follows a custom domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
