### PR TITLE
Fail Deploy API when the machines don't take the release

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -90,3 +90,30 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           SERVICE_VERSION: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      # The step above exiting 0 does not mean anything was deployed. flyctl
+      # creates a release and hands it to flyd; flyd can fail to apply it and
+      # revert the machine to its last working config, after which flyctl sees a
+      # started, healthy machine and reports success. That is not hypothetical -
+      # it froze production for a day in August 2026 while eleven consecutive
+      # runs of this workflow reported success. The script says how, and why no
+      # field on the release record can be read instead.
+      #
+      # A step in *this* job rather than a separate workflow, for three reasons.
+      # A run's conclusion is per-run, so only a step here can make Deploy API
+      # itself red - a second workflow would leave this one green, which is the
+      # exact failure being fixed. The `concurrency` group above serialises
+      # deploys, and a separate workflow would sit outside it, free to verify
+      # against a release a queued deploy had already superseded. And this job
+      # is deliberately the only holder of FLY_API_TOKEN.
+      #
+      # Distinct from the deploy step, though, because the two failures want
+      # different responses: a red Deploy is flyctl failing (build, token,
+      # timeout), a red Verify is flyctl succeeding while the machines refuse
+      # the config.
+      # No working-directory: the script cd's to the module holding fly.toml
+      # itself, so it behaves the same run from a workflow, a laptop or a hook.
+      - name: Verify the machines took the release
+        run: ./scripts/verify-fly-release.sh
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/scripts/verify-fly-release.sh
+++ b/scripts/verify-fly-release.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Assert that the Fly machines are actually running the release that was just
+# deployed, and fail the run when they are not.
+#
+# **Why this exists: a green `flyctl deploy` is not evidence of a deploy.**
+# Between 2026-08-20 and 2026-08-21 every run of .github/workflows/deploy-api.yml
+# reported success while the machines kept a day-old image and a day-old `[env]`.
+# The mechanism is that flyctl and flyd are two processes: flyctl creates a
+# release and asks flyd to apply it, flyd fails to apply it and *reverts* the
+# machine to the last config that started cleanly, and flyctl then sees a
+# started, healthy machine and exits 0. The revert appears only in the machine's
+# own event log:
+#
+#   started   | revert | flyd | 2026-08-21T20:38:30.383+01:00
+#   replacing | update | user | 2026-08-21T20:38:27.65+01:00
+#
+# The cause that time was a secret declared in machine_config.json under a name
+# that did not exist in `fly secrets` (SENDGRID_API_KEY vs the SENGRID_API_KEY
+# that was actually set). Any config flyd cannot apply does the same thing, so
+# this checks the outcome rather than that one cause.
+#
+# **Nothing on the release record can substitute for this.** All 25 releases in
+# the app's history - the eleven reverted ones included - report
+# `Status: complete`, `InProgress: false` and `Stable: false`. Those fields are
+# vestiges of Apps V1, where a deploy was a Nomad rollout with a state machine;
+# on Apps V2 nothing fills them in, so they are constants rather than signals.
+# `Stable` is false on releases that demonstrably took. The machines are the
+# only thing worth asking.
+#
+# Read-only: it lists releases and machines and writes nothing.
+set -euo pipefail
+cd "$(dirname "$0")/../netlify-functions/recipes"
+
+# `-c fly.toml` from this directory, rather than `-a big-shop-api`, so the app
+# name lives in exactly one place - the same file the deploy step passes.
+fly_args=(--config fly.toml --json)
+
+# The release flyctl just created. Read purely as "the number and image to
+# expect on the machines" - see above for why its own status means nothing.
+# Safe to take the newest without a race: the workflow's `concurrency` group
+# serialises deploys, so no second one can have released while this ran.
+release=$(flyctl releases "${fly_args[@]}")
+want_version=$(jq -r '.[0].Version'  <<<"$release")
+want_image=$(jq -r   '.[0].ImageRef' <<<"$release")
+
+if [ -z "$want_version" ] || [ "$want_version" = null ]; then
+  echo "::error::could not read the current release from flyctl"
+  exit 1
+fi
+echo "Expecting release $want_version on $want_image"
+
+# Polled rather than asked once. `flyctl deploy` has already waited for the
+# machines to become healthy, so this is covering read-after-write lag in Fly's
+# API and nothing else - hence a short bound. It is deliberately not a
+# retry-until-green: a machine that has not converged within a minute of a
+# finished deploy is the failure this script is for.
+attempts=6
+for attempt in $(seq 1 "$attempts"); do
+  bad=0
+  seen=0
+
+  # Fields, in order: machine id, its state, its process group, the release its
+  # config claims, and the image that config runs.
+  #
+  # `fly_release_version` is checked as well as the image because a release does
+  # not have to change the image to be a release - `fly secrets set` makes one,
+  # and so does a redeploy of unchanged source. Several consecutive releases in
+  # this app's history share one ImageRef. Against those, an image comparison
+  # passes whether or not the config applied, because the machine was already
+  # running that image. The release version always moves.
+  while IFS=$'\t' read -r id state group version image; do
+    [ "$group" = app ] || continue
+    seen=$((seen + 1))
+
+    [ "$state" = started ] ||
+      { echo "  machine $id: state is $state, want started"; bad=1; }
+    [ "$version" = "$want_version" ] ||
+      { echo "  machine $id: on release ${version:-none}, want $want_version"; bad=1; }
+    [ "$image" = "$want_image" ] ||
+      { echo "  machine $id: running ${image:-none}, want $want_image"; bad=1; }
+  done < <(flyctl machines list "${fly_args[@]}" | jq -r '.[] |
+    [ .id,
+      .state,
+      (.config.metadata.fly_process_group   // ""),
+      (.config.metadata.fly_release_version // ""),
+      (.config.image                        // "") ] | @tsv')
+
+  # A filter that matches nothing is how an assertion quietly stops asserting.
+  # There is always at least one machine in the `app` group; none means the
+  # process group was renamed, or the query returned something unexpected, and
+  # either way this script no longer knows what it is checking.
+  if [ "$seen" -eq 0 ]; then
+    echo "::error::no machines found in process group 'app' - this check is not"
+    echo "::error::verifying anything. Compare fly.toml's process groups with"
+    echo "::error::'flyctl machines list --config fly.toml'."
+    exit 1
+  fi
+
+  if [ "$bad" -eq 0 ]; then
+    echo "OK: all $seen machines are running release $want_version."
+    exit 0
+  fi
+
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "  (attempt $attempt of $attempts; re-checking in 10s)"
+    sleep 10
+  fi
+done
+
+echo "::error::The machines did not take release $want_version, though flyctl"
+echo "::error::reported a successful deploy. The most likely cause is that flyd"
+echo "::error::could not apply the new config and reverted it - check for a"
+echo "::error::'revert' event in 'flyctl machine status <id>'."
+echo "::error::"
+echo "::error::The usual reason is a secret named in machine_config.json that"
+echo "::error::does not exist in 'flyctl secrets list', including by typo. Note"
+echo "::error::the app is still serving the OLD image and the OLD fly.toml"
+echo "::error::[env] - nothing from this deploy has reached production."
+exit 1


### PR DESCRIPTION
Closes the "Still open: a green deploy proves nothing" half of [Deploy API reports success while the machines keep a stale image and env](https://www.notion.so/Deploy-API-reports-success-while-the-machines-keep-a-stale-image-and-env-3c3c724ecda1819d882bf5702c3c9718). The incident itself is fixed; the thing that hid it for a day was not.

## The problem

flyctl and flyd are two processes. flyctl creates a release and asks flyd to apply it; flyd can fail to apply it and **revert** the machine to the last config that started cleanly; flyctl then sees a started, healthy machine and exits 0. The revert appears only in the machine's own event log:

```
started   | revert | flyd | 2026-08-21T20:38:30.383+01:00
replacing | update | user | 2026-08-21T20:38:27.65+01:00
```

Eleven consecutive runs of this workflow reported success that way while production sat on a day-old image and a day-old `fly.toml` `[env]`, 401ing every authenticated request against the pre-cutover Auth0 issuer.

## What this adds

A `Verify the machines took the release` step that asks the machines what they are running and fails the run when it isn't the release just deployed.

**No field on the release record could have been read instead.** Across the app's entire history:

| | |
| --- | --- |
| total releases | 25 |
| `Stable` | `false` × 25 |
| `Status` | `complete` × 25 |
| `InProgress` | `false` × 25 |
| `DeploymentStrategy` | `""` × 25 |

`Stable` is `false` on releases that demonstrably took, including the one running right now. These are Apps V1 (Nomad) vestiges — a rollout state machine that Apps V2 doesn't have — so nothing fills them in. The machines are the only thing worth asking.

Three details worth the review time:

- **It checks `fly_release_version` as well as the image.** A release doesn't have to change the image to be a release — `fly secrets set` makes one, and several consecutive releases in this app's history share an `ImageRef`. Against those, an image comparison passes whether or not the config applied, because the machine was already running that image.
- **It fails when no machine matches the `app` process group**, rather than vacuously passing. A filter that matches nothing is how an assertion quietly stops asserting.
- **The retry is bounded at six attempts over a minute** and covers read-after-write lag in Fly's API only — `flyctl deploy` has already waited for health. It is deliberately not a retry-until-green.

## Why a step in this job, not a separate workflow

A run's conclusion is per-run, so only a step here can make Deploy API *itself* red — a separate workflow leaves this one green, which is the exact failure being fixed. The `concurrency: deploy-api` group serialises deploys and a separate workflow would sit outside it, free to verify against a release a queued deploy had already superseded. And this job is deliberately the only holder of `FLY_API_TOKEN`.

Kept distinct from the `Deploy` step because the failures want different responses: a red Deploy is flyctl failing (build, token, timeout); a red Verify is flyctl succeeding while the machines refuse the config.

## Testing

Neither required check exercises this — `deploy-api.yml` only runs on `workflow_run` from CI on `master` — so all three paths were driven by hand against the live app, read-only:

```
$ ./scripts/verify-fly-release.sh
Expecting release 70 on registry.fly.io/big-shop-api:deployment-01M0MM3S9XEG23NHS2713BQADZ
OK: all 2 machines are running release 70.                                    # exit 0
```

```
$ # forcing the expected release to 999
Expecting release 999 on registry.fly.io/big-shop-api:deployment-01M0MM3S9XEG23NHS2713BQADZ
  machine 781231dbe99298: on release 70, want 999
  machine 683e161a42d928: on release 70, want 999
  (attempt 1 of 6; re-checking in 10s)
  ...
::error::The machines did not take release 999, though flyctl
::error::reported a successful deploy. The most likely cause is that flyd
::error::could not apply the new config and reverted it - check for a
::error::'revert' event in 'flyctl machine status <id>'.                      # exit 1
```

```
$ # forcing the process group filter to match nothing
::error::no machines found in process group 'app' - this check is not
::error::verifying anything.                                                  # exit 1
```

No user-visible surface, so no screenshots.

## Not in this PR

Two things found while investigating, both filed separately rather than widening this change:

1. **`AUTH0_MGMT_CLIENT_ID` and `AUTH0_MGMT_CLIENT_SECRET` are set as Fly secrets but declared in no container in `machine_config.json`** — a live, fourth instance of the trap `fly.toml` documents. `erasure.go`'s `auth0Configured()` therefore returns false in production, so account deletion is silently skipping the Auth0 identity: the exact bug #59 existed to fix.
2. **A pre-deploy reconciliation of `machine_config.json` against `fly secrets list`**, in both directions. That would have caught the original `SENGRID_API_KEY` typo *before* deploying, where this PR catches its consequence after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)