### PR TITLE
Reconcile the declared secrets against the app's before deploying

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -58,6 +58,24 @@ jobs:
       # surfaced it. Re-check this tag whenever a runner deprecation lands.
       - uses: superfly/flyctl-actions/setup-flyctl@1.6
 
+      # Before the deploy, because a machine_config.json naming a secret that
+      # does not exist produces a config flyd cannot apply - it reverts the
+      # machine, and flyctl reports success over the top of it. The Verify step
+      # at the end catches that, but only after a full remote build and only by
+      # its symptom. This catches the cause, in seconds, and says which name is
+      # wrong. It also catches the opposite drift, which Verify cannot see at
+      # all: a secret that exists and reaches no container is simply empty at
+      # runtime, and has twice meant a security property silently not holding.
+      #
+      # It lives here rather than in ci.yml because it needs FLY_API_TOKEN, and
+      # this job is deliberately the only holder of it. The cost is that the
+      # check runs on master rather than on the pull request that introduced the
+      # drift - acceptable, since it still runs before anything is deployed.
+      - name: Check the declared secrets against the app's
+        run: ./scripts/check-fly-secrets.sh
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
       # --remote-only builds on Fly's builder rather than this runner. It is
       # already flyctl's default (--local-only is the opt-out), so this is
       # explicit rather than necessary - worth keeping so the intent survives a

--- a/netlify-functions/recipes/fly.toml
+++ b/netlify-functions/recipes/fly.toml
@@ -37,6 +37,13 @@ primary_region = "fra"
 # which for a credential means a feature that fails only when exercised. Adding
 # a secret is now a two-part change: set it, and declare it.
 #
+# **This is now checked rather than only written down.** After four instances,
+# three of which are recorded below, scripts/check-fly-secrets.sh reconciles the
+# names in machine_config.json against the names in `fly secrets` and fails the
+# deploy on drift in either direction. That does not make the rest of this
+# comment redundant - the check tells you a name is wrong, and the paragraphs
+# below are what tell you what goes wrong when it is.
+#
 # Live example, now resolved and left here as the worked one: SENDGRID_API_KEY
 # was read by the API for invitation emails while not being set on this app at
 # all, so that flow was broken independently of any of this. It is now set with

--- a/scripts/check-fly-secrets.sh
+++ b/scripts/check-fly-secrets.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Reconcile machine_config.json's declared secrets against the names that
+# actually exist in `fly secrets`, and fail before deploying when they disagree.
+#
+# **Why this is a check and not a convention.** Under `[experimental]
+# machine_config`, a Fly secret reaches a container only if that container names
+# it. Adding a secret is therefore two edits in two systems - `fly secrets set`
+# and this repository - and every time the two have drifted apart it has cost
+# real production behaviour:
+#
+#   declared, not set    machine_config.json said SENDGRID_API_KEY while the
+#                        secret was set as SENGRID_API_KEY. flyd could not apply
+#                        the config, reverted every deploy for a day, and flyctl
+#                        reported success throughout. Authenticated requests
+#                        401'd for that whole day.
+#
+#   set, not declared    AUTH0_MGMT_CLIENT_ID / AUTH0_MGMT_CLIENT_SECRET were
+#                        set the day #59 shipped and declared by nobody, so
+#                        account deletion silently skipped the Auth0 identity -
+#                        the exact bug #59 existed to fix. Before that, the same
+#                        thing happened to INVITE_EMAIL_PEPPER and HashEmail
+#                        quietly degraded to a plain SHA-256.
+#
+# fly.toml's comment block has documented this trap since the first instance.
+# Four instances later, documenting it is demonstrably not enough.
+#
+# **Both directions are errors, and the second one deliberately so.** A secret
+# declared nowhere cannot break a request, so the temptation is to warn. But the
+# whole lesson of the deploy incident is that nothing reads a warning in a green
+# run - a set-but-undeclared secret has now twice meant a security property
+# silently not holding, and neither was noticed by anyone. A secret that is
+# genuinely meant to exist without reaching any container goes in
+# `undeclared_on_purpose` below, which makes it a reviewed decision instead of a
+# line of log output.
+#
+# Read-only: it lists secret NAMES and nothing else. `flyctl secrets list` never
+# emits a value, only a digest, so there is no value here to leak.
+set -euo pipefail
+cd "$(dirname "$0")/../netlify-functions/recipes"
+
+# Secrets that exist on the app on purpose while reaching no container. Empty,
+# and it should stay that way - add a name only with a comment saying why, and
+# prefer `fly secrets unset` if the real answer is that nothing needs it.
+undeclared_on_purpose=()
+
+declared=$(jq -r '.containers[].secrets[]?.env_var' machine_config.json | sort -u)
+
+# Across *every* container, not just `api`. Scoping this to one container would
+# report the collector's GRAFANA_CLOUD_* trio as undeclared on every run.
+if ! actual=$(flyctl secrets list --config fly.toml --json | jq -r '.[].name' | sort -u); then
+  echo "::error::could not list secrets. This check cannot be skipped on a"
+  echo "::error::failure to read - that is how it would come to pass silently."
+  exit 1
+fi
+
+if [ -n "${undeclared_on_purpose[*]:-}" ]; then
+  actual=$(comm -23 <(echo "$actual") <(printf '%s\n' "${undeclared_on_purpose[@]}" | sort -u))
+fi
+
+missing=$(comm -23 <(echo "$declared") <(echo "$actual"))   # declared, not set
+orphaned=$(comm -13 <(echo "$declared") <(echo "$actual"))  # set, not declared
+
+status=0
+
+if [ -n "$missing" ]; then
+  status=1
+  echo "::error::machine_config.json declares secrets that do not exist:"
+  echo "$missing" | sed 's/^/::error::  /'
+  echo "::error::flyd cannot apply a config naming a secret it cannot resolve."
+  echo "::error::It will revert the machine and flyctl will report success"
+  echo "::error::anyway, leaving production on the previous image and [env]."
+  echo "::error::Check for a typo first - that is what it was last time."
+fi
+
+if [ -n "$orphaned" ]; then
+  status=1
+  echo "::error::secrets exist on the app but are declared by no container:"
+  echo "$orphaned" | sed 's/^/::error::  /'
+  echo "::error::Each will be an empty string at runtime, with nothing"
+  echo "::error::reporting a problem. If the API reads one, the feature behind"
+  echo "::error::it is silently degraded. Declare it in the right container's"
+  echo "::error::'secrets' array, 'fly secrets unset' it, or - if it really is"
+  echo "::error::meant to sit unused - add it to undeclared_on_purpose in this"
+  echo "::error::script, with a reason."
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "OK: $(echo "$declared" | wc -l | tr -d ' ') declared secrets match the app's."
+fi
+
+exit "$status"


