### PR TITLE
Give each worktree its own e2e stack, derived from its path

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,11 +27,11 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       # playwright.config.ts's webServer runs `npm run dev:full`, which
-      # brings up MySQL + the Go API via docker compose (pinned to ports
-      # from e2e/env.ts, project name `bigshop-e2e`) and Next.js natively -
-      # same stack used for `npm run test:e2e` locally, just without the
-      # dev-only auto-increment-on-collision port fallback ever kicking in
-      # on a fresh runner.
+      # brings up MySQL + the Go API via docker compose (on the ports and
+      # project name e2e/instance.cjs derives from the checkout path) and
+      # Next.js natively - the same stack `npm run test:e2e` uses locally.
+      # A runner has one checkout, so the per-worktree derivation is a no-op
+      # here; it exists for the several worktrees on a development machine.
       - name: Run e2e tests
         run: npm run test:e2e
 
@@ -55,11 +55,12 @@ jobs:
 
       # Only useful signal we have when "API did not become healthy in time"
       # fires (see follow-ups.md #21) - dumps whatever db/api logged before
-      # the stack gets torn down below. COMPOSE_PROJECT_NAME must match what
-      # e2e/env.ts pins Playwright's webServer to, or this targets nothing.
+      # the stack gets torn down below. e2e-compose.sh derives the project name
+      # from e2e/instance.cjs, the same module Playwright's webServer reads, so
+      # this can't drift out of sync and target nothing.
       - name: Dump docker compose logs
         if: failure()
-        run: COMPOSE_PROJECT_NAME=bigshop-e2e docker compose logs db api > docker-compose.log 2>&1 || true
+        run: ./scripts/e2e-compose.sh logs db api > docker-compose.log 2>&1 || true
 
       - name: Upload docker compose logs
         if: failure()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,10 @@ when done — don't run bare `docker compose down`/migrations/`exec` against
 whatever project happens to already be running unless you've confirmed via
 `docker inspect` that it's actually this worktree's stack.
 
+This applies to the **dev** stack only. The e2e stack derives its own
+per-worktree project name and ports and needs none of it — see "End-to-end
+tests" below.
+
 **There is no mocks mode.** `NEXT_PUBLIC_USE_MOCKS` and `mocks/*.json` are gone
 — `npm run dev:full` made them redundant, and they had started to mislead: the
 mock Shopping List reimplemented ingredient combining, incorrectly and by its
@@ -230,13 +234,46 @@ npm run test:e2e:debug   # headed, slowed down (E2E_SLOWMO) - for stepping throu
 Config is `playwright.config.ts`; specs live in `e2e/` (`recipe.spec.ts`,
 `shopping-list.spec.ts`), with its own scoped `e2e/tsconfig.json` separate
 from the root `tsconfig.json`.
