### PR TITLE
Repair a stale dev database instead of reporting it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,43 @@ This runs `scripts/dev-full.sh`, which:
   directory is no longer empty — producing a Healthy container with exactly
   the broken schema the check rejected. **Fixing the migration is not enough
   on its own for the same reason: the replay only runs against an empty data
-  directory, so recreate the volume** (`docker compose down -v`).
+  directory, so the volume has to be recreated** — which `npm run dev:full`
+  now does for you (below).
+
+  **A volume that is merely *behind* is repaired automatically, and you should
+  never need to run `docker compose down -v` by hand.** The replay above runs
+  exactly once in a volume's life, so it could not catch this: `ok = 1` is a
+  statement about the day the volume was created and stays 1 forever, meaning
+  a volume that predates a migration reported Healthy while serving a schema
+  with holes in it. The symptom was an application-looking 500, not a schema
+  error.
+
+  Two things now close that. The init script records *which* migrations it
+  replayed on `_migration_status`, and the healthcheck compares that set
+  against `./migrations` (bind-mounted into the container) on every check, so
+  `api` refuses to start against a stale schema through the same mechanism
+  that already protects it from a broken one. And `scripts/ensure-db-current.sh`
+  — run by `dev-full.sh` before anything waits on health, and by
+  `sync-from-prod.sh` before it imports — *repairs* the drift rather than
+  reporting it: it dumps the volume's data out of the running container, drops
+  the volume, lets the init path replay and seed, and restores the data. On a
+  volume that is already current it is one `SELECT` and prints nothing.
+
+  The premise is that **the dev database volume is a cache, not a store of
+  record**: everything in it is reconstructible from `migrations/*.sql`,
+  `docker/mysql-seed/dev-seed.sql` and a dump on the host. `sync-from-prod.sh`
+  already worked this way — it truncates and reimports on every run, and its
+  `--no-create-info --complete-insert` exists precisely so production's rows
+  can land in a *local* schema that is ahead of production.
+
+  **The one case that still needs you** is a migration that rewrites rows
+  rather than schema (`022`, `023`, `029`, `031` are of this kind). The
+  restore puts your old rows back as they were, so a fixup that migration
+  would have applied stays unapplied locally. The script warns when it sees
+  one, and the fix is `scripts/sync-from-prod.sh` — production has had the
+  migration applied properly. If the restore fails outright (a new column or
+  constraint the old rows cannot satisfy) the database is rebuilt clean, and
+  the dump is kept and named so nothing is lost.
 - Brings up `lgtm` (`grafana/otel-lgtm` — Collector, Tempo, Loki, Prometheus
   and Grafana in one image), the local stand-in for the Grafana Cloud stack.
   Grafana is on **3200**, not 3000 — the web app keeps 3000. The API exports

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,24 +39,67 @@ services:
       #
       # Unhealthy here means: `docker compose logs db`, then
       # `docker compose down -v && docker compose up -d db` once fixed.
-      # 3. A data directory created before _migration_status existed is not a
-      #    failure. The script creates that table before it applies anything,
-      #    so on any volume it has ever run, the table is there - absence means
-      #    the volume predates this check entirely. The entrypoint will never
-      #    re-run migrations on it (non-empty data directory), so there is
-      #    nothing for the check to check, and it falls back to the plain ping
-      #    this healthcheck used to be. Without that, upgrading turned every
-      #    existing developer's database unhealthy and the only way out was
-      #    `down -v`, which throws away a synced copy of production.
+      # 3. The migrations that applied are the ones the repo has. (2) only ever
+      #    spoke about the day the volume was created: the entrypoint runs
+      #    docker-entrypoint-initdb.d exactly once, when the data directory is
+      #    empty, so `ok = 1` is frozen from then on. Add a migration and every
+      #    existing volume is silently behind, with this healthcheck asserting
+      #    the opposite - the check cannot run, precisely because the volume is
+      #    stale. So the script now also records the basenames it replayed, and
+      #    this compares them against ./migrations, which is already bind-mounted
+      #    here read-only. `api` therefore refuses to start against a schema that
+      #    is merely out of date, through the same mechanism that already
+      #    protects it from one a migration failed to build.
+      #
+      #    A volume with no _migration_status row, no `applied` column or a NULL
+      #    value fails too. This reverses the earlier version of this comment,
+      #    which fell back to a plain ping on an unrecorded volume so that
+      #    upgrading would not turn every existing database unhealthy - the cost
+      #    of the only remedy then available being a `down -v` that "throws away
+      #    a synced copy of production". scripts/ensure-db-current.sh has since
+      #    made the remedy automatic and non-destructive, so that cost is gone;
+      #    and an unrecorded volume is exactly the one most likely to be stale,
+      #    so trusting it was blind in the worst possible place.
+      #
+      #    This detects and refuses; it never repairs. A healthcheck must be
+      #    side-effect-free, and it has nowhere to put a dump. The repair lives
+      #    in ensure-db-current.sh, which dev-full.sh runs *before* anything
+      #    waits on this. Keeping the check here as well is what covers someone
+      #    running a bare `docker compose up -d db api` around the wrapper.
+      #
+      # Unhealthy here means: `npm run dev:full`, which repairs both cases (or
+      # tells you which migration is broken). `docker compose logs db` for why.
       test:
         - CMD-SHELL
         - >-
