### PR TITLE
Say on the span why a 401 was refused

### DIFF
--- a/netlify-functions/recipes/internal/pkg/app/app.go
+++ b/netlify-functions/recipes/internal/pkg/app/app.go
@@ -142,7 +142,7 @@ func jwtHandler() negroni.HandlerFunc {
 			// Deliberately the same body a bad token gets. Whether this API is
 			// misconfigured is not something an unauthenticated caller should
 			// be able to read off the response.
-			unauthorized(w, "JWT is invalid.")
+			unauthorized(w, r, reasonUnconfigured, "JWT is invalid.")
 		}
 	}
 
@@ -197,10 +197,14 @@ func newJWTMiddleware() (*jwtmiddleware.JWTMiddleware, error) {
 func authErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
 	case errors.Is(err, jwtmiddleware.ErrJWTMissing):
-		unauthorized(w, "JWT is missing.")
+		unauthorized(w, r, reasonTokenMissing, "JWT is missing.")
 	case errors.Is(err, jwtmiddleware.ErrJWTInvalid):
-		unauthorized(w, "JWT is invalid.")
+		unauthorized(w, r, reasonTokenInvalid, "JWT is invalid.")
 	default:
+		// Stamped before delegating, because DefaultErrorHandler writes the
+		// response itself and this is the last point that still knows the
+		// refusal happened here.
+		telemetry.SetAuthFailureReason(r.Context(), reasonOther)
 		jwtmiddleware.DefaultErrorHandler(w, r, err)
 	}
 }
