### PR TITLE
Add the post-login Action that links a second sign-in method

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,4 +652,10 @@ which is correct while a PR is open, and wrong the second it lands.
   behind `ONBOARDING_EMAIL_ENABLED` (off); how to test it and switch it on:
   [email-testing-runbook.md](./docs/email-testing-runbook.md)
 - [TiDB Console](https://tidbcloud.com/console/clusters/10445360365857932862/sqleditor?orgId=1372813089209222715&projectId=1372813089454538934)
-- [Auth0 Management](https://manage.auth0.com/dashboard/eu/dev-x-n37k6b/applications/HxkTOH3ZYxjbsgrVI4ii1CV2TQx7hk9G/settings)
+- [Auth0 Management](https://manage.auth0.com/dashboard/eu/dev-x-n37k6b/applications/HxkTOH3ZYxjbsgrVI4ii1CV2TQx7hk9G/settings) —
+  the tenant is configured through its dashboard, but the post-login Action that
+  links a person's second sign-in method to their existing account is kept in
+  [`auth0/`](./auth0/README.md) so it is reviewable. **Nothing deploys it**: edit
+  the file, then paste it into the dashboard, and say so in the PR. That
+  directory also carries the setup steps and the reasoning for its connection
+  allowlist.

--- a/auth0/README.md
+++ b/auth0/README.md
@@ -1,0 +1,121 @@
+# Auth0 configuration that lives outside the tenant
+
+The Auth0 tenant is configured through its dashboard, not from this repository —
+there is no Terraform provider or `a0deploy` pipeline here, and adding one for a
+single Action would cost more than it returns. What that leaves is code with no
+home: an Action is a JavaScript file that exists only inside a dashboard text
+box, invisible to review, to `git log`, and to anyone reading this codebase
+trying to understand why logins behave the way they do.
+
+So the source of truth for **behaviour** is this directory, and the source of
+truth for **what is running** is the dashboard. Those can drift, and the only
+thing preventing it is the discipline of editing here first and pasting second.
+Say so in the PR when you change one.
+
+## `actions/link-social-identities.js`
+
+A post-login Action that links a returning person's second sign-in method to
+the account they already have.
+
+**Why it is needed** is argued at the top of the file and on the board item
+[Offer more social login options than Google][board]. The short version: Big
+Shop stores the raw Auth0 subject with no foreign key back to Auth0, so an
+unrecognised subject silently becomes a new, empty Account. Adding Microsoft or
+Apple without this means an existing Google user can sign in the "wrong" way and
+find every recipe gone.
+
+### What it does not do
+
+- **It never denies a login.** Any failure falls through to Big Shop's own
+  guard, which answers `409` from `POST /user` and shows the "Your recipes are
+  safe" screen. That guard stays regardless of this Action; the two are layered
+  deliberately, and the Action is written to fail *into* it.
+- **It does not merge Big Shop Accounts.** Auth0 linking merges logins. If two
+  populated Accounts already exist, linking would make one of them permanently
+  unreachable — so the Action refuses that case rather than choosing whose
+  recipes survive. It only ever links an identity on its **first** login.
+- **It does not help Apple Private Relay users.** Apple can hand over
+  `…@privaterelay.appleid.com` instead of the real address, which will never
+  match an existing Google account, so those users get a fresh Account and meet
+  the 409 screen. This is a hole in the mitigation with no fix at this layer —
+  it is the strongest argument for prompting during Apple signup rather than
+  relying on linking alone.
+
+### Setup
+
+**1. A machine-to-machine application with Management API access.**
+
+Check whether the one behind `AUTH0_MGMT_CLIENT_ID` / `AUTH0_MGMT_CLIENT_SECRET`
+on Fly (added for account deletion) can be reused — a second M2M app is a second
+credential to rotate for no benefit. It needs, under
+**Applications → APIs → Auth0 Management API → Machine to Machine Applications**:
+
+| Scope | Why |
+| --- | --- |
+| `read:users` | the `users-by-email` lookup |
+| `update:users` | the identity link itself |
+
+Account deletion already needs `delete:users`, so reuse means widening an
+existing application rather than starting from nothing.
+
+**2. Create the Action.** **Actions → Library → Create Action → Build from
+scratch**, trigger **Login / Post Login**. Paste the contents of
+`actions/link-social-identities.js` over the default body.
+
+Do **not** install the `auth0` npm dependency. The file calls the Management API
+over `fetch` on purpose — the package's client surface has been reshaped across
+recent majors, the pinned version lives in the dashboard rather than in this
+file, and nothing in CI would catch the two disagreeing. The first symptom of a
+mismatch would be a login-time `TypeError` in production.
+
+**3. Add three secrets** in the Action's **Secrets** panel:
+
+| Key | Value |
+| --- | --- |
+| `AUTH0_DOMAIN` | the **canonical** tenant domain (`dev-x-n37k6b.eu.auth0.com`), not a custom domain — the Management API audience is always the canonical one |
+| `MGMT_CLIENT_ID` | the M2M application's client id |
+| `MGMT_CLIENT_SECRET` | its client secret |
+
+**4. Deploy, then add it to the flow.** Deploying an Action does not run it.
+Drag it into **Actions → Triggers → post-login** and apply, or nothing happens
+and everything looks fine.
+
+**5. Check the allowlist matches reality.** `TRUSTED_CONNECTIONS` in the file
+lists the connections that may be linked, by Auth0 connection name — not
+strategy, not display name. Confirm each against **Authentication → Social**
+before relying on it; a typo silently disables linking for that provider, and
+the symptom is the 409 screen rather than an error.
+
+**The allowlist exists because every entry must be a connection where the
+identity provider verifies the address itself.** That is what makes
+`email_verified` meaningful. A database (username/password) connection asserts
+whatever the user typed until they click a confirmation mail, so linking on one
+would let somebody claim another person's address and inherit their recipes.
+Big Shop's database connection is currently disabled, which is what makes
+automatic linking defensible here at all. **Whether it comes back is an open
+question on the board — if it does, it must not join this list without settling
+that question first.**
+
+### Testing it
+
+`DISABLE_AUTH=true` locally means none of this is exercised by the dev stack,
+the e2e suite, or CI. It can only be tested against a real tenant.
+
+1. Sign in to a deploy preview with Google and save a recipe, so there is
+   something to lose.
+2. Sign out, then sign in with Microsoft using the same address.
+3. **Expected:** the recipe is still there, and Auth0's user record shows two
+   entries under **Identities** with the Google one primary.
+4. **The failure worth looking for specifically** is landing in an empty account
+   *while* the Auth0 record shows the identities correctly linked. That means
+   the link worked and `api.authentication.setPrimaryUser` did not, so this
+   login is still carrying the secondary subject.
+5. Then check **Monitoring → Logs**, filtered to `Success Login`, and read the
+   Action's `console.log` lines — every decline logs its reason.
+
+Test the declines too, and the second one is the important one: a second
+identity that has *already* logged in once must **not** be linked, because that
+is the case where linking would strand data. Both should end on the "Your
+recipes are safe" screen rather than in an empty account.
+
+[board]: https://app.notion.com/p/3c3c724ecda18140bbcdca9521ad17a3

--- a/auth0/actions/link-social-identities.js
+++ b/auth0/actions/link-social-identities.js
@@ -1,0 +1,259 @@
+/**
+ * post-login — link a returning person's second sign-in method to the Auth0
+ * account they already have, so Big Shop keeps seeing one subject for them.
+ *
+ * ## Why this exists
+ *
+ * `user.id` and `account_user.user_id` in Big Shop's database hold the raw
+ * Auth0 subject, there is no foreign key to Auth0, and nothing detects a
+ * mismatch. A subject nobody has seen before is therefore indistinguishable
+ * from a new person: the API creates a User row and hands them a brand-new,
+ * empty Account. So without this Action, an existing Google user tapping
+ * "Sign in with Microsoft" loses every recipe they own — same human, same
+ * address, new empty account, no error raised anywhere.
+ *
+ * Linking makes both providers resolve to one subject, which is the only
+ * mitigation that actually prevents the problem rather than reporting it.
+ *
+ * ## This is the belt; the API has the braces
+ *
+ * `POST /user` refuses with a 409 when it sees an email already held under a
+ * different subject, and the app shows a "Your recipes are safe" screen. That
+ * guard is deliberately still there, and this Action is written to **fail into
+ * it** rather than around it: every check below returns without linking rather
+ * than guessing, and a Management API failure is swallowed. The worst outcome
+ * of this Action doing nothing is the 409 screen. The worst outcome of it
+ * linking something it should not have is somebody reaching a stranger's
+ * recipes, so the asymmetry decides every judgement call in here.
+ *
+ * **It must never deny the login.** `api.access.deny` on a Management API blip
+ * would lock the whole userbase out of an app whose accounts are all fine.
+ *
+ * ## Setup
+ *
+ * See ../README.md for the secrets, the M2M application's scopes, and how to
+ * test it against a real second provider.
+ */
+
+// The connections this Action will link, on either side. **An allowlist, and
+// it is load-bearing rather than tidy.**
+//
+// Every entry has to be a connection where the identity provider verifies the
+// address itself. That is what makes `email_verified` mean something: on a
+// database (username/password) connection the address is self-asserted until a
+// confirmation mail is clicked, so linking on it would be an account-takeover
+// primitive — sign up claiming somebody's address, get linked to their account,
+// read their recipes.
+//
+// Big Shop's database connection is currently disabled, which is what makes
+// auto-linking defensible at all here. Re-enabling it is an open question on
+// the board, and **if it comes back, it must not be added to this list** without
+// deciding that question deliberately.
+const TRUSTED_CONNECTIONS = ['google-oauth2', 'windowslive', 'apple'];
+
+/**
+ * A Management API token, cached for as long as the Action's container lives.
+ *
+ * Module scope survives between executions on a warm container and is empty on
+ * a cold one, which is exactly the behaviour wanted: it saves a token request
+ * on most logins and is merely a miss, never a bug, when it does not. Nothing
+ * here depends on the cache existing.
+ */
+let cachedToken = null;
+
+exports.onExecutePostLogin = async (event, api) => {
+  let primaryUserId;
+
+  try {
+    primaryUserId = await findAndLink(event);
+  } catch (error) {
+    // Swallowed on purpose — see the header. A failure here means the person
+    // signs in under the new subject and meets the API's 409 screen, which is
+    // recoverable; denying the login is not.
+    console.log(`account linking failed, falling through to the app's guard: ${error.message}`);
+    return;
+  }
+
+  if (!primaryUserId) return;
+
+  // **The half that is easy to miss.** Linking rewrites Auth0's records but
+  // does not retarget the login already in flight, so without this the very
+  // session that triggered the link still carries the *secondary* subject —
+  // and Big Shop reads the subject off the token. The person would be linked
+  // correctly and still land in an empty account for this one login.
+  api.authentication.setPrimaryUser(primaryUserId);
+};
+
+/**
+ * Decides whether this login should be linked, and does it.
+ *
+ * Returns the primary user's id when a link was made, or undefined when any
+ * check said no. Every early return is a case where linking might be right but
+ * is not certainly right, and "not certainly right" resolves to leaving it to
+ * the app's 409.
+ */
+async function findAndLink(event) {
+  const email = event.user.email;
+
+  // Nothing to match on. Apple with Private Relay lands here too when the
+  // relay address does not match anything — see README.md, it is a known and
+  // unavoidable hole, not an oversight.
+  if (!email || !event.user.email_verified) return;
+
+  if (!TRUSTED_CONNECTIONS.includes(event.connection.name)) return;
+
+  // **Only ever on an identity's first login**, and this is the check that
+  // makes the Action safe against the one thing linking cannot undo.
+  //
+  // Auth0 linking merges *logins*. It does not merge Big Shop Accounts: the
+  // database still holds a `user` row and an `account` row for the secondary
+  // subject, and after linking nothing can ever resolve to them again. So
+  // linking an identity that has been used before can strand whatever was
+  // saved under it — the exact harm this whole exercise is about, caused by the
+  // fix for it.
+  //
+  // An identity on its first login cannot have accumulated anything, because
+  // Big Shop only ever writes rows for a subject that has logged in. Anyone who
+  // has already double-signed-up gets no link and meets the 409 screen, which
+  // is the correct outcome: merging two populated accounts is a data decision
+  // for a human, not something to infer during a login.
+  //
+  // `<= 1` rather than `=== 1` because Auth0's documentation does not commit to
+  // whether the count includes the login in progress, and both readings mean
+  // the same thing here.
+  if (event.stats.logins_count > 1) return;
+
+  const token = await managementToken(event);
+  const sharing = await usersWithEmail(event, token, email);
+
+  const others = sharing.filter((candidate) => candidate.user_id !== event.user.user_id);
+
+  // Nobody else holds the address: an ordinary new signup, which is most of
+  // what reaches this line. Nothing to link.
+  if (others.length === 0) return;
+
+  // More than one. Somebody has already double-signed-up, so choosing a primary
+  // means choosing whose recipes survive — see the note above. Refuse.
+  if (others.length > 1) {
+    console.log(`account linking declined: ${others.length} existing users share this address`);
+    return;
+  }
+
+  const primary = others[0];
+
+  // The existing account has to clear the same bar as the arriving one, on both
+  // counts. An unverified address on the *primary* side is the takeover vector
+  // read backwards: it would let a verified new login be attached to an account
+  // somebody claimed without proving they owned the address.
+  if (!primary.email_verified) return;
+  if (!(primary.identities || []).every((identity) => TRUSTED_CONNECTIONS.includes(identity.connection))) return;
+
+  // **The pre-existing account is always primary, and this is not a
+  // preference.** Big Shop's `user.id` and `account_user.user_id` rows already
+  // point at its subject. Making the arriving identity primary would leave
+  // every one of those rows pointing at a subject that no longer resolves —
+  // the same person, locked out of their own data, with no error to explain it.
+  //
+  // `logins_count <= 1` above already establishes which is which: the arriving
+  // identity is the new one by construction.
+  const secondary = event.user.identities[0];
+
+  await linkIdentity(event, token, primary.user_id, {
+    provider: secondary.provider,
+    // The bare provider-side id, not the full `provider|id` subject. This is
+    // why it is read off the identity rather than split out of `user_id`.
+    user_id: secondary.user_id,
+  });
+
+  console.log(`account linking: attached ${secondary.provider} to an existing account`);
+  return primary.user_id;
+}
+
+/**
+ * A client-credentials token for the Management API.
+ *
+ * **Called over plain fetch rather than through the `auth0` npm package**, and
+ * that is deliberate. An Action's dependencies are pinned in the dashboard
+ * rather than in this file, the package's client surface has been reshaped
+ * across recent majors (`usersByEmail.getByEmail` and `users.link` in one
+ * version, `users.listUsersByEmail` and `users.identities.link` in another),
+ * and there is nothing in this repository that would fail when the pinned
+ * version and this code disagree — the first symptom would be a login-time
+ * TypeError in production. Two endpoints do not justify that exposure, and
+ * `fetch` is global on every Node runtime Actions offer.
+ */
+async function managementToken(event) {
+  const now = Date.now();
+  if (cachedToken && cachedToken.expiresAt > now) return cachedToken.value;
+
+  const domain = event.secrets.AUTH0_DOMAIN;
+  const audience = `https://${domain}/api/v2/`;
+
+  const response = await fetch(`https://${domain}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'client_credentials',
+      client_id: event.secrets.MGMT_CLIENT_ID,
+      client_secret: event.secrets.MGMT_CLIENT_SECRET,
+      audience,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`management token request returned ${response.status}`);
+  }
+
+  const body = await response.json();
+  cachedToken = {
+    value: body.access_token,
+    // A minute of headroom, so a token cannot expire between this check and the
+    // request that uses it.
+    expiresAt: now + (body.expires_in - 60) * 1000,
+  };
+  return cachedToken.value;
+}
+
+/**
+ * Every Auth0 user holding this email address.
+ *
+ * Lowercased before searching: Auth0 stores addresses in lower case and this
+ * endpoint matches exactly, so `Ada@Example.com` would find nothing and the
+ * silent result would be no link — which reads as the feature not working
+ * rather than as a bug.
+ */
+async function usersWithEmail(event, token, email) {
+  const url = `https://${event.secrets.AUTH0_DOMAIN}/api/v2/users-by-email`
+    + `?email=${encodeURIComponent(email.toLowerCase())}`;
+
+  const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!response.ok) {
+    throw new Error(`users-by-email returned ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
+ * Attaches a secondary identity to a primary user.
+ *
+ * The user named in the *path* becomes primary; the body names what is being
+ * folded into them. Reversing the two is the failure mode called out above, and
+ * it is not detectable afterwards from the response.
+ */
+async function linkIdentity(event, token, primaryUserId, secondary) {
+  const url = `https://${event.secrets.AUTH0_DOMAIN}/api/v2/users/`
+    + `${encodeURIComponent(primaryUserId)}/identities`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(secondary),
+  });
+
+  if (!response.ok) {
+    throw new Error(`identity link returned ${response.status}`);
+  }
+}


### PR DESCRIPTION
The Auth0 post-login Action for [Offer more social login options than Google](https://app.notion.com/p/3c3c724ecda18140bbcdca9521ad17a3). Companion to #138: that PR added the guard that *reports* a stranded account, this one is the mitigation that *prevents* it.

**Nothing here deploys.** An Action lives in a dashboard text box; the file is kept in the repo so it is reviewable and greppable, and `auth0/README.md` states the rule — edit here, paste second, say so in the PR.

## Setup this needs (not done — it is dashboard work)

`auth0/README.md` has the full runbook. In short: an M2M app with `read:users` + `update:users` (check whether the existing `AUTH0_MGMT_CLIENT_ID` one can be widened rather than making a second), three Action secrets, and **dragging it into the post-login trigger** — deploying an Action does not run it, which is the easiest step to miss.

## Three decisions worth reviewing

**It links only on an identity's *first* login** (`event.stats.logins_count > 1` → refuse). This is the safety property I'd most like a second opinion on. Auth0 linking merges *logins*, not Big Shop Accounts: the secondary subject's `user` and `account` rows survive in TiDB and become permanently unreachable. So linking an identity that has been used before can strand data — the exact harm this exists to prevent, caused by the fix for it. An identity on its first login cannot have accumulated anything, because Big Shop only writes rows for a subject that has logged in.

Consequence: anyone who has already double-signed-up gets no link and meets the 409 screen. That is intended — merging two populated Accounts is a decision for a human, not something to infer during a login.

**The connection allowlist is load-bearing.** Every entry must be a provider that verifies the address itself; that is the only thing making `email_verified` mean anything. A database connection asserts whatever was typed until a confirmation mail is clicked, so linking on one would let somebody claim another person's address and inherit their recipes. **That Big Shop's database connection is currently disabled is what makes automatic linking defensible at all** — and whether it comes back is still an open question on the board. If it does, it must not join the list without settling that first.

**It calls the Management API over `fetch`, not the `auth0` package.** The client surface has been reshaped across recent majors (`usersByEmail.getByEmail`/`users.link` in one, `users.listUsersByEmail`/`users.identities.link` in another), the pinned version lives in the dashboard rather than in this file, and nothing in CI would catch the two disagreeing — the first symptom would be a login-time `TypeError` in production. Two endpoints do not justify that exposure.

## Two things it deliberately does not do

- **Never denies a login.** A Management API blip must not lock out a userbase whose accounts are all fine. Every failure falls through to #138's 409 screen, which is recoverable.
- **Does not help Apple Private Relay users.** `…@privaterelay.appleid.com` will never match an existing Google address, so those users get a fresh Account and meet the 409 screen. A hole with no fix at this layer, and the strongest argument for prompting during Apple signup rather than relying on linking alone. Documented rather than papered over.

## The one subtle bug this is written to avoid

Linking rewrites Auth0's records but does **not** retarget the login already in flight. Without `api.authentication.setPrimaryUser`, the very session that triggered the link still carries the *secondary* subject — and Big Shop reads the subject off the token, so the person is linked correctly and still lands in an empty account for that one login. `auth0/README.md`'s test plan calls this out as the specific failure to look for.

## Testing

`DISABLE_AUTH=true` locally means none of this is exercised by the dev stack, e2e, or CI — it can only be tested against a real tenant, and the README has the steps including the declines. Repo checks pass unchanged (lint, typecheck, 381 Vitest, `node --check` on the Action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
