### PR TITLE
Make the account-deletion cancel flake diagnose itself

### DIFF
--- a/e2e/account-deletion.spec.ts
+++ b/e2e/account-deletion.spec.ts
@@ -76,8 +76,55 @@ test.describe('deleting your account', () => {
 
   test('cancelling puts it away and deletes nothing', async ({ page, request }) => {
     await page.goto('/account');
+
+    // A sentinel that nothing but a full document load can clear, and the only
+    // reason it is here is to make one specific failure diagnose itself.
+    //
+    // On 2026-08-22 this test failed once with `Yes, delete my account` simply
+    // not found. The click had succeeded - Playwright waits for the button to
+    // be enabled, and `Delete your account` carries
+    // `disabled={otherMembers === undefined}` - and once `confirmingDelete` is
+    // true the panel renders unconditionally, nothing inside it depending on
+    // `otherMembers`. So the component had lost its state, which means it
+    // remounted. What no evidence survived to say was *why*.
+    //
+    // Three candidate mechanisms have since been tested and none of them
+    // reproduce it: a Fast Refresh hot update preserves the state (that being
+    // the entire point of Fast Refresh), compiling other routes on demand does
+    // not disturb an open page, and dropping and restoring the HMR websocket
+    // does not either. Nor did 11 cold runs reproduce it naturally. So the
+    // cause is still open, and the next occurrence is the next piece of
+    // evidence - which makes it worth spending a few lines so that occurrence
+    // arrives already carrying the one fact that separates the two families of
+    // explanation: whether the document reloaded, or React remounted underneath
+    // a document that never went away.
+    await page.evaluate(() => { (window as Window & { __pageAlive?: true }).__pageAlive = true; });
+
     await page.getByRole('button', { name: 'Delete your account' }).click();
-    await expect(page.getByRole('button', { name: 'Yes, delete my account' })).toBeVisible();
+
+    try {
+      await expect(page.getByRole('button', { name: 'Yes, delete my account' })).toBeVisible();
+    } catch (err) {
+      // Deliberately re-thrown, never swallowed: this adds a sentence to the
+      // failure, it does not retry the click or tolerate the panel being shut.
+      // Retrying would absorb a genuine intermittent regression in the panel
+      // just as readily as it would absorb the artefact.
+      const alive = await page
+        .evaluate(() => (window as Window & { __pageAlive?: true }).__pageAlive === true)
+        .catch(() => null);
+      const verdict = alive === null
+        ? 'the page could not be evaluated at all (it may have crashed)'
+        : alive
+          ? 'the document did NOT reload, so React remounted under a live document'
+          : 'the document DID reload, so the state went with the page load';
+      throw new Error(
+        `The confirmation panel is not open after a successful click on "Delete your account".\n` +
+        `Diagnosis: ${verdict}.\n` +
+        `This is the flake recorded on the board as "account-deletion.spec.ts's cancel test can ` +
+        `fail by losing the panel's open state" - please add this run to that row rather than ` +
+        `re-running until green.\n\n${err}`
+      );
+    }
 
     await page.getByRole('button', { name: 'Cancel' }).click();
 


### PR DESCRIPTION
Carries the board row *account-deletion.spec.ts's cancel test can fail by losing the panel's open state* as far as the evidence allows — which turned out to be further at **eliminating** causes than at finding one.

**This does not fix the flake, and does not claim to.** The row should go back to `backlog` with this evidence, not to `done`.

## The row's leading hypothesis is disconfirmed

The row proposed Fast Refresh remounting the page during `next dev`'s on-demand compilation. I forced each candidate mechanism directly rather than waiting for it:

| Experiment | Result |
| --- | --- |
| Fast Refresh hot update, forced by editing `pages/account.tsx` with the panel open | `[Fast Refresh] rebuilding` → `done in 17ms`; **`panelOpen=true`, sentinel alive** |
| On-demand compilation of five cold routes with the page open | `[Fast Refresh] done in 777ms`; **`panelOpen=true`, sentinel alive** |
| HMR websocket dropped and reconnected (`context.setOffline`) | **`panelOpen=true`, sentinel alive** |

The first is the decisive one: preserving `useState` across a hot update is *the entire purpose* of Fast Refresh, so "Fast Refresh remounted it" was never going to be the mechanism on its own. Only a **full document reload** produces the reported symptom.

It also does not reproduce naturally — **11 cold runs** (fresh `.next`, dropped volumes, all three tests racing `/account`'s first compile under `fullyParallel: true`) all passed.

## One of the row's arguments is stronger than it claimed

The row ruled out #136's `accountReady` gate by noting that no e2e URL carries `?code=&state=`. The gate in fact **cannot move at all** under `DISABLE_AUTH`:

- `useMockAuth0` returns literal `isAuthenticated: true` and `isLoading: false`
- `arrivedFromLogin` is a module-scope constant, so `accountReady = settled || !arrivedFromLogin` is `true` from the first render

All three terms of `InnerApp`'s gate are constants in e2e. It is not merely that the transition doesn't happen — it can't.

## What this ships instead

Since the mechanism is disconfirmed, shipping a fix for it would be treating a cause I've disproved. **I wrote the route-warming fix and then reverted it** for exactly that reason.

What ships is the thing that unblocks the row: a sentinel on `window`, set after the page loads and read only on failure, so the next occurrence arrives carrying the one fact none of the experiments could recover after the fact — **did the document reload, or did React remount underneath a live one?**

It adds a sentence to the failure and nothing else. The assertion is re-thrown, never swallowed, and the click is not retried — retrying would absorb a genuine intermittent regression in the panel exactly as readily as the artefact, which is why that option was rejected.

## Verified both ways

Unmodified, the spec passes (3/3). With a `page.reload()` injected between the click and the assertion, it fails with the original error plus the diagnosis:

```
Error: The confirmation panel is not open after a successful click on "Delete your account".
Diagnosis: the document DID reload, so the state went with the page load.
This is the flake recorded on the board as "account-deletion.spec.ts's cancel test can
fail by losing the panel's open state" - please add this run to that row rather than
re-running until green.

Error: expect(locator).toBeVisible() failed
  Locator: getByRole('button', { name: 'Yes, delete my account' })
  Error: element(s) not found
```

That second half is character-for-character the failure originally reported, which is the check that the sentinel is wrapping the right assertion.

Test-only change, no user-visible surface, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)