### PR TITLE
Build the DSN from components, so its parameters stop being hand-pasted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,11 @@ Routes are registered under
 `/api/bigshop` (`main.go`'s `basePath`, passed to `GetRouter`), so
 `NEXT_PUBLIC_API_HOST` must include that suffix, e.g.
 `http://localhost:8080/api/bigshop` (already the case in
-`.env.development`). It needs a live DB via `DSN`, and `DISABLE_AUTH=true`
+`.env.development`). It needs a live DB via `TIDB_HOST`, `TIDB_PORT`,
+`TIDB_USER`, `TIDB_PASSWORD` and `TIDB_DB` — `dsn.go` builds the connection
+string from those, and refuses to start naming any that are missing rather than
+connecting somewhere half-configured (leave `TIDB_TLS` unset for a local
+database; it is `true` only for TiDB Cloud). It also needs `DISABLE_AUTH=true`
 (no `NEXT_PUBLIC_` prefix — read server-side by the Go process) to skip real
 Auth0 JWT validation; the router then injects a fixed `DEV_USER_ID` (default
 `local-dev-user`) as the request's user ID, which must exist in `account_user`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,15 +107,24 @@ services:
       db:
         condition: service_healthy
     environment:
-      # interpolateParams=true makes the driver interpolate arguments
-      # client-side instead of preparing server-side, which halves the blocking
-      # round trips of every parameterised query (measured: GET /shopping-list
-      # 15.2 -> 9.1). collation is pinned *because of* it, not incidentally:
-      # the driver's guard against the multibyte escape-bypass charsets is
-      # `Collation != "" && unsafeCollations[Collation]`, so leaving the
-      # collation unset disarms it. Keep them together, and never add
-      # multiStatements - see specs/completed/request-model-optimisations.md.
-      DSN: "root:root@tcp(db:3306)/bigshop?parseTime=true&interpolateParams=true&collation=utf8mb4_general_ci"
+      # The connection, by component. There is no DSN string here any more:
+      # parseTime, interpolateParams and collation are literals in
+      # netlify-functions/recipes/dsn.go, because not one of them ever differed
+      # between this stack and production - and a hand-written string is exactly
+      # how production came to lose parseTime and answer 500 on GET /user for a
+      # day. See that file for the reasoning, and never add multiStatements.
+      #
+      # TIDB_* rather than DB_*, matching .env.tidb, even though this particular
+      # database is a MySQL container rather than TiDB. One name for one thing
+      # beats two conventions.
+      #
+      # TIDB_TLS is deliberately absent: this speaks to a container over the
+      # compose network. Production sets it in fly.toml.
+      TIDB_HOST: "db"
+      TIDB_PORT: "3306"
+      TIDB_USER: "root"
+      TIDB_PASSWORD: "root"
+      TIDB_DB: "bigshop"
       DISABLE_AUTH: "true"
       DEV_USER_ID: "local-dev-user"
       # Read by the OTel SDK's own env handling (telemetry.Setup passes no

--- a/docker/README.md
+++ b/docker/README.md
@@ -90,14 +90,13 @@ Missing `TIDB_HOST` or `TIDB_USER` is a hard error naming what is missing -
 they are deliberately not defaulted, because a script that silently connects
 somewhere you did not mean is worse than one that refuses.
 