-Requires Docker: `webServer` in the config auto-starts `npm run dev:full`
-against pinned ports with its own `COMPOSE_PROJECT_NAME=bigshop-e2e`, so it
-won't collide with another worktree's stack; `test:e2e`/`test:e2e:debug` both
-run `test:e2e:stop` first to tear down any containers left over from an
-interrupted previous run (otherwise `dev-full.sh`'s own auto-increment-on-
-collision port logic silently drifts to different ports than the ones pinned
-in `e2e/env.ts`).
+Requires Docker: `webServer` in the config auto-starts `npm run dev:full` on a
+stack whose identity — compose project name and all three ports — is derived
+per worktree by `e2e/instance.cjs`. `test:e2e`/`test:e2e:debug` both run
+`test:e2e:stop` first to tear down any containers left over from an interrupted
+previous run.
+
+**Every e2e stack is per-worktree, and that is load-bearing rather than tidy.**
+This section used to say the pinned `COMPOSE_PROJECT_NAME=bigshop-e2e` stopped
+the e2e stack colliding with another worktree's. It stopped it colliding with a
+*dev* stack, and did the exact opposite for a second e2e run: every worktree
+resolved to the same project, so the same containers and the same volumes. And
+because `test:e2e` *begins* with `test:e2e:stop` — `docker compose down
+--remove-orphans --volumes` — starting a run in one worktree tore another
+worktree's in-flight run down mid-suite, database included. From the other side
+that is invisible: containers vanish and specs fail in ways that read exactly
+like application bugs, which quietly falsified the "a flaky-looking e2e failure
+gets investigated, not re-run-until-green" rule below whenever a second
+worktree existed.
+
+So `e2e/instance.cjs` hashes the worktree path into a project name
+(`bigshop-e2e-4-big-shop-442f25` — the slug is readable, the digest is what
+makes it unique) and a 0–99 offset picking one port from each of three blocks:
+web `3900+`, DB `4200+`, API `8980+`. It is automatic on purpose; the failure it
+prevents was silent, so a convention to remember would not have held. Nothing
+reads a hardcoded name any more — `e2e/env.ts` imports the module,
+`test:e2e:stop` and `.github/workflows/e2e.yml`'s log dump both go through
+`scripts/e2e-compose.sh`, which asks it for the project name. **Adding another
+`docker compose` call against the e2e stack means calling that wrapper, not
+writing the name out.** CI is unaffected either way: one checkout per runner.
+
+The two escape hatches, for the rare case where two worktrees hash to the same
+offset:
+- `E2E_INSTANCE=<name>` overrides the derived identity for both the project
+  name and the ports.
+- `PIN_PORTS=true` (which `playwright.config.ts` sets) makes `dev-full.sh` fail
+  loudly on a port already in use instead of auto-incrementing to the next free
+  one. That fallback is right for `npm run dev:full` and wrong here: Playwright's
+  `baseURL` and health-check URL are already fixed, so a drifting stack is one
+  nothing is connected to, and the symptom is an unexplained health-check
+  timeout. The failure message names both hatches.
 
 **The e2e stack deliberately runs without telemetry.** `playwright.config.ts`
 passes `START_LGTM=false` and an empty `OTEL_EXPORTER_OTLP_ENDPOINT`, so

--- a/e2e/env.ts
+++ b/e2e/env.ts
@@ -1,18 +1,18 @@
-// Ports pinned (rather than left to dev-full.sh's auto-increment-on-collision
-// behavior) so Playwright's webServer health check and baseURL agree on
-// exactly where the stack will come up. Distinct from dev-full.sh's own
-// defaults (3000/8080/3308) so a manually-running `npm run dev:full` in the
-// same worktree doesn't collide with the one Playwright starts for e2e.
-export const WEB_PORT = 3900;
-export const API_PORT = 8980;
-export const DB_PORT = 3908;
+// Ports and the docker compose project name are derived per worktree in
+// `e2e/instance.cjs` - see that file for why they are computed rather than
+// pinned to literals, and why it is CommonJS. This module is only the typed
+// front door onto it, plus the two URLs built from those ports.
+//
+// Pinned *within* a worktree (rather than left to dev-full.sh's
+// auto-increment-on-collision behavior) so Playwright's webServer health check
+// and baseURL agree on exactly where the stack will come up; distinct *across*
+// worktrees so two e2e runs never share containers, ports or volumes.
+import instance from './instance.cjs';
+
+export const WEB_PORT: number = instance.WEB_PORT;
+export const API_PORT: number = instance.API_PORT;
+export const DB_PORT: number = instance.DB_PORT;
+export const COMPOSE_PROJECT_NAME: string = instance.COMPOSE_PROJECT_NAME;
 
 export const BASE_URL = `http://localhost:${WEB_PORT}`;
 export const API_HOST = `http://localhost:${API_PORT}/api/bigshop`;