@@ -218,7 +222,7 @@ func authErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
 func (a *App) userMiddleware(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	claims, ok := r.Context().Value(jwtmiddleware.ContextKey{}).(*validator.ValidatedClaims)
 	if !ok || claims.RegisteredClaims.Subject == "" {
-		unauthorized(w, "JWT is invalid.")
+		unauthorized(w, r, reasonClaimsMissing, "JWT is invalid.")
 		return
 	}
 
@@ -277,9 +281,55 @@ func userSub(r *http.Request) string {
 	return caller.UserID
 }
 
+// The closed set of values for the auth.failure_reason span attribute.
+//
+// Constants rather than literals at the call sites because the point of the
+// attribute is to be queryable: a fifth spelling invented in passing is not a
+// new fact in Grafana, it is a filter that silently matches nothing. Declared
+// here, in the package that does the refusing, rather than in telemetry, which
+// should not know what the auth chain's failure modes are.
+//
+// Deliberately coarser than the message sent to the caller. tokenInvalid covers
+// every way a present token can be refused - expired, wrong audience, wrong
+// issuer, bad signature, unknown kid - because go-jwt-middleware collapses them
+// all into ErrJWTInvalid before this code sees them, and inventing a
+// distinction the library does not draw would put a value on the span that
+// nothing can be trusted to set correctly.
+const (
+	// No Authorization header, or one the library could not read a token from.
+	reasonTokenMissing = "token_missing"
+	// A token was present and was refused. See above for why this is one value.
+	reasonTokenInvalid = "token_invalid"
+	// The token validated, but carried no usable subject. Distinct from
+	// tokenInvalid because it means the tenant and this API disagree about the
+	// shape of a valid token, which is a configuration fault rather than a
+	// caller's.
+	reasonClaimsMissing = "claims_missing"
+	// This deployment has no Auth0 environment, so *every* request is refused.
+	// One span with this on it is worth more than any amount of staring at a
+	// 100% error rate, which is what it otherwise looks like.
+	reasonUnconfigured = "auth_unconfigured"
+	// go-jwt-middleware returned an error that is neither of its two exported
+	// sentinels. Nothing produces this today; it exists so that if something
+	// starts to, the span says "unclassified" rather than saying nothing.
+	reasonOther = "other"
+)
+
 // unauthorized writes the 401 body shape go-jwt-middleware itself uses, so a
-// refusal looks the same wherever in the auth chain it came from.
-func unauthorized(w http.ResponseWriter, message string) {
+// refusal looks the same wherever in the auth chain it came from, and records
+// on the request's span which way that was.
+//
+// The two happen together, in one function, on purpose. The span attribute is
+// the only account of a 401 that survives the request - telemetry.Middleware
+// never runs on this path - so a refusal path added later that wrote the body
+// without stamping the span would be invisible in exactly the way this change
+// exists to fix. Taking the reason as a parameter alongside the message makes
+// that omission impossible rather than merely discouraged.
+//
+// The request is here only to reach the span through its context; nothing about
+// the response depends on it.
+func unauthorized(w http.ResponseWriter, r *http.Request, reason, message string) {
+	telemetry.SetAuthFailureReason(r.Context(), reason)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
 	_, _ = w.Write([]byte(`{"message":"` + message + `"}`))

--- a/netlify-functions/recipes/internal/pkg/app/app_test.go
+++ b/netlify-functions/recipes/internal/pkg/app/app_test.go
@@ -15,6 +15,12 @@ import (
 	"time"
 
 	"recipes/internal/pkg/common"
+	"recipes/internal/pkg/telemetry"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/danielgtaylor/huma/v2"
 	// Registered for its side effect only, so sql.Open("mysql", ...) above has
@@ -578,4 +584,107 @@ func TestTheSpanTolerantlyHasNoSubjectBeforeAuth(t *testing.T) {
 	if got := userSub(httptest.NewRequest(http.MethodGet, testBase+"/health", nil)); got != "" {
 		t.Errorf("userSub with no Caller = %q, want empty", got)
 	}
+}
+
+// A refused request must say on its span *why* it was refused.
+//
+// The gap this closes: telemetry.Middleware, which puts user.sub on the span,
+// runs after the auth pair and so never runs on a 401 at all. That left a
+// refusal as a span with the otelhttp attributes and nothing else - and since
+// `{"message":"JWT is missing."}` and `{"message":"JWT is invalid."}` are both
+// exactly 29 bytes, http.response.body.size could not separate them either. In
+// Grafana a 401 was legible as having happened and illegible as to why, which
+// is the state that made an actual production incident - a phone refused on
+// every route while the same account worked on the desktop - undiagnosable from
+// traces.
+//
+// Driven through the whole stack rather than by calling
+// telemetry.SetAuthFailureReason directly, because the assertion worth making
+// is not "the setter sets" - it is that the span is still *reachable* from
+// inside the auth chain. That is the coupling that broke for user.sub twice
+// before (see TestTheSpanCarriesTheAuthenticatedSubject), and it fails silently
+// both times: an attribute nothing sets is indistinguishable from a request
+// that had nothing to say.
+func TestARefusalRecordsItsReasonOnTheSpan(t *testing.T) {
+	t.Run("a missing token", func(t *testing.T) {
+		handler, spans := newTracedRouter(t, func(t *testing.T) {
+			t.Setenv("DISABLE_AUTH", "")
+			t.Setenv("AUTH0_DOMAIN", "tenant.invalid")
+			t.Setenv("AUTH0_AUDIENCE", testAudience)
+		})
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, testBase+"/shopping-list", nil))
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+		assertOneSpanWithReason(t, spans, reasonTokenMissing)
+	})
+
+	// The fail-closed path, and the one where the attribute earns the most: an
+	// API with no Auth0 environment refuses every request, which from a
+	// dashboard is indistinguishable from every caller suddenly being wrong.
+	t.Run("an unconfigured deployment", func(t *testing.T) {
+		handler, spans := newTracedRouter(t, func(t *testing.T) {
+			t.Setenv("DISABLE_AUTH", "")
+			t.Setenv("AUTH0_DOMAIN", "")
+			t.Setenv("AUTH0_AUDIENCE", "")
+		})
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, testBase+"/shopping-list", nil))
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", rec.Code)
+		}
+		assertOneSpanWithReason(t, spans, reasonUnconfigured)
+	})
+}
+
+// newTracedRouter builds the real negroni stack wrapped in the same
+// telemetry.Handler main.go wraps it in, over a recording TracerProvider.
+//
+// The provider is installed globally and restored afterwards because
+// otelhttp.NewHandler resolves it through otel.GetTracerProvider() at
+// construction time and telemetry.Handler exposes no way to pass one in.
+// Registered before the handler is built, for the same reason.
+func newTracedRouter(t *testing.T, env func(*testing.T)) (http.Handler, *tracetest.SpanRecorder) {
+	t.Helper()
+	env(t)
+
+	spans := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spans))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() { otel.SetTracerProvider(previous) })
+
+	application, err := NewApp(&common.Env{})
+	if err != nil {
+		t.Fatalf("NewApp() error = %v", err)
+	}
+	router, api, err := application.GetRouter(testBase)
+	if err != nil {
+		t.Fatalf("GetRouter() error = %v", err)
+	}
+	return telemetry.Handler(router, testBase, RouteTemplates(api)), spans
+}
+
+func assertOneSpanWithReason(t *testing.T, spans *tracetest.SpanRecorder, want string) {
+	t.Helper()
+
+	ended := spans.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("recorded %d spans, want exactly 1", len(ended))
+	}
+
+	for _, attr := range ended[0].Attributes() {
+		if attr.Key == attribute.Key("auth.failure_reason") {
+			if got := attr.Value.AsString(); got != want {
+				t.Errorf("auth.failure_reason = %q, want %q", got, want)
+			}
+			return
+		}
+	}
+	t.Errorf("span carries no auth.failure_reason; a 401 is illegible without it")
 }

