### PR TITLE
Declare AUTH0_MGMT_* so account deletion can reach Auth0

### DIFF
--- a/netlify-functions/recipes/fly.toml
+++ b/netlify-functions/recipes/fly.toml
@@ -87,7 +87,7 @@ primary_region = "fra"
 #     docs/fly-migration-runbook.md used to imply it went. See the note by the
 #     value itself.
 #
-# Three are secrets, set out-of-band with `fly secrets set` (see
+# Five are secrets, set out-of-band with `fly secrets set` (see
 # docs/fly-migration-runbook.md) and deliberately absent from this file:
 #
 #   TIDB_PASSWORD     - the database password, and now the *only* part of the
@@ -104,6 +104,21 @@ primary_region = "fra"
 #                       that it was set but undeclared, and HashEmail quietly
 #                       degraded to a plain SHA-256. The worked example of the
 #                       trap above.
+#   AUTH0_MGMT_CLIENT_ID / AUTH0_MGMT_CLIENT_SECRET - the machine-to-machine
+#                       credentials erasure.go exchanges for a Management API
+#                       token, to delete the Auth0 identity when an Account is
+#                       deleted. Set when #59 shipped (a705081, 2026-08-20) and
+#                       declared by nobody, so for the two days between that and
+#                       this line auth0Configured() (erasure.go) saw two empty
+#                       strings and returned false in production. Deletion went
+#                       on removing every database row while silently skipping
+#                       the identity - the precise bug #59 existed to fix, so a
+#                       deleted user could still log in, resolving to nothing.
+#
+#                       Note the irony of the dates: a705081 is also the config
+#                       the machines were frozen on while the deploys reverted,
+#                       so this is one gap the freeze did not cause and did not
+#                       hide. It was undeclared from the first minute it ran.
 #
 # DISABLE_AUTH must never be set here. It is a local-development
 # switch that makes the API resolve every request to DEV_USER_ID without

--- a/netlify-functions/recipes/machine_config.json
+++ b/netlify-functions/recipes/machine_config.json
@@ -5,7 +5,9 @@
       "secrets": [
         { "env_var": "TIDB_PASSWORD" },
         { "env_var": "SENDGRID_API_KEY" },
-        { "env_var": "INVITE_EMAIL_PEPPER" }
+        { "env_var": "INVITE_EMAIL_PEPPER" },
+        { "env_var": "AUTH0_MGMT_CLIENT_ID" },
+        { "env_var": "AUTH0_MGMT_CLIENT_SECRET" }
       ],
       "env": {
         "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318"


### PR DESCRIPTION
Fixes [AUTH0_MGMT_* are set as Fly secrets but declared in no container](https://app.notion.com/p/3c4c724ecda181249646e4fe13c834de). Found while investigating the deploy-verification work in #137; filed separately because it is a different bug with a different blast radius.

## The fault

`erasure.go` reads `AUTH0_MGMT_CLIENT_ID` and `AUTH0_MGMT_CLIENT_SECRET` to exchange client credentials for an Auth0 Management API token. `auth0Configured()` gates the entire Auth0 half of account deletion on both being non-empty.

Both are set on the app:

```
$ flyctl secrets list
AUTH0_MGMT_CLIENT_ID       Deployed
AUTH0_MGMT_CLIENT_SECRET   Deployed
```

Neither was declared in any container in `machine_config.json`. Under `[experimental] machine_config` a container receives **only** the secrets it names, so both have been empty strings at runtime since `a705081` (#59, 2026-08-20). `auth0Configured()` has been returning false in production ever since.

**The consequence is that account deletion has been removing every database row while silently skipping the Auth0 identity** — so a deleted user can still log in, resolving to nothing. That is precisely the bug #59 existed to fix, reintroduced by the half of the change that lives outside the Go code.

Confirmed against the running machines, not just the file: the live `containers[api]` config carries exactly `TIDB_PASSWORD`, `SENDGRID_API_KEY`, `INVITE_EMAIL_PEPPER`.

## The change

Two entries in the `api` container's `secrets` array, plus the explanation in `fly.toml`'s comment block, which documents this trap and until now said "three are secrets".

This is the fourth instance of that trap and its **silent** direction. Declared-but-unset reverts the whole deploy loudly — that is what froze production for a day, and what #137 now catches. Set-but-undeclared degrades one feature with nothing reporting anything, which is how this sat unnoticed while a much noisier instance of the same trap was being investigated two files away.

Worth noting on the dates: `a705081` is *also* the config the machines were frozen on during that incident. So this is one gap the freeze neither caused nor hid — it was undeclared from the first minute it ran.

## Verification

`flyctl config validate` passes, and the JSON parses with all eight declarations across both containers.

Nothing here can be proven before it deploys, because the fault is entirely in what the runtime receives. **After merge, this needs checking rather than assuming**: delete a throwaway account and confirm the Auth0 user is actually gone. #137's post-deploy assertion (if merged first) will confirm the machines took the release; it cannot confirm the credential now resolves.

No user-visible surface changes, so no screenshots.

## Checked but deliberately not changed

`NETLIFY_PURGE_TOKEN` / `NETLIFY_SITE_ID` and `SITE_URL` are also read by the Go process and also unset — but all three are optional by design (`purge.New` documents the no-op Purger as the sane default; `SiteURL()` falls back to `defaultSiteURL`). Only the `AUTH0_MGMT_*` pair fails silently in a way that matters. Whether edge purging is *meant* to be on in production is a separate question worth asking, not a bug to fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)