-
-// See CLAUDE.md's "Multiple worktrees" section: docker compose derives its
-// project name from the directory basename by default, and every worktree of
-// this repo is checked out into a directory named `big-shop` - an explicit,
-// e2e-specific project name stops Playwright's stack from colliding with
-// (or silently reusing) another worktree's containers.
-export const COMPOSE_PROJECT_NAME = 'bigshop-e2e';

--- a/e2e/instance.cjs
+++ b/e2e/instance.cjs
@@ -1,0 +1,94 @@
+// The identity of one e2e stack: its docker compose project name and the three
+// ports it binds. Everything is derived here, once, so that the port Playwright
+// talks to and the port the stack actually binds are the same number by
+// construction rather than by two files agreeing.
+//
+// Why it is derived rather than pinned to literals: several agents work this
+// repo in parallel git worktrees, and a fixed project name means every worktree
+// resolves to the *same* containers and volumes. `npm run test:e2e` begins with
+// `test:e2e:stop` (`docker compose down --volumes`), so starting a run in one
+// worktree tore down another's in-flight run, database included, mid-suite -
+// invisibly from the other side, and looking exactly like an application bug.
+//
+// Deriving from the worktree path makes that automatic: no per-agent convention
+// to remember, which matters because the failure it prevents is silent and a
+// convention would not be.
+//
+// Plain CommonJS rather than TypeScript because the consumers are split across
+// two runtimes: `e2e/env.ts` (via Playwright's own TS pipeline, which emits
+// CJS) and shell - `scripts/e2e-compose.sh` runs this file with `node` to get
+// the project name for a `docker compose` invocation. A .cjs file is the one
+// shape both load without depending on Node's type-stripping or `require(esm)`.
+
+const { createHash } = require('node:crypto');
+const path = require('node:path');
+
+// This file lives in `e2e/`, so the worktree root is one level up. Resolved
+// from __dirname rather than process.cwd() so the answer does not depend on
+// where the caller was invoked from.
+const worktreeRoot = path.resolve(__dirname, '..');
+
+// An explicit E2E_INSTANCE wins, for the case where two worktrees happen to
+// land on the same port offset (docker compose fails loudly on the port
+// clash - see scripts/dev-full.sh's strict mode - and this is the way out).
+const instanceKey = (process.env.E2E_INSTANCE || '').trim() || worktreeRoot;
+const digest = createHash('sha256').update(instanceKey).digest();
+
+// 0-99. Each port family below gets its own block of 100, so a given offset
+// picks one port from each and no two families can ever overlap.
+const offset = digest.readUInt16BE(0) % 100;
+
+/**
+ * A readable label for the instance, so `docker compose ls` says whose stack a
+ * set of containers is without anyone having to `docker inspect` the mounts.
+ *
+ * The last two path segments, because every worktree of this repo is checked
+ * out into a directory named `big-shop` - the segment above it is the only part
+ * that differs (`.../4/big-shop` -> `4-big-shop`).
+ */
+function label() {
+  if (process.env.E2E_INSTANCE) {
+    return slugify(process.env.E2E_INSTANCE).slice(0, 24);
+  }
+  const tail = worktreeRoot.split(path.sep).filter(Boolean).slice(-2).join('-');
+  // The digest suffix is what actually guarantees uniqueness; the slug is only
+  // there to be read.
+  return `${slugify(tail).slice(0, 24)}-${digest.toString('hex').slice(0, 6)}`;
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// Port blocks deliberately distinct from scripts/dev-full.sh's own defaults
+// (3000/8080/3308), so a manually-running `npm run dev:full` in the same
+// worktree doesn't collide with the stack Playwright starts for e2e.
+const WEB_PORT = 3900 + offset; // 3900-3999
+const DB_PORT = 4200 + offset; //  4200-4299, clear of 4317/4318 (OTLP)
+const API_PORT = 8980 + offset; // 8980-9079
+
+module.exports = {
+  COMPOSE_PROJECT_NAME: `bigshop-e2e-${label()}`,
+  WEB_PORT,
+  DB_PORT,
+  API_PORT,
+};
+
+// Also usable as a CLI, which is how the shell consumers read these values:
+//   node e2e/instance.cjs COMPOSE_PROJECT_NAME
+// With no argument it prints every value as KEY=value lines.
+if (require.main === module) {
+  const [, , key] = process.argv;
+  if (key) {
+    if (!(key in module.exports)) {
+      console.error(`Unknown e2e instance key: ${key}`);
+      process.exit(1);
+    }
+    console.log(String(module.exports[key]));
+  } else {
+    for (const [k, v] of Object.entries(module.exports)) console.log(`${k}=${v}`);
+  }
+}

--- a/e2e/instance.d.cts
+++ b/e2e/instance.d.cts
@@ -1,0 +1,11 @@
+// Hand-written because e2e/instance.cjs is plain CommonJS JavaScript and the
+// e2e tsconfig does not enable allowJs. Values only - the shape is four
+// constants, and duplicating four type annotations is cheaper than turning JS
+// checking on for the whole e2e project.
+declare const instance: {
+  COMPOSE_PROJECT_NAME: string;
+  WEB_PORT: number;
+  DB_PORT: number;
+  API_PORT: number;
+};
+export = instance;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:watch": "vitest",
     "test:e2e": "npm run test:e2e:stop && playwright test",
     "test:e2e:debug": "npm run test:e2e:stop && E2E_SLOWMO=800 playwright test --headed --workers=1",
-    "test:e2e:stop": "COMPOSE_PROJECT_NAME=bigshop-e2e docker compose down --remove-orphans --volumes >/dev/null 2>&1 || true",
+    "test:e2e:stop": "./scripts/e2e-compose.sh down --remove-orphans --volumes >/dev/null 2>&1 || true",
     "test:evals": "./evals/run-evals.sh",
     "test:evals:shopping": "./evals/run-evals.sh shopping",
     "test:dave": "node evals/test-runner.js"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -49,7 +49,8 @@ export default defineConfig({
     // starting. A measured failing run spent ~110s of its 120s budget before
     // MySQL had even been asked to start: pulling mysql:8.0 (129MB) and
     // building the Go API image from scratch, with `docker compose up`
-    // reporting "Container bigshop-e2e-db-1 Waiting" as the clock ran out.
+    // reporting "Container bigshop-e2e-<instance>-db-1 Waiting" as the clock
+    // ran out.
     // Locally both are cached and the whole thing is up in seconds, which is
     // why this only ever failed in CI - and it did so on unrelated branches
     // too, at roughly one run in four.
@@ -73,6 +74,12 @@ export default defineConfig({
       // collector that was never started. See scripts/dev-full.sh.
       START_LGTM: 'false',
       OTEL_EXPORTER_OTLP_ENDPOINT: '',
+      // dev-full.sh moves to the next free port when a requested one is taken,
+      // which is right for `npm run dev:full` and wrong here: baseURL and the
+      // health-check url above are already fixed, so a drifting stack is one
+      // nothing is connected to. Fail loudly instead - scripts/dev-full.sh's
+      // message says how to get out of it.
+      PIN_PORTS: 'true',
     },
   },
 });

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -6,6 +6,12 @@
 # in use (e.g. another checkout/worktree running dev:full), the next free port
 # is used automatically. Set the env vars yourself to pin specific ports:
 #   DB_PORT=3309 API_PORT=8081 WEB_PORT=3002 npm run dev:full
+#
+# Set PIN_PORTS=true to turn that fallback off for the DB/API/web ports, so a
+# port already in use is a hard error instead. The e2e suite does this: its
+# caller has already told Playwright which ports to talk to, and drifting to a
+# different one there does not degrade gracefully - it produces a stack nothing
+# is connected to and a health check that times out for no visible reason.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -21,6 +27,41 @@ find_available_port() {
   echo "$port"
 }
 