--- a/netlify-functions/recipes/internal/pkg/telemetry/http.go
+++ b/netlify-functions/recipes/internal/pkg/telemetry/http.go
@@ -126,6 +126,28 @@ func SetAccountID(ctx context.Context, accountID int) {
 	trace.SpanFromContext(ctx).SetAttributes(attribute.Int("account.id", accountID))
 }
 
+// SetAuthFailureReason records why the auth chain refused a request, on the
+// span the request already has.
+//
+// This exists because a 401 is the one outcome the rest of this file cannot
+// describe. Middleware runs *after* the auth pair (see app.GetRouter), and a
+// refused request never reaches it - so a 401 span carries the otelhttp
+// attributes and nothing else: no user.sub to say who was refused, and nothing
+// at all to say why. The distinction the API does draw, "JWT is missing."
+// against "JWT is invalid.", lives only in the response body, and the two
+// bodies are both exactly 29 bytes, so not even http.response.body.size can
+// separate them from outside.
+//
+// A classification, not an identifier and emphatically not the token: ADR-0008
+// §1 excludes content, and the values are a closed set of constants declared in
+// package app. On the span only, never on a metric - the set is small enough
+// that a label would be safe, but "why was this refused" is not a property of
+// the duration histogram, and ADR-0008 §2's rule is that a span is where a fact
+// about one request belongs.
+func SetAuthFailureReason(ctx context.Context, reason string) {
+	trace.SpanFromContext(ctx).SetAttributes(attribute.String("auth.failure_reason", reason))
+}
+
 // isTracedRoute reports whether a request should produce a server span. Every
 // route does, except the health check - see healthRoute.
 //


### PR DESCRIPTION
## The gap

`telemetry.Middleware` — the thing that puts `user.sub` and `account.id` on a span — is registered **after** the auth pair in `GetRouter`, and the JWT middleware terminates the chain on failure. So a refused request produced a span carrying the otelhttp semconv attributes and nothing else.

The distinction the API *does* draw lives only in the response body, and `{"message":"JWT is missing."}` and `{"message":"JWT is invalid."}` are both **exactly 29 bytes** — so `http.response.body.size` could not separate them from outside either.

Net effect: in Grafana a 401 was legible as having happened and illegible as to why. That is what made a real incident undiagnosable from traces — a PWA on an iPhone refused on every route while the same Account worked on desktop, with no way to tell whether it was sending no token, an expired one, or one for the wrong audience. Three causes, three different fixes, and the trace could not choose between them.

## What this adds

`auth.failure_reason`, on every path out of the auth chain:

| Value | Meaning |
| --- | --- |
| `token_missing` | No Authorization header, or none a token could be read from |
| `token_invalid` | A token was present and refused |
| `claims_missing` | Validated, but no usable subject — a configuration fault, not a caller's |
| `auth_unconfigured` | No Auth0 environment, so *every* request is refused |
| `other` | Neither of go-jwt-middleware's exported sentinels. Nothing produces this today |

Which makes this answerable:

```
{ resource.service.name = "bigshop-api" && span.http.response.status_code = 401 }
  | select(span.auth.failure_reason, span.client.address)
```

## Two decisions worth reviewing

**The reason is a parameter of `unauthorized()`**, alongside the message, rather than a separate call at each of the four refusal sites. The span attribute is the only account of a 401 that survives the request, so a path added later that wrote the body without stamping the span would be invisible in exactly the way this change exists to fix. Making that omission impossible beat making it discouraged.

**`token_invalid` is deliberately coarse.** go-jwt-middleware collapses expiry, audience, issuer, signature and unknown-kid into `ErrJWTInvalid` before this code sees it. Inventing a finer distinction would mean putting a value on the span that nothing can be trusted to set correctly.

Span only, never a metric (ADR-0008 §2). A classification, not an identifier and not the token (§1).

## Testing

The new test drives a request through the whole negroni stack wrapped in the same `telemetry.Handler` `main.go` uses, under a recording `TracerProvider`, rather than calling the setter directly. The assertion worth making is not "the setter sets" — it is that the span is still *reachable* from inside the auth chain. That is the coupling that silently broke `user.sub` twice before (see `TestTheSpanCarriesTheAuthenticatedSubject`), and both times the symptom was an attribute that was simply absent, which is indistinguishable from a request that had nothing to say.

`gofmt`, `go vet`, `go test ./...` and the `docs/openapi.yaml` drift check all run clean locally. No user-visible surface, so no screenshots.

## Follow-up filed

[The app believes you are logged in while every API call 401s](https://app.notion.com/p/3c3c724ecda181dc9ad3cf9ef2584c0b) — the other half of this incident. `useRecipes` returns `data ?? []` and never reads `error`, so a 401 renders as an empty Account rather than as a failure, and because TanStack captures the rejection it never reaches `console.error` and Faro never sees it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)