### PR DESCRIPTION
Closes [Reconcile machine_config.json against `fly secrets list` before deploying](https://app.notion.com/p/3c4c724ecda18161a64bd6de99952b4a).

**Stacked on #137** — based on `deploy-api-verify-release` because both touch `deploy-api.yml`. Retarget to `master` once #137 merges; the diff shown here is this change alone.

## Why

Under `[experimental] machine_config` a Fly secret reaches a container only if that container names it, so adding one is two edits in two systems. Every time they have drifted apart it has cost production behaviour:

| Direction | What happened |
| --- | --- |
| **Declared, not set** | `machine_config.json` said `SENDGRID_API_KEY`; the secret was set as `SENGRID_API_KEY`. flyd could not apply the config, reverted every deploy for a day, and flyctl reported success throughout. Every authenticated request 401'd. |
| **Set, not declared** | `AUTH0_MGMT_*` (#139) — account deletion silently skipping the Auth0 identity. Before that, `INVITE_EMAIL_PEPPER`, and `HashEmail` quietly degrading to a plain SHA-256. |

`fly.toml` has documented this trap since the first instance. Four instances later, documenting it is demonstrably not enough.

## Design decisions worth the review time

**Before the deploy, not after.** #137's Verify step catches the first case by its *symptom*, after a full remote build. This catches the cause in seconds and names the wrong string. It also catches the second case, which Verify cannot see at all — a reverted deploy is visible in the machine config, an unused secret is visible nowhere.

**Both directions are errors.** A secret declared nowhere cannot break a request, so the temptation is to warn. But the whole lesson of the deploy incident is that nothing reads a warning in a green run — set-but-undeclared has now twice meant a security property silently not holding, and neither was noticed by anyone. A secret genuinely meant to exist without reaching a container goes in `undeclared_on_purpose` (empty today), making it a reviewed decision rather than a line of log output.

**Across all containers, not just `api`** — scoping to one would report the collector's `GRAFANA_CLOUD_*` trio as undeclared on every run.

**In this job rather than `ci.yml`**, because it needs `FLY_API_TOKEN` and this job is deliberately the only holder of it. The cost is that it runs on `master` rather than on the PR that introduced the drift — acceptable, since it is still before anything is deployed.

**A read failure fails the check.** Skipping on a failure to read is how a check comes to pass silently, which is the genre of bug this whole thread is about.

## The open question in the row, now settled

The row flagged an unknown: whether the app-scoped deploy token can list secrets at all. Fly's docs scope it only as "limited to managing a single app and its resources", which doesn't answer it, and guessing wrong would mean the first post-merge deploy failing at this step.

Settled empirically against the **real** `FLY_API_TOKEN` — a throwaway `push`-triggered workflow on a temporary branch, printing names only, since a `workflow_dispatch` workflow has to exist on the default branch and direct pushes to `master` are rejected here:

```
--- flyctl secrets list --json ---
PERMITTED. names:
GRAFANA_CLOUD_API_KEY
GRAFANA_CLOUD_INSTANCE_ID
...
```

Branch and workflow deleted. Nothing was written to Fly, and `flyctl secrets list` never emits values, only digests.

## Testing

Driven against the live app, read-only. On this branch (which lacks #139's fix) it independently finds the bug I found by hand:

```
$ ./scripts/check-fly-secrets.sh
::error::secrets exist on the app but are declared by no container:
::error::  AUTH0_MGMT_CLIENT_ID
::error::  AUTH0_MGMT_CLIENT_SECRET                                      # exit 1
```

With #139's declarations applied:

```
OK: 8 declared secrets match the app's.                                  # exit 0
```

And reproducing the original incident — `SENDGRID_API_KEY` declared as `SENGRID_API_KEY` — which is correctly reported from both directions at once, since a typo is simultaneously a missing declaration and an orphaned secret:

```
::error::machine_config.json declares secrets that do not exist:
::error::  SENGRID_API_KEY
::error::Check for a typo first - that is what it was last time.
::error::secrets exist on the app but are declared by no container:
::error::  SENDGRID_API_KEY                                              # exit 1
```

No user-visible surface, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)