+PIN_PORTS="${PIN_PORTS:-false}"
+
+# The three ports a caller can be holding a fixed expectation about. Grafana and
+# OTLP below are deliberately left on the auto-increment path either way: they
+# are only bound when START_LGTM is true, and nothing outside this script is
+# told where they landed.
+resolve_pinnable_port() {
+  local requested="$1" service="$2"
+  if ! port_in_use "$requested"; then
+    echo "$requested"
+    return
+  fi
+  if [ "$PIN_PORTS" = "true" ]; then
+    cat >&2 <<MSG
+
+Port ${requested} (${service}) is already in use, and PIN_PORTS is set, so this
+script will not quietly move to another one - whoever started it is expecting
+the stack on exactly that port.
+
+If this is the e2e suite, the likely cause is either a stale stack from this
+worktree:
+
+    npm run test:e2e:stop
+
+or another worktree whose derived port offset collides with this one (see
+e2e/instance.cjs). Break the tie by naming this instance explicitly:
+
+    E2E_INSTANCE=<something-unique> npm run test:e2e
+
+MSG
+    exit 1
+  fi
+  find_available_port "$requested"
+}
+
 requested_db_port="${DB_PORT:-3308}"
 requested_api_port="${API_PORT:-8080}"
 requested_web_port="${WEB_PORT:-3000}"
