### PR TITLE
Make CreateAccount's existence check correct on purpose

### DIFF
--- a/netlify-functions/recipes/internal/pkg/service/account.go
+++ b/netlify-functions/recipes/internal/pkg/service/account.go
@@ -10,26 +10,66 @@ import (
 	"github.com/google/uuid"
 )
 
-// CreateAccount creates a new account for a user
+// hasAccountQuery asks whether a User holds *any* membership row - not which
+// Account they can currently reach, which is GetAccountID's different question.
+//
+// **The absence of `enabled = true` is deliberate, and it is the one place these
+// two functions are allowed to disagree.** GetAccountID filters it because it
+// answers "where do this person's recipes live right now", and a disabled row is
+// a membership somebody has left. This answers "should a fresh Account be minted
+// for them", and there the disabled row still counts: the only way to hold
+// nothing but disabled memberships is to be sitting between the deletion
+// sequence's soft gate and its cascade (DisableUserAccount, and see
+// DeleteAccount). Filtering them out would mint a second Account for someone
+// mid-deletion - re-granting the access the gate just took away, and leaving an
+// orphan `account` row behind when the cascade deletes every membership by
+// user_id but only the original Account by id.
+//
+// So POST /user for a gated user creates nothing and the request then fails
+// downstream where GetAccountID finds no reachable Account. That is a worse
+// error message than it deserves, but it is the correct outcome: the gate holds.
+// Unreachable in practice today - the cascade deletes the rows outright - but
+// the reasoning is what stops a future edit "fixing" the inconsistency.
+//
+// EXISTS rather than a SELECT of the id, because existence is the entire
+// question. A user can hold two membership rows (the invite flow disables the
+// old one and inserts a new one), so selecting account_id returns an arbitrary
+// one of them, and having a variable in scope that looks like "their account id"
+// but is only meaningful on the branch that just wrote it is how this function
+// came to be correct by accident. There is now no such variable to misread.
+const hasAccountQuery = `SELECT EXISTS(SELECT 1 FROM account_user WHERE user_id = ?)`
+
+// CreateAccount gives a User an Account if they do not already have one.
+//
+// A no-op for everyone but a genuinely new user, which is almost every call: it
+// hangs off POST /user, and that runs on every login.
 func CreateAccount(ctx context.Context, db *sql.DB, user common.User) error {
-	var accountID int
-	accountQuery := `SELECT account_id FROM account_user WHERE user_id = ?`
-	err := db.QueryRowContext(ctx, accountQuery, user.ID).Scan(accountID)
-	if err != nil && err == sql.ErrNoRows {
-		// create a new account
-		res, err := db.ExecContext(ctx, `INSERT INTO account (id) VALUES (null)`)
-		if err != nil {
-			return fmt.Errorf("creating account: %w", err)
-		}
-		id, err := res.LastInsertId()
-		if err != nil {
-			return fmt.Errorf("reading new account id: %w", err)
-		}
-		accountID = int(id)
-		accountUserQuery := `INSERT INTO account_user (user_id, account_id) VALUES (?, ?)`
-		if _, err := db.ExecContext(ctx, accountUserQuery, user.ID, accountID); err != nil {
-			return fmt.Errorf("linking user to new account: %w", err)
-		}
+	// EXISTS always returns exactly one row, so sql.ErrNoRows cannot happen here
+	// and every error is a real one. That is the point of the shape: this used to
+	// scan into a non-pointer `int`, which made `Scan` fail with "destination not
+	// a pointer" for every returning user - and because that error is not
+	// ErrNoRows, the create branch was skipped and the error discarded. The right
+	// behaviour, reached by declining to create an Account for a reason that had
+	// nothing to do with whether one existed.
+	var exists bool
+	if err := db.QueryRowContext(ctx, hasAccountQuery, user.ID).Scan(&exists); err != nil {
+		return fmt.Errorf("checking whether the user already has an account: %w", err)
+	}
+	if exists {
+		return nil
+	}
+
+	res, err := db.ExecContext(ctx, `INSERT INTO account (id) VALUES (null)`)
+	if err != nil {
+		return fmt.Errorf("creating account: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("reading new account id: %w", err)
+	}
+	accountUserQuery := `INSERT INTO account_user (user_id, account_id) VALUES (?, ?)`
+	if _, err := db.ExecContext(ctx, accountUserQuery, user.ID, int(id)); err != nil {
+		return fmt.Errorf("linking user to new account: %w", err)
 	}
 	return nil
 }

--- a/netlify-functions/recipes/internal/pkg/service/account_test.go
+++ b/netlify-functions/recipes/internal/pkg/service/account_test.go
@@ -417,3 +417,30 @@ func TestSoleMemberDecision(t *testing.T) {
 		}
 	}
 }