-          if mysql -h 127.0.0.1 -uroot -proot -N -B -e "SELECT ok FROM bigshop._migration_status WHERE id = 1" 2>/dev/null | grep -qx 1; then exit 0; fi;
-          if mysql -h 127.0.0.1 -uroot -proot -N -B -e "SELECT 1 FROM bigshop._migration_status LIMIT 0" >/dev/null 2>&1; then exit 1; fi;
-          mysqladmin ping -h 127.0.0.1 -uroot -proot
+          expected="$$(cd /migrations && ls -1 *.sql | sort | tr '\n' '@')";
+          mysql -h 127.0.0.1 -uroot -proot -N -B
+          -e "SELECT 1 FROM bigshop._migration_status WHERE id = 1 AND ok = 1
+          AND REPLACE(applied, CHAR(10), '@') = '$$expected'"
+          2>/dev/null | grep -qx 1
       interval: 5s
       timeout: 5s
-      retries: 20
+      # 20 before start_period existed, because the retry budget was doubling as
+      # the window for the initial replay. That is what start_period is for, and
+      # once the check has succeeded once, retries only ever delays *noticing*.
+      # 5 keeps a transient hiccup from flapping the container while still
+      # reporting drift within half a minute.
+      retries: 5
+      # The replay of every migration plus the seed happens inside this window on
+      # a fresh volume, and it is longer than retries x interval. Failures during
+      # it are expected and must not count towards `retries`. Docker ends the
+      # period early on the first success, so this costs nothing on a volume that
+      # is already good - a fresh one here reports healthy in about 12 seconds,
+      # and this is 5x that for a slower machine.
+      #
+      # Sized down rather than up, because it is also how long a *stale* volume
+      # sits in `starting` before it admits to being unhealthy: the two cases are
+      # indistinguishable to a healthcheck, which has only pass and fail to say
+      # it with. That delay is only ever paid by someone running a bare
+      # `docker compose up -d db api` - through dev-full.sh or sync-from-prod.sh,
+      # ensure-db-current.sh has already repaired the drift before anything waits
+      # on health at all.
+      start_period: 60s
 
   # Collector, Tempo, Loki, Prometheus and Grafana in one image - the local
   # stand-in for the Grafana Cloud stack, so no cloud credentials exist outside

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,6 +7,15 @@ runs everything in `mysql-init/` automatically, which applies
 synthetic recipes, just enough to exercise every page. That happens once per
 volume - it doesn't re-run on every `docker compose up` (see `CLAUDE.md`).
 
+Because it happens once per volume, a volume created before a migration was
+added would otherwise go on serving a schema without it. `dev:full` therefore
+runs `../scripts/ensure-db-current.sh` first, which notices and repairs that:
+it dumps the volume's data (to `prod-dumps/pre-rebuild-<timestamp>.sql`),
+recreates the volume so the init path replays every migration, and restores
+the data on top. Silent and instant when there is nothing to do. **You should
+not need to run `docker compose down -v` by hand**, and the sync described
+below goes through the same check before it imports.
+
 This doc covers the alternative: pulling in your own real recipes from
 production instead of the two made-up ones.
 
@@ -41,6 +50,12 @@ script, only the recipe-related tables.
 **Heads up**: importing replaces the local `recipe`, `part`, `recipe_tag`,
 `ingredient`, `unit`, `tag`, and `department` tables entirely. Any test
 recipes you'd added locally through the app are gone after this runs.
+
+This is also why a rebuild by `ensure-db-current.sh` is not the data loss it
+sounds like: this script already treats the local copy as disposable and
+reproducible, and step 3 leaves a replayable dump on the host, outside the
+volume. What a rebuild preserves that this script does not is local-only data
+you made through the app.
 
 ## Before running it: find your account id
 