@@ -31,9 +72,9 @@ requested_web_port="${WEB_PORT:-3000}"
 requested_grafana_port="${GRAFANA_PORT:-3200}"
 requested_otlp_port="${OTLP_HTTP_PORT:-4318}"
 
-DB_PORT="$(find_available_port "$requested_db_port")"
-API_PORT="$(find_available_port "$requested_api_port")"
-WEB_PORT="$(find_available_port "$requested_web_port")"
+DB_PORT="$(resolve_pinnable_port "$requested_db_port" MySQL)"
+API_PORT="$(resolve_pinnable_port "$requested_api_port" "the Go API")"
+WEB_PORT="$(resolve_pinnable_port "$requested_web_port" "Next.js")"
 GRAFANA_PORT="$(find_available_port "$requested_grafana_port")"
 OTLP_HTTP_PORT="$(find_available_port "$requested_otlp_port")"
 

--- a/scripts/e2e-compose.sh
+++ b/scripts/e2e-compose.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Runs `docker compose` against *this worktree's* e2e stack.
+#
+# The project name comes from e2e/instance.cjs, the same module Playwright's
+# webServer reads, so a teardown here can never hit another worktree's
+# containers - which is exactly what `docker compose down --volumes` against a
+# hardcoded `bigshop-e2e` used to do, mid-suite, to whoever else was running.
+#
+# Usage: scripts/e2e-compose.sh down --remove-orphans --volumes
+#        scripts/e2e-compose.sh logs db api
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+COMPOSE_PROJECT_NAME="$(node e2e/instance.cjs COMPOSE_PROJECT_NAME)" \
+  exec docker compose "$@"


### PR DESCRIPTION
Closes the board item *"The e2e suite cannot be run from two worktrees, and running it destroys the other one's in-flight run"*.

## The problem

`e2e/env.ts` pinned one identity for the whole machine, and `package.json` + `.github/workflows/e2e.yml` wrote `bigshop-e2e` out by hand twice more. Every worktree resolved to the **same compose project, containers and volumes** — and `npm run test:e2e` *begins* with `test:e2e:stop`, i.e. `docker compose down --remove-orphans --volumes`. Starting a run in worktree A tore worktree B's in-flight run down mid-suite, database included. From B's side that is invisible: containers vanish, specs fail in ways that read exactly like application bugs.

That quietly falsified CLAUDE.md's *"a flaky-looking e2e failure gets investigated, not re-run-until-green — the suite tears down its volumes on every run precisely so failures are real"*. It has already cost time on the #50 email work, where e2e could not be run at all for a session.

## The fix

`e2e/instance.cjs` derives the whole identity once, from the worktree path:

