### PR TITLE
Deploy only master's tip, so the workflow and the tree are one commit

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -30,12 +30,115 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  # Decides whether this run should deploy at all, and says so out loud.
+  #
+  # **The workflow definition and the tree it operates on are two different
+  # commits, and nothing used to reconcile them.** For `workflow_run` GitHub
+  # takes the workflow file from the default branch's tip, while the checkout
+  # below deliberately pins the triggering commit. Both halves are right on
+  # their own; together they mean a run can execute master's newest steps
+  # against a checkout that predates them.
+  #
+  # That is observed, not theorised. Run 32585058437, 2026-08-22: PR #139 merged,
+  # then PR #137 - which added scripts/verify-fly-release.sh and the step calling
+  # it - merged moments later. The deploy triggered by #139's CI ran with
+  # github.sha = 5ec3e82 (#137, already carrying the new step) against a checkout
+  # of 9369bb5 (#139), which predates the script:
+  #
+  #   ./scripts/verify-fly-release.sh: No such file or directory
+  #   ##[error]Process completed with exit code 127
+  #
+  # That failure was loud. The same mechanism running the other way is silent: a
+  # step *deleted* from the workflow still runs when the trigger is old, and a
+  # step that reads a config file which has since changed shape reads it wrongly
+  # with nothing to report.
+  #
+  # **The fix is to deploy only master's tip, rather than to reconcile the two
+  # halves after the fact.** `github.sha` on a `workflow_run` event is the last
+  # commit on the default branch - which is exactly the commit the workflow
+  # definition was taken from - so requiring it to equal the commit being checked
+  # out collapses workflow, tree and tip into one commit. Both directions of the
+  # problem then cannot arise, rather than being detected.
+  #
+  # It also fixes a second hazard that had nothing to do with missing scripts.
+  # `concurrency` above queues deploys rather than superseding them, and nothing
+  # ordered the queue by commit. Two commits landing close together, the newer
+  # one's CI finishing first, would deploy the newer and then the older on top -
+  # a silent rollback of whatever the newer one changed, lasting until the next
+  # push. An older commit's run now skips instead.
+  #
+  # **What this gives up**, deliberately: if master's tip goes red, the previous
+  # green commit no longer ships. Its run skips because it is not the tip, and
+  # the tip's own run never happens because CI failed. Nothing is lost, and the
+  # next green commit carries everything - but a red master now blocks deploys
+  # rather than quietly shipping the commit before it. A red master is already
+  # the thing to fix first.
+  #
+  # A separate job rather than a condition on `deploy` itself so the decision is
+  # *visible*. Both values are plain contexts, so this could have been an
+  # expression in the job-level `if` below - but a job that reports "skipped"
+  # with no reason is the same genre of silence as the bug it fixes.
+  guard:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
+    # The conclusion gate stays at job level, where it was, so a red CI costs no
+    # runner at all - it is by far the most common reason not to deploy, and a
+    # skipped Deploy API after a failed CI needs no explaining. The decision this
+    # job exists to narrate is the surprising one below.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
+    outputs:
+      deploy: ${{ steps.decide.outputs.deploy }}
+    steps:
+      - id: decide
+        env:
+          # The commit CI passed on, and the one the deploy would check out.
+          TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
+          # The default branch's tip, and the commit this very file came from.
+          TIP_SHA: ${{ github.sha }}
+          EVENT: ${{ github.event_name }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          set -euo pipefail
+
+          # workflow_dispatch checks out a hard 'master', so it is the tip by
+          # construction and there is nothing to compare.
+          if [ "$EVENT" = workflow_dispatch ]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Manual dispatch: deploying master."
+            exit 0
+          fi
+
+          # Belt and braces. The job-level `if` above already screens this out,
+          # so reaching here means that condition and this one have drifted
+          # apart - which should fail closed rather than deploy. `completed`
+          # includes failure and cancelled.
+          if [ "$CONCLUSION" != success ]; then
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CI concluded '$CONCLUSION', not 'success'. Not deploying."
+            exit 0
+          fi
+
+          if [ "$TRIGGER_SHA" != "$TIP_SHA" ]; then
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping: $TRIGGER_SHA is no longer master's tip ($TIP_SHA)."
+            echo "::notice::This workflow file came from $TIP_SHA, so its steps and the"
+            echo "::notice::checkout would be different commits - see the comment in"
+            echo "::notice::deploy-api.yml. Deploying anyway could also put an older"
+            echo "::notice::commit on top of a newer one that already shipped."
+            echo "::notice::$TIP_SHA deploys via its own CI run. Nothing to do here."
+            exit 0
+          fi
+
+          echo "deploy=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::$TRIGGER_SHA is master's tip and passed CI. Deploying."
+
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: guard
+    if: needs.guard.outputs.deploy == 'true'
     steps:
       # Two things this ref is doing. For workflow_run, checkout would otherwise
       # take the default branch's tip rather than the commit CI actually ran
@@ -44,6 +147,14 @@ jobs:
       # not github.ref: dispatching from a feature branch would otherwise push
       # that branch straight onto the production machine, and per-branch API
       # deploys are explicitly out of scope for this migration.
+      #
+      # The `guard` job above has already established that this ref *is* the
+      # default branch's tip, so the pin is no longer the only thing keeping the
+      # deployed image and the tested commit together - it is now also the same
+      # commit this workflow file was read from. Keep the pin regardless: it is
+      # what makes that equality checkable rather than assumed, and dropping it
+      # would silently reintroduce "deploy whatever master is now" on a run
+      # triggered by an older commit.
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha || 'master' }}