+
+// TestHasAccountQuery pins the two properties of CreateAccount's lookup that are
+// invisible by inspection and were both wrong before.
+//
+// Asserted against the query constant the function runs, rather than a copy of
+// it, for the same reason TestOtherAccountMembersQuery is: the behaviour lives
+// entirely in the predicate, and there is no way to fake *sql.Row to reach it.
+func TestHasAccountQuery(t *testing.T) {
+	// EXISTS is what makes sql.ErrNoRows impossible, which is what lets
+	// CreateAccount treat every scan error as a real failure instead of having to
+	// tell "no account yet" apart from "the query broke". Selecting account_id
+	// instead reintroduces that distinction - and it was getting it wrong that
+	// made the function correct only by accident.
+	if !strings.Contains(hasAccountQuery, "EXISTS") {
+		t.Errorf("the lookup can return no rows, so a broken query is indistinguishable from a new user: %s", hasAccountQuery)
+	}
+	// The deliberate disagreement with GetAccountID. Adding this filter mints a
+	// second Account for a user sitting between the deletion sequence's soft gate
+	// and its cascade, undoing the gate and orphaning an `account` row. See
+	// hasAccountQuery's comment for the full argument.
+	if strings.Contains(hasAccountQuery, "enabled") {
+		t.Errorf("filtering on enabled makes a mid-deletion user look accountless, so POST /user mints them a second Account: %s", hasAccountQuery)
+	}
+	if !strings.Contains(hasAccountQuery, "user_id = ?") {
+		t.Errorf("the lookup is not scoped to one user: %s", hasAccountQuery)
+	}
+}


### PR DESCRIPTION
Closes the board row *service.CreateAccount scans into a non-pointer, and is correct only by accident*.

## The bug

```go
var accountID int
err := db.QueryRowContext(ctx, accountQuery, user.ID).Scan(accountID)
if err != nil && err == sql.ErrNoRows {
```

`accountID`, not `&accountID`. `sql.Row.Scan` checks for rows *before* it checks the destination, so the two cases diverged:

- **No rows** (a genuinely new user) → `Scan` returns `sql.ErrNoRows` before it ever looks at the destination, the branch runs, an Account is created. Correct.
- **A row exists** (every returning user) → `Scan` reaches `convertAssign` and fails with `sql: destination not a pointer`. Not `ErrNoRows`, so the branch is skipped and the error discarded.

The second path is the right behaviour for the wrong reason: it declined to create a second Account because the scan errored, not because it found one.

## The fix

Reshaped into an existence check rather than only fixing the pointer:

```go
const hasAccountQuery = `SELECT EXISTS(SELECT 1 FROM account_user WHERE user_id = ?)`
```

`EXISTS` always returns exactly one row, so `sql.ErrNoRows` cannot happen — every error is a real one, and now propagates instead of being swallowed. It also designs out the hazard the row named: there is no longer an `accountID` variable left at zero on the lookup path, so the reverse edit (keeping the non-pointer, adding a branch that reads it) has nothing to misread. Selecting the id was wrong on its own terms too — the invite flow gives a user two membership rows, so `QueryRow` returned an arbitrary one.

`err != nil && err == sql.ErrNoRows` goes with it: redundant first half, and the comparison should have been `errors.Is`. Both are moot once the error path is unconditional.

## The `enabled` disagreement — kept, and documented

The row's third point is that this lookup does not filter `enabled = true` while `GetAccountID` does. **I have deliberately not aligned them**, because adding the filter is a data bug rather than a tidy-up:

A user sitting between the deletion sequence's soft gate and its cascade holds nothing but disabled memberships. With the filter, `CreateAccount` reads them as accountless and mints a **second** Account — re-granting the access `DisableUserAccount` had just taken away, and leaving an orphan `account` row behind, since the cascade deletes every membership by `user_id` but only the original Account by `id`.

The two functions genuinely ask different questions: *"where do this person's recipes live right now"* (enabled only) versus *"should a fresh Account be minted for them"* (a disabled row still counts). The 500 that user currently gets downstream is a worse error message than they deserve, but it is the correct outcome — the gate holds. The argument now lives on the query constant so a future edit "fixing" the inconsistency reads it first.

## Tests

`TestHasAccountQuery` pins all three properties against the constant the function actually runs, following the existing `TestOtherAccountMembersQuery` pattern — the behaviour lives entirely in the predicate, and there is no way to fake `*sql.Row` to reach it.

Separately verified against real MySQL that `SELECT EXISTS(...)` scans into a Go `bool` in both the true and false directions (throwaway test, not committed).

`gofmt`, `go vet` and `go test ./... -race` all clean locally.

No user-visible surface, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)