- project name `bigshop-e2e-<slug>-<digest>` — the slug is there to be read in `docker compose ls`, the digest is what makes it unique;
- a `0–99` offset picking one port from each of three non-overlapping blocks: web `3900+`, DB `4200+`, API `8980+`.

Every consumer reads that one module — `e2e/env.ts` as a typed front door, and `scripts/e2e-compose.sh` for the two shell callers (`test:e2e:stop` and CI's log dump). No literal project name survives anywhere. It is CommonJS because the consumers straddle two runtimes (Playwright's TS pipeline, which emits CJS, and plain `node`), and `.cjs` is the one shape both load without depending on Node's type-stripping or `require(esm)`.

Derivation is automatic rather than a documented per-agent convention on purpose: the failure it prevents is silent, and a convention would not be.

### Two escape hatches

For the rare case where two worktrees hash to the same offset — which fails loudly on a port clash rather than silently:

- `E2E_INSTANCE=<name>` overrides the derived identity (project name *and* ports).
- `PIN_PORTS=true`, which `playwright.config.ts` now sets, stops `dev-full.sh` auto-incrementing to the next free port behind Playwright's back. That fallback is right for `npm run dev:full` and wrong once `baseURL` is fixed, where it only yields a stack nothing is connected to and an unexplained health-check timeout. The failure message names both hatches.

## Evidence

The bug reproduced live on this machine, and the fix is visible in the same output. Before the run, another checkout had a `bigshop-e2e` stack up — the old code would have destroyed it:

```
NAME                STATUS                  CONFIG FILES
bigshop-e2e         running(2)              /Users/ianfeather/Repositories/big-shop/docker-compose.yml
bigshop-impl43      running(2)              /Users/ianfeather/.treehouse/.../4/big-shop/docker-compose.yml
...
```

After `npm run test:e2e` from this worktree — **37 passed (27.7s)** — the other worktree's stack is untouched and this one has its own:

```
NAME                            STATUS         CONFIG FILES
bigshop-e2e                     running(2)     /Users/ianfeather/Repositories/big-shop/docker-compose.yml   <- survived
bigshop-e2e-4-big-shop-442f25   running(2)     /Users/ianfeather/.treehouse/.../4/big-shop/docker-compose.yml
```

All six worktrees on this machine derive distinct names and ports:

```
bigshop-e2e-repositories-big-shop-6b0bb7  web 3903  db 4203  api 8983
bigshop-e2e-1-big-shop-a9eabc             web 3998  db 4298  api 9078
bigshop-e2e-2-big-shop-59c3da             web 3979  db 4279  api 9059
bigshop-e2e-3-big-shop-f1d269             web 3906  db 4206  api 8986
bigshop-e2e-4-big-shop-442f25             web 3955  db 4255  api 9035
bigshop-e2e-5-big-shop-a7c4e1             web 3948  db 4248  api 9028
```

`PIN_PORTS` verified by pointing it at a port already in use — it exits 1 before touching docker:

```
Port 4255 (MySQL) is already in use, and PIN_PORTS is set, so this
script will not quietly move to another one ...
    E2E_INSTANCE=<something-unique> npm run test:e2e
```

Also green locally: `npm run lint`, `npm run typecheck`, `npm run test` (370 tests).

No screenshots: this is build tooling with no user-visible surface.

## Notes

- **CI is unaffected** — one checkout per runner, so the derivation is a no-op there. Comments in `e2e.yml` say so.
- CLAUDE.md's Testing section is rewritten. It previously presented the pinned name as the thing that stopped worktree collisions, which was true of the *dev* stack and the exact opposite for a second e2e run.
- **One-off cleanup for anyone with an old stack:** nothing will ever tear down a leftover project literally named `bigshop-e2e`, since no worktree claims that name any more. Once no run is using it: `COMPOSE_PROJECT_NAME=bigshop-e2e docker compose down -v`. Not done here — it may be someone's live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)