-- **Host and username** can be read straight out of the production `DSN`
-  connection string, which lives in Netlify's environment variables UI (see the
-  Netlify Dashboard link in `CLAUDE.md`) rather than anywhere in this repo. The
-  `DSN` format is `user:password@tcp(host:port)/bigshop?...` (see `main.go`'s
-  `sql.Open("mysql", os.Getenv("DSN"))`). The query parameters after the `?`
-  are load-bearing rather than incidental - see
-  [technical-architecture.md](../technical-architecture.md#the-dsns-query-parameters)
-  before rewriting one.
+- **Host and username** are the same values the API itself uses, in
+  `netlify-functions/recipes/fly.toml`'s `[env]` block - `TIDB_HOST` and
+  `TIDB_USER`, under those exact names. They used to have to be dug out of a
+  `DSN` connection string in Netlify's environment UI; there is no such string
+  any more, because `dsn.go` assembles the connection from these components and
+  the `TIDB_PASSWORD` secret. See
+  [technical-architecture.md](../technical-architecture.md#the-connection-string-and-why-nobody-writes-one).
 - **Password** - never passed as an argument, never read from `.env.tidb` or
   from the environment, and stored nowhere. Each script prompts once, silently,
   and holds it in memory only for the container calls that need it, which
@@ -163,7 +162,7 @@ capability - a small/free-tier cluster (this app's likely tier) probably
 only exposes the web SQL Editor (fine for ad hoc queries, but row-limited
 and can't cascade across joined tables) or plain MySQL wire-protocol access.
 `mysqldump`/`mysql` CLI work over that same protocol regardless of tier -
-the same access the app's own `DSN` already relies on - so that's what this
+the same access the app's own connection already relies on - so that's what this
 script uses. Auth0 never comes into it either way: it gates the
 *application's* API, not direct database access.
 

--- a/docs/fly-migration-runbook.md
+++ b/docs/fly-migration-runbook.md
@@ -17,7 +17,7 @@ whole time, untouched, which is what makes step 5 revertible.
 | You need | Why |
 | --- | --- |
 | A Fly.io account, `flyctl` installed (`brew install flyctl`), `fly auth login` | Steps 1–3 |
-| The production `DSN` (TiDB connection string) | Step 2 — it's in Netlify's env vars today |
+| The production TiDB password | Step 2 |
 | The production `SENDGRID_API_KEY` | Step 2 — same place |
 | Netlify dashboard access | Step 5 |
 | GitHub repo admin | Steps 4 and 6 |
@@ -55,9 +55,15 @@ together.
 
 ```bash
 fly secrets set \
-  DSN='<the production TiDB connection string>' \
+  TIDB_PASSWORD='<the production TiDB password>' \
   SENDGRID_API_KEY='<the production SendGrid key>'
 ```
+
+**Only the password.** The host, port, username and database name are public
+identifiers and are pinned in `fly.toml`'s `[env]`, and the driver's query
+parameters are literals in `dsn.go`. This used to be a single `DSN` string
+carrying all five, which is exactly how production lost `parseTime=true` and
+answered 500 on every `GET /user` for a day — see that file's header.
 
 `fly secrets set` normally triggers a release to roll the new values out; with no machines
 created yet it simply stores them.
@@ -129,7 +135,7 @@ so the deleted user can still log in, resolving to nothing. That is precisely th
 and CI, where no tenant is reachable) and it records a warning on the request's span
 saying exactly which variable is missing, but nothing refuses the deletion.
 
-Otherwise only `DSN`, `SENDGRID_API_KEY`, `INVITE_EMAIL_PEPPER`, `AUTH0_MGMT_CLIENT_ID` and `AUTH0_MGMT_CLIENT_SECRET`. `AUTH0_DOMAIN` and `AUTH0_AUDIENCE` are public
+Otherwise only `TIDB_PASSWORD`, `SENDGRID_API_KEY`, `INVITE_EMAIL_PEPPER`, `AUTH0_MGMT_CLIENT_ID` and `AUTH0_MGMT_CLIENT_SECRET`. `AUTH0_DOMAIN` and `AUTH0_AUDIENCE` are public
 identifiers and are already
 pinned in `fly.toml`'s `[env]` block — deliberately, because getting them wrong does not
 fail loudly: with `AUTH0_DOMAIN` unset the JWKS fetch goes to `https:///.well-known/jwks.json`

--- a/netlify-functions/recipes/fly.toml
+++ b/netlify-functions/recipes/fly.toml
@@ -8,7 +8,7 @@
 #   fly deploy ./netlify-functions/recipes
 # (this file sits next to the Dockerfile so the build context is the Go module
 # and nothing else - not the whole repo). docs/fly-migration-runbook.md has the
-# first-time setup, including the DSN secret.
+# first-time setup, including the TIDB_PASSWORD secret.
 
 app = "big-shop-api"
 
@@ -25,7 +25,7 @@ primary_region = "fra"
 #
 # **Why machine_config and not [build.compose].** A compose deploy was tried
 # first and failed outright: no `fly secrets` reached either container, so the
-# API fell back to an empty DSN and died on
+# API fell back to an empty connection string and died on
 # `dial tcp 127.0.0.1:3306: connect: connection refused` before serving
 # anything. The cause is not a platform bug - in a multi-container Machine a
 # container receives ONLY the secrets it declares, and the compose path gives no
@@ -66,8 +66,14 @@ primary_region = "fra"
 [build]
   dockerfile = "Dockerfile"
 
-# Three of the Go process's environment variables (grep os.Getenv) are public
+# Most of the Go process's environment variables (grep os.Getenv) are public
 # identifiers and live here, in version control, so a deploy cannot forget them:
+#
+#   TIDB_HOST / TIDB_PORT / TIDB_USER / TIDB_DB / TIDB_TLS - where the database
+#     is and who connects to it. These used to be inside the DSN secret, which
+#     meant four values that grant nothing on their own were being hand-pasted
+#     alongside the one that does. .env.tidb has always tracked the same four in
+#     git and says why; this is the API agreeing with it. See dsn.go.
 #
 #   AUTH0_DOMAIN / AUTH0_AUDIENCE - both are already public in
 #     .env.development. Getting these wrong does not fail loudly: with
@@ -81,27 +87,59 @@ primary_region = "fra"
 #     docs/fly-migration-runbook.md used to imply it went. See the note by the
 #     value itself.
 #
-# Two are secrets, set out-of-band with `fly secrets set` (see
+# Three are secrets, set out-of-band with `fly secrets set` (see
 # docs/fly-migration-runbook.md) and deliberately absent from this file:
 #
-#   DSN               - TiDB connection string
+#   TIDB_PASSWORD     - the database password, and now the *only* part of the
+#                       connection that is secret. It is declared in the `api`
+#                       container's `secrets` array in machine_config.json;
+#                       renaming it here without renaming it there means the
+#                       process starts with no password and cannot connect.
 #   SENDGRID_API_KEY  - every email Big Shop sends (internal/pkg/service/email).
 #                       Now genuinely set, and correspondingly declared in the
 #                       `api` container's `secrets` array in machine_config.json.
 #                       Both halves are required; see the trap above.
+#   INVITE_EMAIL_PEPPER - the HMAC pepper for invite address digests. Declared
+#                       as of specs/completed/transactional-email.md; before
+#                       that it was set but undeclared, and HashEmail quietly
+#                       degraded to a plain SHA-256. The worked example of the
+#                       trap above.
 #
-# The fifth, DISABLE_AUTH, must never be set here. It is a local-development
+# DISABLE_AUTH must never be set here. It is a local-development
 # switch that makes the API resolve every request to DEV_USER_ID without
 # validating a token; docker-compose.yml is the only place it belongs.
 # These reach *every* container in the Machine. `fly secrets` do not: under
 # machine_config each container receives only the secrets it names, which was
 # measured, not assumed - a probe container declaring only
-# GRAFANA_CLOUD_OTLP_ENDPOINT saw that and could not see DSN.
+# GRAFANA_CLOUD_OTLP_ENDPOINT saw that and could not see the API's database
+# secret (then named DSN, now TIDB_PASSWORD).
 #
 # So ADR-0007's "credentials live in collector config, not application code"
 # holds more strongly than it reads: the API container need never be given a
-# Grafana credential at all, and the collector need never be given DSN.
+# Grafana credential at all, and the collector need never be given
+# TIDB_PASSWORD.
 [env]
+  # Where the database is and who connects to it. The same four values
+  # .env.tidb holds for the scripts, which is the point - one description of one
+  # instance, and the password (TIDB_PASSWORD, a Fly secret) the only part that
+  # grants anything.
+  #
+  # The query parameters that used to travel with these inside the DSN string
+  # are gone from configuration entirely; they are literals in dsn.go. Read that
+  # file before changing anything here.
+  TIDB_HOST = "gateway01.eu-central-1.prod.aws.tidbcloud.com"
+  # 4000 is TiDB Cloud's protocol port, not MySQL's usual 3306.
+  TIDB_PORT = "4000"
+  TIDB_USER = "3of82tmdiXMHzuo.root"
+  TIDB_DB = "bigshop"
+
+  # TLS is on because TiDB Cloud requires it, and it is stated rather than
+  # inferred from the hostname: a guess would mean that the day the host stops
+  # looking like TiDB Cloud, the connection quietly stops being encrypted.
+  # dsn.go builds the certificate's ServerName from TIDB_HOST above, so this
+  # file names the production host exactly once.
+  TIDB_TLS = "true"
+
   # The custom domain, because it is the issuer of the login tokens this API
   # validates: a token minted at auth.bigshop.life carries
   # `iss: https://auth.bigshop.life/`, and newJWTMiddleware pins the validator to

--- a/netlify-functions/recipes/internal/pkg/dbconfig/dsn.go
+++ b/netlify-functions/recipes/internal/pkg/dbconfig/dsn.go
@@ -1,0 +1,142 @@
+// Package dbconfig turns the database's component environment variables into a
+// driver connection string.
+//
+// A package of its own rather than a file in main, and that is not filing: a
+// test in package main runs main's init(), which opens the database and
+// log.Fatals when it cannot. The first test ever added to that package
+// discovered this by failing in CI - on a bare runner with no TIDB_* set - while
+// passing locally, where the api container has them. Testing the thing that
+// builds the connection string should not require a database to connect to.
+package dbconfig
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// tlsConfigName is the name the driver knows our TLS settings by. It appears in
+// the generated DSN as `tls=tidb` and nowhere else - nothing outside this file
+// needs to know it.
+const tlsConfigName = "tidb"
+
+// dsnCollation is pinned *because of* InterpolateParams, not for its own sake.
+//
+// Interpolation moves parameter escaping out of the server and into the driver,
+// and the driver's guard against the multibyte escape-bypass charsets (gbk,
+// big5, sjis, cp932, gb2312, gb18030) is
+// `InterpolateParams && Collation != "" && unsafeCollations[Collation]`. Since
+// driver v1.8 the collation defaults to *empty*, so leaving it unset silently
+// disarms that guard. The two belong together; see
+// specs/completed/request-model-optimisations.md.
+const dsnCollation = "utf8mb4_general_ci"
+
+// DSN assembles the driver's connection string from its components.
+//
+// # Why this is not just an environment variable
+//
+// It was one - a single `DSN` secret holding the whole string - and on
+// 2026-08-21 that cost production a broken route. The secret had lost
+// `parseTime=true`, so `service.GetLatestConsent` could not scan `created_at`
+// into a `time.Time` and every `GET /user` answered 500. Nothing else broke,
+// because that scan is the only `time.Time` on any request-serving path, and
+// nothing noticed for a day, because `GetLatestConsent` returns early on
+// `sql.ErrNoRows` and `consent_event` was empty until someone accepted the
+// consent banner. A parameter dropped by hand, a route broken with no deploy to
+// blame, and one query in the codebase able to reveal it.
+//
+// The fix is not to validate the string but to stop hand-writing it. Of the
+// five things that DSN carried, exactly one is a secret: `.env.tidb` already
+// tracks the username, host, port and database name in git, and argues why -
+// they "identify the instance but grant nothing without the password". So the
+// password stays a secret, the identifiers move to fly.toml's [env] where a
+// deploy cannot forget them, and the three query parameters below stop being
+// configuration at all. None of them is environment-specific; the local stack
+// and production always wanted the same three values, which is what made them
+// literals rather than settings.
+//
+// # Why the TLS ServerName is not written down
+//
+// It used to be, as a `gateway01.eu-central-1.prod.aws.tidbcloud.com` literal in
+// init(), which meant the production hostname existed in three places - here,
+// the DSN secret, and .env.tidb - that had to agree with nothing making them.
+// Moving TiDB Cloud instances would have updated the secret and left the
+// certificate name behind, failing the handshake rather than the lookup. It now
+// derives from TIDB_HOST, so there is one hostname.
+func DSN() (string, error) {
+	host := os.Getenv("TIDB_HOST")
+	port := os.Getenv("TIDB_PORT")
+	user := os.Getenv("TIDB_USER")
+	dbName := os.Getenv("TIDB_DB")
+
+	// LookupEnv rather than Getenv, so an intentionally empty password is
+	// distinguishable from an absent one. A local MySQL with no password set is
+	// a real configuration; a production secret that failed to reach the
+	// process is not, and it must not silently become the former.
+	password, passwordSet := os.LookupEnv("TIDB_PASSWORD")
+
+	var missing []string
+	for _, v := range []struct {
+		name  string
+		value string
+	}{
+		{"TIDB_HOST", host},
+		{"TIDB_PORT", port},
+		{"TIDB_USER", user},
+		{"TIDB_DB", dbName},
+	} {
+		if v.value == "" {
+			missing = append(missing, v.name)
+		}
+	}
+	if !passwordSet {
+		missing = append(missing, "TIDB_PASSWORD")
+	}
+	// Reported together rather than one per run. Every one of these has to be
+	// present for the process to serve anything, so failing on the first would
+	// just mean finding out about the rest one restart at a time.
+	if len(missing) > 0 {
+		return "", fmt.Errorf("database configuration is incomplete: %s not set", strings.Join(missing, ", "))
+	}
+
+	cfg := mysql.NewConfig()
+	cfg.User = user
+	cfg.Passwd = password
+	cfg.Net = "tcp"
+	cfg.Addr = net.JoinHostPort(host, port)
+	cfg.DBName = dbName
+
+	// The three that used to be hand-written, and the reason this function
+	// exists. ParseTime makes DATETIME/TIMESTAMP columns scan into time.Time
+	// rather than []byte; InterpolateParams halves the blocking round trips of
+	// every parameterised query by escaping client-side instead of preparing
+	// server-side (measured: GET /shopping-list 15.2 -> 9.1); dsnCollation
+	// keeps the escape-bypass guard armed, as its own comment explains.
+	//
+	// **multiStatements must never join them.** An unsafe collation the driver
+	// refuses outright, failing at startup; nothing stops multiStatements being
+	// combined with InterpolateParams, and it is the setting that would turn any
+	// future escaping defect into stacked statements.
+	cfg.ParseTime = true
+	cfg.InterpolateParams = true
+	cfg.Collation = dsnCollation
+
+	// Explicit rather than inferred from the hostname. Guessing would mean that
+	// the day a host stops looking like TiDB Cloud, the connection quietly stops
+	// being encrypted - a failure with no symptom at all.
+	if os.Getenv("TIDB_TLS") == "true" {
+		if err := mysql.RegisterTLSConfig(tlsConfigName, &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			ServerName: host,
+		}); err != nil {
+			return "", fmt.Errorf("registering the %q TLS config: %w", tlsConfigName, err)
+		}
+		cfg.TLSConfig = tlsConfigName
+	}
+
+	return cfg.FormatDSN(), nil
+}

--- a/netlify-functions/recipes/internal/pkg/dbconfig/dsn_test.go
+++ b/netlify-functions/recipes/internal/pkg/dbconfig/dsn_test.go
@@ -1,0 +1,172 @@
+package dbconfig
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// setEnv puts the process into a fully configured state, so each test can
+// change or unset the one thing it is about.
+func setEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("TIDB_HOST", "gateway01.eu-central-1.prod.aws.tidbcloud.com")
+	t.Setenv("TIDB_PORT", "4000")
+	t.Setenv("TIDB_USER", "someuser.root")
+	t.Setenv("TIDB_PASSWORD", "hunter2")
+	t.Setenv("TIDB_DB", "bigshop")
+	t.Setenv("TIDB_TLS", "true")
+}
+
+// The regression this whole file exists for. A DSN that reaches the driver
+// without these three is not a slower or a laxer connection, it is a broken
+// one: production lost parseTime and GET /user answered 500 until someone
+// noticed. They are asserted through ParseDSN rather than by string matching so
+// the test pins what the driver will actually do, not how FormatDSN spells it.
+func TestBuildDSNPinsTheLoadBearingParameters(t *testing.T) {
+	setEnv(t)
+
+	dsn, err := DSN()
+	if err != nil {
+		t.Fatalf("DSN: %v", err)
+	}
+
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		t.Fatalf("the DSN we generated does not parse: %v", err)
+	}
+
+	if !cfg.ParseTime {
+		t.Error("parseTime is not set: DATETIME columns will scan into []byte and every time.Time read fails")
+	}
+	if !cfg.InterpolateParams {
+		t.Error("interpolateParams is not set: every parameterised query costs two blocking round trips")
+	}
+	if cfg.Collation != dsnCollation {
+		t.Errorf("collation = %q, want %q: an empty collation disarms the driver's escape-bypass guard", cfg.Collation, dsnCollation)
+	}
+	// Named explicitly because it is the one that would turn an escaping defect
+	// into stacked statements, and nothing in the driver refuses it.
+	if cfg.MultiStatements {
+		t.Error("multiStatements is set, and must never be")
+	}
+}
+
+func TestBuildDSNAssemblesTheAddress(t *testing.T) {
+	setEnv(t)
+
+	dsn, err := DSN()
+	if err != nil {
+		t.Fatalf("DSN: %v", err)
+	}
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		t.Fatalf("the DSN we generated does not parse: %v", err)
+	}
+
+	if want := "gateway01.eu-central-1.prod.aws.tidbcloud.com:4000"; cfg.Addr != want {
+		t.Errorf("Addr = %q, want %q", cfg.Addr, want)
+	}
+	if cfg.User != "someuser.root" {
+		t.Errorf("User = %q", cfg.User)
+	}
+	if cfg.Passwd != "hunter2" {
+		t.Errorf("Passwd = %q", cfg.Passwd)
+	}
+	if cfg.DBName != "bigshop" {
+		t.Errorf("DBName = %q", cfg.DBName)
+	}
+}
+
+// TLS is switched by TIDB_TLS alone. Inferring it from the hostname would mean
+// that the day the host stops looking like TiDB Cloud, the connection silently
+// stops being encrypted.
+func TestBuildDSNTLSIsExplicit(t *testing.T) {
+	t.Run("on", func(t *testing.T) {
+		setEnv(t)
+		dsn, err := DSN()
+		if err != nil {
+			t.Fatalf("DSN: %v", err)
+		}
+		cfg, err := mysql.ParseDSN(dsn)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if cfg.TLSConfig != tlsConfigName {
+			t.Errorf("TLSConfig = %q, want %q", cfg.TLSConfig, tlsConfigName)
+		}
+	})
+
+	t.Run("off", func(t *testing.T) {
+		setEnv(t)
+		t.Setenv("TIDB_TLS", "")
+		dsn, err := DSN()
+		if err != nil {
+			t.Fatalf("DSN: %v", err)
+		}
+		cfg, err := mysql.ParseDSN(dsn)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if cfg.TLSConfig != "" {
+			t.Errorf("TLSConfig = %q, want empty - the local stack speaks plaintext to a container", cfg.TLSConfig)
+		}
+	})
+}
+
+// Missing configuration must stop the process rather than produce a DSN that
+// half-works. Every name is reported at once so the fix takes one restart
+// rather than one per variable.
+func TestBuildDSNReportsEveryMissingVariable(t *testing.T) {
+	setEnv(t)
+	t.Setenv("TIDB_HOST", "")
+	t.Setenv("TIDB_DB", "")
+
+	_, err := DSN()
+	if err == nil {
+		t.Fatal("DSN succeeded with TIDB_HOST and TIDB_DB unset")
+	}
+	for _, want := range []string{"TIDB_HOST", "TIDB_DB"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %s", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "TIDB_USER") {
+		t.Errorf("error %q names TIDB_USER, which was set", err)
+	}
+}
+
+// An empty password is a real local configuration; an absent one is a secret
+// that did not reach the process. Getenv cannot tell them apart, which is why
+// DSN uses LookupEnv - and why this is worth a test rather than a comment.
+func TestBuildDSNDistinguishesEmptyPasswordFromAbsent(t *testing.T) {
+	t.Run("empty is allowed", func(t *testing.T) {
+		setEnv(t)
+		t.Setenv("TIDB_PASSWORD", "")
+		dsn, err := DSN()
+		if err != nil {
+			t.Fatalf("DSN rejected an empty password: %v", err)
+		}
+		cfg, err := mysql.ParseDSN(dsn)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if cfg.Passwd != "" {
+			t.Errorf("Passwd = %q, want empty", cfg.Passwd)
+		}
+	})
+
+	t.Run("absent is not", func(t *testing.T) {
+		setEnv(t)
+		os.Unsetenv("TIDB_PASSWORD")
+		_, err := DSN()
+		if err == nil {
+			t.Fatal("DSN succeeded with TIDB_PASSWORD unset")
+		}
+		if !strings.Contains(err.Error(), "TIDB_PASSWORD") {
+			t.Errorf("error %q does not name TIDB_PASSWORD", err)
+		}
+	})
+}