--- a/docker/mysql-init/01-migrate-and-seed.sh
+++ b/docker/mysql-init/01-migrate-and-seed.sh
@@ -26,12 +26,28 @@ sql bigshop -e "
     \`id\` tinyint NOT NULL,
     \`ok\` tinyint(1) NOT NULL COMMENT '1 only if every migration applied as expected and the seed loaded',
     \`detail\` text COMMENT 'the unexpected errors, when ok = 0',
+    \`applied\` text COMMENT 'the migration basenames this replay applied, sorted, newline-separated',
     \`applied_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (\`id\`)
   ) COLLATE=utf8mb4_bin
     COMMENT 'set by docker/mysql-init/01-migrate-and-seed.sh; read by the db healthcheck';
   REPLACE INTO \`_migration_status\` (id, ok, detail) VALUES (1, 0, 'migrations did not finish');
 "
+
+# The set of migrations this replay is about to apply, recorded so that a later
+# start can tell whether the volume has fallen behind the repo.
+#
+# This is the half of the check that could not exist before: the entrypoint only
+# runs this script when the data directory is empty, so everything above runs
+# exactly once in a volume's life and `ok = 1` is a statement about the day the
+# volume was created. Add a migration and every existing volume is silently
+# behind, with a green healthcheck asserting the opposite. Recording *what* was
+# applied is what lets the healthcheck (and scripts/ensure-db-current.sh) notice.
+#
+# Basenames rather than a checksum, because the comparison has to be able to
+# name the missing files - "11 migrations missing, starting at 034_consent_event"
+# is actionable and "digest mismatch" is not.
+APPLIED="$(cd "$MIGRATIONS" && ls -1 *.sql | sort | tr '\n' '@')"
 
 for f in "$MIGRATIONS"/*.sql; do
   base="$(basename "$f")"
@@ -118,5 +134,7 @@ fi
 echo "Applying dev seed data"
 sql bigshop < /seed/dev-seed.sql
 
-sql bigshop -e "REPLACE INTO \`_migration_status\` (id, ok, detail) VALUES (1, 1, NULL);"
+# ok = 1 and the applied set land in the same statement, deliberately: a volume
+# must never be able to report a migration set it did not finish applying.
+sql bigshop -e "REPLACE INTO \`_migration_status\` (id, ok, detail, applied) VALUES (1, 1, NULL, REPLACE('$APPLIED', '@', CHAR(10)));"
 echo "Migrations and seed applied; _migration_status.ok = 1"

--- a/scripts/dev-full.sh
+++ b/scripts/dev-full.sh
@@ -117,17 +117,26 @@ compose_up_failed() {
   cat >&2 <<'MSG'
 
 docker compose could not bring the stack up. If it reported the db as
-unhealthy, the most likely cause is a migration that failed to apply:
+unhealthy, the cause is a migration that failed to apply - a volume that is
+merely out of date is repaired by scripts/ensure-db-current.sh above, so by
+this point it has been ruled out. The replay says which migration:
 
     docker compose logs db | grep -A20 'not in expected-migration-errors'
 
-Fix the migration, then recreate the volume - the MySQL entrypoint only
-replays migrations when the data directory is empty:
-
-    docker compose down -v && npm run dev:full
+Fix the migration, then run this again. Recreating the volume is handled for
+you: the MySQL entrypoint only replays migrations when the data directory is
+empty, and ensure-db-current.sh is what empties it.
 MSG
   exit 1
 }
+
+# Bring the database's schema up to date before anything waits on it being
+# healthy - the healthcheck now fails on a volume that is behind migrations/,
+# and this is what clears that. Near-instant and silent when there is nothing to
+# do, which is the normal case; see the script's header for what it does when
+# there is. It brings `db` up itself, so it has to run before the compose up
+# below rather than after.
+scripts/ensure-db-current.sh
 
 if [ "$START_LGTM" = "true" ]; then
   echo "Starting local MySQL + Go API + LGTM (docker compose)..."

--- a/scripts/ensure-db-current.sh
+++ b/scripts/ensure-db-current.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+# Make the local dev database's schema match migrations/, repairing it if not.
+#
+# Called by scripts/dev-full.sh before the API comes up, and by
+# scripts/sync-from-prod.sh before it imports. Safe and near-instant to run at
+# any time: on the normal path it is one SELECT and it prints nothing.
+#
+# ---------------------------------------------------------------------------
+# The problem this exists for
+# ---------------------------------------------------------------------------
+# MySQL only runs docker-entrypoint-initdb.d when the data directory is empty.
+# So docker/mysql-init/01-migrate-and-seed.sh - the replay, the reconciliation
+# against expected-migration-errors.txt, the verdict in _migration_status -
+# runs exactly ONCE in a volume's life, on creation.
+#
+# That makes it structurally incapable of catching a volume that has fallen
+# behind: the check does not run, precisely because the volume is stale.
+# `ok = 1` is a statement about the day the volume was created and it stays 1
+# forever. Add a migration and every existing volume is silently behind, with a
+# green healthcheck asserting the opposite. The symptom is not a schema error -
+# it is a 500 from an endpoint touching the missing table, which reads exactly
+# like an application bug. That is how it was found (a worktree volume four
+# days old missing `consent_event` and `email_send`, so GET /user 500'd and
+# every account-scoped page rendered empty).
+#
+# ---------------------------------------------------------------------------
+# Why this repairs rather than reports
+# ---------------------------------------------------------------------------
+# The obvious fix is to detect the drift and tell the developer to run
+# `docker compose down -v`. That is discipline with a reminder bolted on: the
+# human still does the work and still loses their data.
+#
+# It is avoidable because **the dev database volume is a cache, not a store of
+# record.** Everything in it is reconstructible from three things that live
+# outside it: migrations/*.sql, docker/mysql-seed/dev-seed.sql, and a dump
+# taken on the host. So this script dumps the volume's data out of the running
+# container (no password, no network - it is talking to a local container as
+# root), destroys the volume, lets the existing init path replay and seed, and
+# puts the data back.
+#
+# Note that scripts/sync-from-prod.sh already took this view: it truncates
+# eight tables and reimports on every run, saves a replayable dump to
+# docker/prod-dumps/, and passes --no-create-info --complete-insert precisely
+# so prod's data can land in a *local* schema that is ahead of production. It
+# assumes the local schema is current, which means a stale volume does not only
+# break `npm run dev:full` - it breaks the sync script too. Hence the call from
+# there as well.
+#
+# ---------------------------------------------------------------------------
+# What this does NOT do
+# ---------------------------------------------------------------------------
+# Apply the missing migrations to the live volume. That needs a real migration
+# runner with idempotency and ordering guarantees, and these migrations are not
+# written to be re-runnable - expected-migration-errors.txt exists because they
+# are replayed wholesale against an empty schema.
+#
+# One honest limit of restoring instead: the restore reproduces the *state* of
+# the local data, not its *history*. That is fine for a DDL migration. It is
+# not fine for a data-fixup migration (022, 023, 029_merge_duplicate_ingredients,
+# 031_backfill_recipe_method are all of this kind), where putting the old rows
+# back on top can reinstate exactly what the new migration removed. Production
+# has had that migration applied properly, so the escape hatch is
+# scripts/sync-from-prod.sh - and this script says so when it sees one coming.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO_ROOT="$(pwd -P)"
+
+DUMP_DIR="docker/prod-dumps"
+
+# MYSQL_PWD rather than -p on the argv, for the reason sync-from-prod.sh gives:
+# mysql emits "[Warning] Using a password on the command line interface can be
+# insecure." on stderr for every invocation, and this script captures stderr to
+# report a failed restore - so the warning would appear inside the error message
+# as though it were part of the problem.
+mysql_in_db() {
+  docker compose exec -T -e MYSQL_PWD=root db mysql -h 127.0.0.1 -uroot "$@"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Get the db container up and answering, but do NOT wait for healthy.
+# ---------------------------------------------------------------------------
+# Healthy is exactly what a stale volume is not - docker-compose.yml's
+# healthcheck now fails on drift - so waiting for it here would deadlock on the
+# condition this script exists to clear. A plain ping is the right readiness
+# signal, and -h 127.0.0.1 (not "localhost") for the reason the healthcheck
+# comment gives at length: "localhost" means the Unix socket, which the
+# temporary --skip-networking mysqld used during init also binds.
+# Output captured rather than discarded: compose writes its progress lines to
+# stderr, and on the normal path this script must print nothing at all. A real
+# failure here still needs to be seen.
+if ! compose_up_output="$(docker compose up -d db 2>&1)"; then
+  echo "$compose_up_output" >&2
+  exit 1
+fi
+
+# Generous, because on a fresh volume this wait *is* the migration replay: the
+# TCP ping only succeeds once the real networked mysqld is up, which is after
+# docker-entrypoint-initdb.d has finished. ~12s on a laptop, and a CI runner is
+# the place where a too-tight bound would fail for no reason.
+for _ in $(seq 1 180); do
+  if docker compose exec -T -e MYSQL_PWD=root db mysqladmin ping -h 127.0.0.1 -uroot --silent >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+if ! docker compose exec -T -e MYSQL_PWD=root db mysqladmin ping -h 127.0.0.1 -uroot --silent >/dev/null 2>&1; then
+  echo "The db container did not become reachable - check 'docker compose logs db'." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Refuse to touch a container belonging to a different worktree.
+# ---------------------------------------------------------------------------
+# This script destroys a volume, unattended. Compose derives its project name
+# from the directory basename, and every worktree of this repo is checked out
+# into a directory called `big-shop` - so a bare `docker compose` from worktree
+# B can silently resolve to worktree A's already-running containers (CLAUDE.md
+# documents this at length for the dev stack). Automating a destructive command
+# that can land on the wrong stack is worse than the bug it fixes.
+#
+# The bind mount is the reliable discriminator: whichever project we resolved
+# to, `/migrations` in that container points at the source tree that started
+# it. If it is not this one, stop.
+CID="$(docker compose ps -q db)"
+MOUNTED_MIGRATIONS="$(docker inspect "$CID" \
+  --format '{{range .Mounts}}{{if eq .Destination "/migrations"}}{{.Source}}{{end}}{{end}}')"
+
+# Docker Desktop does not report the host path the daemon was given. It reports
+# the path as seen from inside its own Linux VM, where the host filesystem is
+# mounted under a fixed prefix - `/host_mnt` on macOS, `/run/desktop/mnt/host`
+# on Windows. So on a Mac this comes back as
+# /host_mnt/Users/you/…/big-shop/migrations and a plain string comparison
+# against the host path fails on every single run.
+#
+# Stripping the known prefixes rather than suffix-matching is deliberate: a
+# suffix match would accept /host_mnt/other/place/big-shop/migrations for a
+# worktree at /place/big-shop, which is exactly the confusion this guard exists
+# to prevent. An unknown prefix is left in place and correctly refused.
+CONTAINER_MIGRATIONS="${MOUNTED_MIGRATIONS#/host_mnt}"
+CONTAINER_MIGRATIONS="${CONTAINER_MIGRATIONS#/run/desktop/mnt/host}"
+
+if [ "$CONTAINER_MIGRATIONS" != "$REPO_ROOT/migrations" ]; then
+  cat >&2 <<MSG
+
+Refusing to continue: the running \`db\` container is not this worktree's.
+
+  this worktree : $REPO_ROOT/migrations
+  the container : ${MOUNTED_MIGRATIONS:-<no /migrations mount>}
+
+Compose resolved to another checkout's project, because it names projects after
+the directory basename and every worktree here is called \`big-shop\`. This
+script would have destroyed that database. Give this worktree its own project:
+
+    COMPOSE_PROJECT_NAME=bigshop-$(basename "$(dirname "$REPO_ROOT")") \\
+      DB_PORT=3309 API_PORT=8081 npm run dev:full
+
+MSG
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Compare the recorded migration set against the repo.
+# ---------------------------------------------------------------------------
+# The '@' round trip keeps the whole set in one batch-mode field: mysql's -B
+# output escapes a real newline to a literal \n, which would then have to be
+# un-escaped here. A migration filename cannot contain '@' (they are all
+# NNN_lower_snake.sql), so nothing is ambiguous. The same substitution is on the
+# writing side in 01-migrate-and-seed.sh and in the healthcheck.
+recorded_raw="$(mysql_in_db -N -B -e \
+  "SELECT REPLACE(applied, CHAR(10), '@') FROM bigshop._migration_status WHERE id = 1" \
+  2>/dev/null || true)"
+
+# Three ways this can be empty, all meaning the same thing: no _migration_status
+# table (a volume predating the whole verdict mechanism), no `applied` column (a
+# volume predating this script), or a NULL value. All are treated as stale,
+# unconditionally.
+#
+# That is a deliberate reversal of the precedent in docker-compose.yml comment
+# 3, which fell back to a plain ping when _migration_status was absent, to avoid
+# turning every existing developer's database unhealthy on upgrade - the cost
+# being a `down -v` that "throws away a synced copy of production". That cost is
+# what has just gone away: the rebuild below is lossless in the normal case. An
+# unrecorded volume is also precisely the volume most likely to be stale, so
+# treating it as current was blind in exactly the wrong place.
+RECORDED="$(mktemp)"
+EXPECTED="$(mktemp)"
+trap 'rm -f "$RECORDED" "$EXPECTED"' EXIT
+
+if [ -n "$recorded_raw" ] && [ "$recorded_raw" != "NULL" ]; then
+  printf '%s' "$recorded_raw" | tr '@' '\n' | grep -v '^$' | sort > "$RECORDED"
+else
+  : > "$RECORDED"
+fi
+
+(cd migrations && ls -1 ./*.sql | sed 's|^\./||') | sort > "$EXPECTED"
+
+if cmp -s "$RECORDED" "$EXPECTED"; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Stale. Say precisely what is missing before doing anything destructive.
+# ---------------------------------------------------------------------------
+missing="$(comm -13 "$RECORDED" "$EXPECTED")"
+removed="$(comm -23 "$RECORDED" "$EXPECTED")"
+
+echo
+echo "The local database is behind migrations/."
+if [ -s "$RECORDED" ]; then
+  if [ -n "$missing" ]; then
+    echo "  missing: $(echo "$missing" | wc -l | tr -d ' ') migration(s)"
+    echo "$missing" | sed 's/^/    + /'
+  fi
+  if [ -n "$removed" ]; then
+    echo "  applied but no longer in the repo:"
+    echo "$removed" | sed 's/^/    - /'
+  fi
+else
+  echo "  It records no migration set at all, so its contents are unknowable."
+fi
+echo "Rebuilding it. Local data is dumped first and restored afterwards."
+
+# The data-fixup warning. A migration that only creates or alters tables is
+# replayed onto an empty schema and the restored rows are unaffected. A
+# migration that rewrites *rows* is not: the fresh volume applies it to seed
+# data, and then the restore drops pre-fix rows back on top. Nothing can detect
+# this reliably, so this is a heuristic on the leading keyword and it errs
+# towards mentioning it.
+if [ -n "$missing" ]; then
+  fixups=""
+  while IFS= read -r m; do
+    [ -n "$m" ] || continue
+    if grep -qiE '^[[:space:]]*(UPDATE|DELETE|INSERT)[[:space:]]' "migrations/$m"; then
+      fixups="${fixups}${m}"$'\n'
+    fi
+  done <<< "$missing"
+
+  if [ -n "$fixups" ]; then
+    cat <<MSG
+
+  Note: these change rows, not just schema -
+
+$(echo "$fixups" | grep -v '^$' | sed 's/^/      /')
+
+  The restore puts your existing rows back as they are, so anything one of
+  those would have corrected stays uncorrected locally. Production has had
+  them applied properly, so if the data looks wrong afterwards:
+
+      scripts/sync-from-prod.sh
+MSG
+  fi
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# 5. Dump the current data.
+# ---------------------------------------------------------------------------
+# Data only, into the schema the rebuild is about to create - the same posture
+# sync-from-prod.sh takes towards production, and for the same reason: the local
+# schema is about to be *ahead* of what this dump was taken from, and
+# --complete-insert lets a new column simply take its default rather than
+# failing on a column-count mismatch.
+#
+# _migration_status is excluded: it is the rebuild's own verdict, and restoring
+# the old row would overwrite a correct `applied` set with the stale one this
+# whole script exists to notice.
+mkdir -p "$DUMP_DIR"
+DUMP="$DUMP_DIR/pre-rebuild-$(date +%Y%m%d-%H%M%S).sql"
+
+if docker compose exec -T -e MYSQL_PWD=root db mysqldump -h 127.0.0.1 -uroot \
+     --no-create-info \
+     --complete-insert \
+     --skip-lock-tables \
+     --ignore-table=bigshop._migration_status \
+     bigshop > "$DUMP" 2>/dev/null && [ -s "$DUMP" ]; then
+  echo "Dumped current local data to $DUMP"
+else
+  rm -f "$DUMP"
+  DUMP=""
+  echo "Nothing to dump (empty or unreadable database); rebuilding from seed."
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Destroy the volume and let the existing init path do its job.
+# ---------------------------------------------------------------------------
+# `docker compose down -v` would also take bigshop-lgtm-data with it. Removing
+# the one volume by the name docker itself reports keeps local Grafana history,
+# and cannot be wrong about which project it belongs to.
+DB_VOLUME="$(docker inspect "$CID" \
+  --format '{{range .Mounts}}{{if eq .Destination "/var/lib/mysql"}}{{.Name}}{{end}}{{end}}')"
+
+if [ -z "$DB_VOLUME" ]; then
+  echo "Could not identify the db data volume; refusing to guess." >&2
+  exit 1
+fi
+
+# `api` too: it holds pooled connections to the database that is about to
+# disappear, and compose will recreate it behind service_healthy anyway.
+docker compose rm -sf db api >/dev/null 2>&1 || true
+docker volume rm "$DB_VOLUME" >/dev/null
+
+echo "Replaying $(wc -l < "$EXPECTED" | tr -d ' ') migrations..."
+if ! docker compose up -d --wait --wait-timeout 300 db >/dev/null 2>&1; then
+  cat >&2 <<'MSG'
+
+The rebuilt database did not come up healthy, which means a migration failed to
+apply - not that this script did. The replay says which:
+
+    docker compose logs db | grep -A20 'not in expected-migration-errors'
+
+MSG
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Restore.
+# ---------------------------------------------------------------------------
+if [ -z "$DUMP" ]; then
+  echo "Database rebuilt on the current schema, with the dev seed."
+  exit 0
+fi
+
+# Truncate exactly the tables the dump carries, so the seed rows just inserted
+# do not collide with the restored ones on primary key - dev-seed.sql inserts
+# local-dev-user, account_user and the unit rows, all of which are in the dump.
+# Tables the dump does not carry keep their seeded contents.
+TABLES="$(grep -o 'INSERT INTO `[^`]*`' "$DUMP" | sed 's/INSERT INTO `//; s/`$//' | sort -u)"
+
+restore() {
+  {
+    echo "SET FOREIGN_KEY_CHECKS=0;"
+    while IFS= read -r t; do
+      [ -n "$t" ] && printf 'TRUNCATE TABLE `%s`;\n' "$t"
+    done <<< "$TABLES"
+    cat "$DUMP"
+    echo "SET FOREIGN_KEY_CHECKS=1;"
+  } | mysql_in_db bigshop
+}
+
+# No --force here, deliberately: this is the one step that can legitimately
+# fail (a new NOT NULL column with no default, a new foreign key the old rows
+# violate), and a half-applied restore is the worst possible outcome - it looks
+# like it worked. Stop at the first error and rebuild clean instead.
+if restore_error="$(restore 2>&1)"; then
+  echo "Restored $(echo "$TABLES" | grep -c . ) tables from the dump."
+  echo "Database is on the current schema with your data. $DUMP kept."
+else
+  docker compose rm -sf db >/dev/null 2>&1 || true
+  docker volume rm "$DB_VOLUME" >/dev/null 2>&1 || true
+  docker compose up -d --wait --wait-timeout 300 db >/dev/null 2>&1 || true
+
+  cat >&2 <<MSG
+
+Your data could not be restored onto the new schema:
+
+$(echo "$restore_error" | sed 's/^/    /' | head -20)
+
+That usually means a new migration added a column or constraint the old rows
+cannot satisfy. The database has been rebuilt clean instead, so it is correct
+and usable - it just has the dev seed rather than your data.
+
+Your data is not lost. The dump is at:
+
+    $DUMP
+
+To get your real recipes back, the supported route is production:
+
+    scripts/sync-from-prod.sh
+
+MSG
+fi

--- a/scripts/sync-from-prod.sh
+++ b/scripts/sync-from-prod.sh
@@ -95,13 +95,14 @@ run_mysqldump "$TIDB_DB" recipe_tag \
 
 echo "Saved to ${DUMP_FILE}"
 
-echo "Bringing up the local db container..."
-docker compose up -d db
-
-echo "Waiting for MySQL to be ready..."
-until docker compose exec -T db mysqladmin ping -uroot -proot --silent 2>/dev/null; do
-  sleep 1
-done
+# Bring the local schema up to date first. This script imports data only
+# (--no-create-info), into whatever schema the volume happens to have - so a
+# volume that is behind migrations/ silently lands production's rows in the
+# wrong shape, or fails on a column it does not have yet. ensure-db-current.sh
+# brings `db` up and waits for it, which is why there is no separate up/ping
+# here any more.
+echo "Checking the local schema is up to date..."
+scripts/ensure-db-current.sh
 
 echo "Clearing existing recipe-related tables locally..."
 echo "(any local-only test data in these tables will be lost)"


### PR DESCRIPTION
Closes the board item [*The migration verifier cannot catch a stale volume, because a stale volume is exactly what stops it running*](https://app.notion.com/p/3c3c724ecda181cd87a8fc3c5c5f0539).

## The bug

`docker/mysql-init/01-migrate-and-seed.sh` replays every migration, reconciles each error against `expected-migration-errors.txt`, and writes a verdict to `_migration_status`. All of it runs **exactly once in a volume's life**, because MySQL only runs `docker-entrypoint-initdb.d` when the data directory is empty.

So `ok = 1` is a statement about the day the volume was created, and it stays `1` forever. Add a migration and every existing volume is silently behind, with a green healthcheck asserting the opposite — the check cannot run, precisely because the volume is stale. It surfaced as `GET /user` 500ing and every account-scoped page rendering empty, which reads like an application bug; it took a schema dump to see it was an environment one.

## Why this repairs rather than reports

The ticket originally proposed detecting the drift and telling the developer to run `docker compose down -v`. That is discipline with a reminder bolted on — the human still does the work and still loses their data. It rejected auto-recreation on the grounds that `sync-from-prod.sh` exists and wiping destroys real work.

That objection doesn't hold up. `sync-from-prod.sh` **truncates 8 tables and reimports on every run**, saves a replayable dump to `docker/prod-dumps/` on the host outside the volume, and passes `--no-create-info --complete-insert` precisely so production's rows can land in a *local* schema that is ahead of production. It already treats local data as disposable and assumes the schema is current — which means a stale volume didn't only break `npm run dev:full`, it broke that script too. Hence it now calls the check as well.

The principle: **the dev volume is a cache, not a store of record.** Everything in it is reconstructible from `migrations/*.sql`, `dev-seed.sql`, and a dump on the host. Once that holds, wiping stops being destructive.

## What's here

**Detection** — the init script records the migration basenames it replayed on `_migration_status`; the healthcheck compares that set against `./migrations`, already bind-mounted into the container. `api` refuses to start against a merely-outdated schema through the same mechanism that already protects it from a broken one.

**Repair** — `scripts/ensure-db-current.sh`, run by `dev-full.sh` before anything waits on health, and by `sync-from-prod.sh` before it imports. Dumps the volume's data out of the running container (no password, no network), drops the volume, lets the init path replay and seed, restores the data.

Detection and repair are deliberately in different places: a healthcheck must be side-effect-free and has nowhere to put a dump, and keeping the check covers someone running a bare `docker compose up -d db api` around the wrapper.

## Evidence

Fresh volume records the set and goes healthy in ~12s:

```
$ docker compose exec -T db mysql ... -e "SELECT ok, ... FROM bigshop._migration_status"
1   957   001_init.sql\n002_unique.sql   041_account_id_foreign_keys.sql
recorded: 41    repo: 41
```

A migration arrives, with local-only data in the volume:

```
$ scripts/ensure-db-current.sh
The local database is behind migrations/.
  missing: 1 migration(s)
    + 999_probe.sql
Rebuilding it. Local data is dumped first and restored afterwards.

Dumped current local data to docker/prod-dumps/pre-rebuild-20260822-135714.sql
Replaying 42 migrations...
Restored 13 tables from the dump.
Database is on the current schema with your data. ... kept.

$ ... -e "SELECT id, name FROM recipe ORDER BY id"
1  Spaghetti Bolognese
2  Veggie Chilli
3  Precious Local Recipe      <- survived the rebuild
$ ... -e "SHOW TABLES LIKE 'zz_probe'"
zz_probe                      <- new migration applied
```

Restore that genuinely cannot work (a migration dropping a column the dump references), plus the row-rewrite warning:

```
  Note: these change rows, not just schema -
      998_break.sql
  The restore puts your existing rows back as they are, so anything one of
  those would have corrected stays uncorrected locally. ...

Your data could not be restored onto the new schema:
    ERROR 1054 (42S22) at line 163: Unknown column 'notes' in 'field list'

The database has been rebuilt clean instead, so it is correct and usable - it
just has the dev seed rather than your data.
Your data is not lost. The dump is at: docker/prod-dumps/pre-rebuild-...sql
```

Left healthy with the seed, and the API serves from the rebuilt DB:

```
$ curl -sf localhost:8099/api/bigshop/recipes
[{"name":"Spaghetti Bolognese","id":1,...},{"name":"Veggie Chilli","id":2,...}]
```

Also exercised: the "applied but no longer in the repo" branch, and the no-op path (0.58s, prints nothing, exit 0).

`npm run test:e2e` — **37 passed**, which drives `dev-full.sh` and therefore the new check on a fresh stack.

## Decisions worth a look

- **An unrecorded volume is stale, unconditionally**, reversing `docker-compose.yml`'s comment 3 (fall back to a plain ping when `_migration_status` is absent). That bought avoiding a `down -v` which "throws away a synced copy of production"; the rebuild is now lossless in the normal case, so the cost is gone — and an unrecorded volume is exactly the one most likely to be stale. This was the ticket's "one real decision"; it stopped being a judgement call once the remedy stopped being destructive.
- **The honest limit.** The restore reproduces the *state* of local data, not its *history*. Fine for DDL; not fine for a row-rewriting migration (`022`, `023`, `029`, `031`), where restoring old rows can reinstate what the migration removed. Nothing detects that reliably, so it's a heuristic on the leading keyword that errs towards mentioning it, pointing at `sync-from-prod.sh` — production has had the migration applied properly.
- **A worktree guard, because this runs `down -v` unattended.** Compose names projects after the directory basename and every worktree here is `big-shop`, so a bare `docker compose` can resolve to another checkout's containers. The script compares the container's `/migrations` bind source against this worktree and refuses otherwise. (Docker Desktop reports that path prefixed with `/host_mnt`, which is stripped — a suffix match was rejected as it would accept the wrong worktree in exactly the case the guard exists for.)
- **`retries` 20 → 5, plus `start_period: 60s`.** The retry budget was doubling as the window for the initial replay; that's what `start_period` is for. Sized against the measured ~12s, and kept short because it is also how long a stale volume sits in `starting` before admitting to being unhealthy — the two are indistinguishable to a healthcheck.

## Not done

Automating the refresh *from production*. It needs a stored credential, and the only one on a laptop today is `.env.tidb`'s `…root` — full read-write on production, the same credential Fly holds as `TIDB_PASSWORD`. The route if it's ever wanted (a scoped read-only TiDB user in the OS keychain, kept separate from `tidb_prompt_password`) is written up on the Notion row. Not needed yet, because the restore above removes most of the pressure to re-sync at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)