--- a/docs/fly-migration-runbook.md
+++ b/docs/fly-migration-runbook.md
@@ -197,6 +197,15 @@ A deploy token is scoped to this one app — do not use a personal access token.
 Test it: Actions → Deploy API → Run workflow. It always deploys `master`, whatever branch
 you dispatch from.
 
+**Run workflow is also how you force a redeploy — re-running an old CI run is not.**
+Deploy API only proceeds when the commit that triggered it is still `master`'s tip, so
+re-running CI for an older commit now skips with a notice explaining why, instead of
+deploying. That is deliberate: the workflow definition always comes from `master`'s tip
+while the checkout is pinned to the triggering commit, so an older trigger runs today's
+steps against a tree that predates them (it once called a script that did not exist yet,
+and failed at exit 127), and it can also put an older commit on top of a newer one that
+has already shipped. See the comment on the `guard` job in `deploy-api.yml`.
+
 ## 5. Cut over
 
 This is the only step users can notice.


### PR DESCRIPTION
Closes the board row *Deploy API runs master's workflow against an older checkout, so a referenced script can be missing*.

## The split

`workflow_run` takes the **workflow definition** from the default branch's tip, while the checkout deliberately pins the triggering commit. Both halves are right on their own; together they mean a run can execute master's newest steps against a checkout that predates them.

I confirmed the mechanism against the real run rather than assuming it:

```
$ gh api repos/Ianfeather/big-shop/actions/runs/32585058437 --jq .head_sha
5ec3e823b91aea401c1b64da83f48cbf272a73a9   # = #137, master's tip = github.sha
```

…while that run checked out `9369bb5` (#139) — the commit that predates `scripts/verify-fly-release.sh`. That also settles the design question underneath this: for a `workflow_run` event `github.sha` **is** the default branch tip, not the triggering run's head.

## The fix

A `guard` job requires the triggering commit to equal `github.sha`. Since that is exactly the commit the workflow file was read from, workflow, tree and tip collapse into one commit — so both directions of the problem **cannot arise**, rather than being detected after the fact.

The silent direction is the one that matters more. The observed failure was loud (exit 127). A step *deleted* from the workflow still ran when the trigger was old, and a step reading a config file that had since changed shape read it wrongly with nothing to report.

### Why not the row's option 1

The row proposed a second checkout at the workflow's commit, with steps calling scripts from there. That breaks on contact with the scripts: both `check-fly-secrets.sh` and `verify-fly-release.sh` do

```bash
cd "$(dirname "$0")/../netlify-functions/recipes"
```

and read `fly.toml` / `machine_config.json` **relative to themselves**. Checking them out at the workflow commit would make `check-fly-secrets.sh` validate the wrong tree's `machine_config.json`. They are tooling whose input is content, so the split the option assumes isn't there — it would need both scripts reworked to take the target tree as a parameter first.

## A second hazard this also fixes

`concurrency` queues deploys rather than superseding them, and nothing ordered the queue by commit. Two commits landing close together, the newer one's CI finishing first, would deploy the newer and then **the older on top** — a silent rollback of whatever the newer one changed, lasting until the next push. An older commit's run now skips.

## What this gives up, deliberately

**If master's tip goes red, the previous green commit no longer ships.** Its run skips as not-the-tip, and the tip's own run never happens because CI failed. Nothing is lost and the next green commit carries everything — but a red master now blocks deploys rather than quietly shipping the commit before it. Called out here because it is a real behaviour change, not a pure improvement.

Also: **re-running an old CI run to force a redeploy is now a no-op**, with a notice saying so. `Actions → Deploy API → Run workflow` is the way to force one. Documented in `docs/fly-migration-runbook.md`.

## Shape

A separate job rather than a condition on `deploy` itself. Both values are plain contexts so this *could* have been an expression in the job-level `if` — but a job that reports "skipped" with no reason is the same genre of silence as the bug it fixes. The conclusion gate stays at job level where it was, so a red CI still costs no runner.

## Verification

The guard script was extracted from the YAML and exercised against all five cases, including a replay of run `32585058437`'s actual SHAs:

| case | result |
| --- | --- |
| real failing run (`9369bb5` trigger, `5ec3e82` tip) | `deploy=false` |
| normal deploy (trigger == tip) | `deploy=true` |
| manual dispatch | `deploy=true` |
| CI failed | `deploy=false` |
| CI cancelled | `deploy=false` |

`guard` is not a required status check (those are `build-lint-test`, `e2e` and `go`, all in other workflows), so the ruleset needs no change — verified via the rulesets API.

No user-visible surface, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)