--- a/netlify-functions/recipes/machine_config.json
+++ b/netlify-functions/recipes/machine_config.json
@@ -3,7 +3,7 @@
     {
       "name": "api",
       "secrets": [
-        { "env_var": "DSN" },
+        { "env_var": "TIDB_PASSWORD" },
         { "env_var": "SENDGRID_API_KEY" },
         { "env_var": "INVITE_EMAIL_PEPPER" }
       ],

--- a/netlify-functions/recipes/main.go
+++ b/netlify-functions/recipes/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
@@ -13,6 +12,7 @@ import (
 
 	"recipes/internal/pkg/app"
 	"recipes/internal/pkg/common"
+	"recipes/internal/pkg/dbconfig"
 	"recipes/internal/pkg/lifecycle"
 	"recipes/internal/pkg/service"
 	"recipes/internal/pkg/telemetry"
@@ -41,7 +41,6 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	negroniadapter "github.com/awslabs/aws-lambda-go-api-proxy/negroni"
 	"github.com/danielgtaylor/huma/v2"
-	"github.com/go-sql-driver/mysql"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/urfave/negroni"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
@@ -165,10 +164,11 @@ func routerBasePath() string {
 }
 
 func init() {
-	mysql.RegisterTLSConfig("tidb", &tls.Config{
-		MinVersion: tls.VersionTLS12,
-		ServerName: "gateway01.eu-central-1.prod.aws.tidbcloud.com",
-	})
+	// The TiDB TLS config is registered by dbconfig.DSN rather than here, so the
+	// certificate's ServerName can come from TIDB_HOST instead of being a
+	// second copy of the production hostname. That is also simply where it
+	// belongs: every mode returning early below does so before opening a
+	// database, so registering a TLS config for them was always wasted.
 
 	// Both email tools return before the database is opened, exactly as the
 	// OpenAPI printer does. Neither needs one: preview renders templates, and
@@ -210,8 +210,16 @@ func init() {
 	// without it.
 	shutdownTelemetry, _ = telemetry.Setup(context.Background())
 
-	var err error
-	db, err = otelsql.Open("mysql", os.Getenv("DSN"),
+	// Fatal, and deliberately so: there is nothing to serve without a database,
+	// and the failure this replaces was the opposite - a DSN missing one
+	// parameter, accepted silently, breaking a single route a day later. The
+	// error names every variable that is missing.
+	dsn, err := dbconfig.DSN()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	db, err = otelsql.Open("mysql", dsn,
 		otelsql.WithAttributes(semconv.DBSystemNameMySQL),
 		otelsql.WithSpanOptions(otelsql.SpanOptions{
 			// Emit a query span only when the caller passed a context that

--- a/technical-architecture.md
+++ b/technical-architecture.md
@@ -280,7 +280,7 @@ application reads them — `@next/env` loads `.env`, `.env.local` and
 
 | Variable | Default | Notes |
 |---|---|---|
-| `TIDB_HOST` | none — required | From the production `DSN` in the Netlify UI |
+| `TIDB_HOST` | none — required | The same value `fly.toml`'s `[env]` gives the API |
 | `TIDB_USER` | none — required | Same place |
 | `TIDB_PORT` | `4000` | TiDB Cloud's protocol port, not MySQL's `3306` |
 | `TIDB_DB` | `bigshop` | |
@@ -421,8 +421,10 @@ local development and e2e working, where the public value is absolute anyway).
 unproxied origin to every visitor and undo the same-origin property.
 
 **Server-side secrets (set in Netlify UI / local `.env.local`):**
-- `DSN` — TiDB connection string. Carries two query parameters that are load-bearing rather
-  than incidental, and a third that must never be added — see below.
+- `TIDB_PASSWORD` — the database password, and the only part of the connection that is a
+  secret. Host, port, username and database name are public identifiers and live in
+  `fly.toml`'s `[env]`; the driver's query parameters are not configuration at all. See
+  below.
 - `OPENAI_API_KEY` — GPT-4 Vision + GPT-3.5-turbo
 - `SENDGRID_API_KEY` — Email invitations
 - `AUTH0_DOMAIN` / `AUTH0_AUDIENCE` — Go JWT validation. `AUTH0_DOMAIN` is
@@ -455,11 +457,26 @@ unproxied origin to every visitor and undo the same-origin property.
   one-way door: `invite` is never more than ~30 days deep because expired rows are purged
   lazily, so a rotation self-heals within a month. See `migrations/035_invite_email_hash.sql`.
 
-#### The DSN's query parameters
+#### The connection string, and why nobody writes one
 
-The DSN is set in exactly two places — `docker-compose.yml`'s `api` service (which covers
-local development *and* e2e) and a Fly secret for production. There is no `.env` copy by
-design (`docker/README.md`). Anyone rewriting it needs all three of these:
+**There is no `DSN` variable any more.** `netlify-functions/recipes/dsn.go` builds the
+connection string from components: `TIDB_HOST`, `TIDB_PORT`, `TIDB_USER`, `TIDB_DB` and
+`TIDB_TLS` from `fly.toml`'s `[env]` (and `docker-compose.yml` locally), plus the
+`TIDB_PASSWORD` secret. The three query parameters below are **literals in that file**, not
+configuration — none of them ever differed between the local stack and production, so
+neither environment was ever choosing them.
+
+That is a direct consequence of this section's previous form. It described the parameters as
+load-bearing and left them in a hand-pasted secret, which is how production came to lose
+`parseTime` on 2026-08-21 and answer 500 on every `GET /user` — `service.GetLatestConsent`
+holds the codebase's only `time.Time` scan on a request path, so one route broke and nothing
+else did. This table now documents what the program does rather than what an operator must
+remember.
+
+It also used to omit `tls=tidb`, which `main.go` required, so following it to rebuild the
+DSN would have taken the API down rather than fixed it. TLS is now `TIDB_TLS`, and the
+certificate's `ServerName` derives from `TIDB_HOST` instead of being a second copy of the
+hostname.
 
 | Parameter | Why |
 | --- | --- |
@@ -584,7 +601,7 @@ Two independent pipelines, one per deployable — an accepted consequence of
   check is never deployed
 - Config: `netlify-functions/recipes/fly.toml`; image:
   `netlify-functions/recipes/Dockerfile`
-- Needs a `FLY_API_TOKEN` repository secret; `DSN`, `SENDGRID_API_KEY`,
+- Needs a `FLY_API_TOKEN` repository secret; `TIDB_PASSWORD`, `SENDGRID_API_KEY`,
   `INVITE_EMAIL_PEPPER`, `AUTH0_MGMT_CLIENT_ID` and `AUTH0_MGMT_CLIENT_SECRET` are Fly
   secrets, `AUTH0_DOMAIN`/`AUTH0_AUDIENCE` are in `fly.toml`'s `[env]`
 - Reached from the browser through a Netlify `status = 200` rewrite, so it stays


### PR DESCRIPTION
## What broke

Production's `DSN` secret had lost `parseTime=true`. Every `GET /user` answered 500, and the trace's exception event named it exactly:

```
getting latest consent: sql: Scan error on column index 2, name "created_at":
unsupported Scan, storing driver.Value type []uint8 into type *time.Time
```

Nothing else broke, because `service.GetLatestConsent` holds the **only** `time.Time` scan on any request-serving path — the other two in the tree are an in-memory cache field and `lifecycle.Candidate`, which belongs to the email ticker.

Nothing noticed for a day either. `GetLatestConsent` returns early on `sql.ErrNoRows`, and production's `consent_event` was empty until the 034 re-run on 2026-08-20. The misconfiguration sat there harmlessly until the first person accepted the consent banner, then broke a route with no deploy to blame it on.

Production was unblocked by re-setting the secret. This is the durable half.

## The change

The fix is not to validate the string but to stop writing one. Of the five things `DSN` carried, exactly one is a secret — and `.env.tidb` has always tracked the other four in git, with its own header arguing why: they "identify the instance but grant nothing without the password".

- `TIDB_PASSWORD` stays a Fly secret, and is now the only part of the connection that is one.
- `TIDB_HOST` / `TIDB_PORT` / `TIDB_USER` / `TIDB_DB` / `TIDB_TLS` move to `fly.toml`'s `[env]`, in version control, where a deploy cannot forget them — the same argument that file already makes for `AUTH0_DOMAIN`.
- `parseTime`, `interpolateParams` and `collation` become literals in `dsn.go`. None was ever environment-specific: the local stack and production always wanted the same three values, which is what makes them part of the program rather than settings.
- Missing configuration is fatal at startup and names **every** absent variable, rather than producing a connection that half-works.

## Two things fixed on the way past

**The production hostname existed in three places** — the secret, `.env.tidb`, and a `ServerName` literal in `init()`. Moving TiDB Cloud instances would have updated the first and left the third behind, failing the TLS handshake rather than the lookup. `ServerName` now derives from `TIDB_HOST`, so the host is named once.

**`technical-architecture.md`'s parameter table omitted `tls=tidb`**, which `main.go` required. Following the documentation to rebuild the DSN would have taken the API down completely rather than fixed one route. That section is rewritten to describe what the program does rather than what an operator must remember.

## Rollout — two steps, in order

`machine_config.json` declares `TIDB_PASSWORD` in the `api` container's `secrets` array. Both halves are required: a secret that is set but not declared is absent at runtime with nothing reporting it, which is the trap `fly.toml` already documents.

```bash
fly secrets set TIDB_PASSWORD='<the production TiDB password>'   # 1. before merging
                                                                 # 2. merge and deploy
fly secrets unset DSN                                            # 3. after it is serving
```

The `[env]` values in `fly.toml` are the same ones `.env.tidb` holds; worth confirming they match the live instance before step 2.

## Verification

No screenshots: this is a backend change with no user-visible surface.

Verified end to end against a **throwaway** stack (`COMPOSE_PROJECT_NAME=bigshop-dsncheck`, fresh volume seeded from `migrations/`), because my own dev database is a production sync on an older schema and was left untouched. With a `consent_event` row present — the exact condition that broke production:

```
$ curl -s localhost:8087/api/bigshop/user
{"id":"local-dev-user","name":"Local Dev","email":"dev@localhost",
 "showPantryStaples":false,"accountId":1,
 "analyticsId":"31e01367-7535-4de8-8792-b7212c74d0d0",
 "consent":{"analytics":true,"policyVersion":"2026-01-01",
            "decidedAt":"2026-08-21T16:30:51Z"}}
HTTP 200
```

`decidedAt` is the scan that was failing.

Also: `gofmt`, `go vet` and `go test ./... -race` clean; `docs/openapi.yaml` shows no drift, which also confirms `go run . openapi` still starts without any `TIDB_*` set (it returns before `buildDSN`).

`dsn_test.go` pins the three parameters through `mysql.ParseDSN`, so it tests what the driver will do rather than how `FormatDSN` spells it. Mutation-checked: setting `cfg.ParseTime = false` fails the test with "parseTime is not set: DATETIME columns will scan into []byte".

Board item: [Build the DSN from components](https://app.notion.com/p/3c3c724ecda1812ab5f4c8babe9aac31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)